### PR TITLE
fix: surface actual error details in goal setup flow

### DIFF
--- a/src/app/api/profile/goals/route.ts
+++ b/src/app/api/profile/goals/route.ts
@@ -131,9 +131,10 @@ export async function POST(request: NextRequest) {
       { status: 201 }
     );
   } catch (error) {
-    console.error("Error creating/updating goal:", error);
+    const message = error instanceof Error ? error.message : String(error);
+    console.error("Error creating/updating goal:", message, error);
     return NextResponse.json(
-      { error: "Failed to save goal" },
+      { error: `Failed to save goal: ${message}` },
       { status: 500 }
     );
   }

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -251,9 +251,10 @@ export async function PUT(request: NextRequest) {
       goals: goalsWithActuals,
     });
   } catch (error) {
-    console.error("Error updating profile:", error);
+    const message = error instanceof Error ? error.message : String(error);
+    console.error("Error updating profile:", message, error);
     return NextResponse.json(
-      { error: "Failed to update profile" },
+      { error: `Failed to update profile: ${message}` },
       { status: 500 }
     );
   }

--- a/src/components/user/GoalSetupModal.tsx
+++ b/src/components/user/GoalSetupModal.tsx
@@ -67,7 +67,18 @@ export default function GoalSetupModal() {
       await updateProfileMutation.mutateAsync({ hasCompletedSetup: true });
     } catch (err) {
       console.error("Error skipping setup:", err);
-      setError("Something went wrong. Please try again.");
+      const message =
+        err instanceof Error ? err.message : "Unknown error";
+      if (
+        message.includes("Session expired") ||
+        message.includes("401")
+      ) {
+        setError(
+          "Your session has expired. Please refresh the page and try again."
+        );
+      } else {
+        setError(`Something went wrong: ${message}`);
+      }
     } finally {
       setIsSubmitting(false);
     }
@@ -98,7 +109,18 @@ export default function GoalSetupModal() {
       await updateProfileMutation.mutateAsync({ hasCompletedSetup: true });
     } catch (err) {
       console.error("Error saving goals:", err);
-      setError("Something went wrong. Please try again.");
+      const message =
+        err instanceof Error ? err.message : "Unknown error";
+      if (
+        message.includes("Session expired") ||
+        message.includes("401")
+      ) {
+        setError(
+          "Your session has expired. Please refresh the page and try again."
+        );
+      } else {
+        setError(`Something went wrong: ${message}`);
+      }
     } finally {
       setIsSubmitting(false);
     }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -255,7 +255,27 @@ async function fetchJson<T>(url: string, options?: RequestInit): Promise<T> {
     },
   });
   if (!res.ok) {
-    throw new Error(`API Error: ${res.status} ${res.statusText}`);
+    // Try to read the error body for more context
+    let detail = "";
+    try {
+      const body = await res.json();
+      detail = body.error || JSON.stringify(body);
+    } catch {
+      // Response body isn't JSON (e.g., HTML from a redirect)
+      if (res.redirected) {
+        detail = "Session expired - please refresh the page";
+      }
+    }
+    throw new Error(
+      detail
+        ? `${res.status}: ${detail}`
+        : `API Error: ${res.status} ${res.statusText}`
+    );
+  }
+  // Verify we actually got JSON (not HTML from a redirect)
+  const contentType = res.headers.get("content-type");
+  if (contentType && !contentType.includes("application/json")) {
+    throw new Error("Session expired - please refresh the page");
   }
   return res.json();
 }


### PR DESCRIPTION
## Summary
- Replace generic "Something went wrong" error in GoalSetupModal with actual error messages from the API
- `fetchJson` now reads server error response bodies and detects session expiration redirects
- API routes (`/api/profile/goals`, `/api/profile`) now include actual error details in 500 responses
- Fixes opaque error Kris Tedesco hit when trying to save goals — the actual cause will now be visible

## Test plan
- [ ] Have Kris Tedesco refresh and retry saving goals — error message will now show the actual cause
- [ ] Verify session expiration shows "Your session has expired" message
- [ ] Verify API errors show the specific failure reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)