### PR TITLE
chore: remove Files tab from activity form

### DIFF
--- a/src/features/activities/components/ActivityFormTabs.tsx
+++ b/src/features/activities/components/ActivityFormTabs.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import TaskLineItems, { type TaskDraft } from "./event-fields/TaskLineItems";
 import ExpenseLineItems from "./event-fields/ExpenseLineItems";
 import RelatedActivitiesTab, { type RelationDraft } from "./tabs/RelatedActivitiesTab";
-import FilesTab from "./tabs/FilesTab";
+
 import StarRating from "./StarRating";
 import OpportunitySearch from "./OpportunitySearch";
 import ContactSelect, { type SelectedContact } from "./event-fields/ContactSelect";
@@ -16,14 +16,13 @@ import {
 import type { OpportunityResult } from "@/features/activities/lib/outcome-types-api";
 import type { ActivityCategory } from "@/features/activities/types";
 
-type TabKey = "tasks" | "expenses" | "related" | "outcomes" | "files";
+type TabKey = "tasks" | "expenses" | "related" | "outcomes";
 
 const TABS: { key: TabKey; label: string; icon: string }[] = [
   { key: "expenses", label: "Expenses", icon: "M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" },
   { key: "tasks", label: "Tasks", icon: "M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4" },
   { key: "related", label: "Related Activities", icon: "M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" },
   { key: "outcomes", label: "Outcomes", icon: "M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" },
-  { key: "files", label: "Files", icon: "M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z" },
 ];
 
 interface ActivityFormTabsProps {
@@ -205,7 +204,6 @@ export default function ActivityFormTabs({
             )}
           </div>
         )}
-        {activeTab === "files" && <FilesTab />}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- Removes the Files tab from the activity creation form right panel
- Tabs are now: Expenses, Tasks, Related Activities, Outcomes

🤖 Generated with [Claude Code](https://claude.com/claude-code)