### PR TITLE
fix: enable expense logging on all activity types

### DIFF
--- a/src/features/activities/components/ActivityFormModal.tsx
+++ b/src/features/activities/components/ActivityFormModal.tsx
@@ -255,7 +255,6 @@ export default function ActivityFormModal({
   const stateOptions = useMemo(() => (states ?? []).map((s) => ({ value: s.fips, label: `${s.name} (${s.abbrev})` })), [states]);
   const typeCategory = getCategoryForType(type);
   const isEventCategory = typeCategory === "events" || typeCategory === "thought_leadership";
-  const showExpenses = isEventCategory && (type === "conference" || type === "road_trip");
 
   if (!isOpen) return null;
 
@@ -524,7 +523,6 @@ export default function ActivityFormModal({
                   onExpensesChange={setExpenses}
                   relatedActivities={relatedActivities}
                   onRelatedActivitiesChange={setRelatedActivities}
-                  showExpenses={showExpenses}
                   onViewActivity={handleViewActivity}
                 />
               </div>

--- a/src/features/activities/components/ActivityFormTabs.tsx
+++ b/src/features/activities/components/ActivityFormTabs.tsx
@@ -22,7 +22,6 @@ interface ActivityFormTabsProps {
   onExpensesChange: (expenses: { description: string; amount: number }[]) => void;
   relatedActivities: RelationDraft[];
   onRelatedActivitiesChange: (relations: RelationDraft[]) => void;
-  showExpenses: boolean;
   onViewActivity?: (activityId: string, title: string) => void;
 }
 
@@ -33,7 +32,6 @@ export default function ActivityFormTabs({
   onExpensesChange,
   relatedActivities,
   onRelatedActivitiesChange,
-  showExpenses,
   onViewActivity,
 }: ActivityFormTabsProps) {
   const [activeTab, setActiveTab] = useState<TabKey>("tasks");
@@ -83,13 +81,7 @@ export default function ActivityFormTabs({
           <TaskLineItems tasks={taskDrafts} onChange={onTaskDraftsChange} />
         )}
         {activeTab === "expenses" && (
-          showExpenses ? (
-            <ExpenseLineItems expenses={expenses} onChange={onExpensesChange} />
-          ) : (
-            <div className="text-center py-6">
-              <p className="text-sm text-[#A69DC0]">Expenses not applicable for this activity type</p>
-            </div>
-          )
+          <ExpenseLineItems expenses={expenses} onChange={onExpensesChange} />
         )}
         {activeTab === "related" && (
           <RelatedActivitiesTab relations={relatedActivities} onChange={onRelatedActivitiesChange} onViewActivity={onViewActivity} />

--- a/src/features/activities/components/ActivityViewPanel.tsx
+++ b/src/features/activities/components/ActivityViewPanel.tsx
@@ -81,7 +81,6 @@ export default function ActivityViewPanel({ activityId, onViewRelated }: Activit
   const planOptions = useMemo(() => (plans ?? []).map((p) => ({ value: p.id, label: p.name })), [plans]);
   const stateOptions = useMemo(() => (states ?? []).map((s) => ({ value: s.fips, label: `${s.name} (${s.abbrev})` })), [states]);
   const isEventCategory = getCategoryForType(type) === "events";
-  const showExpenses = isEventCategory && (type === "conference" || type === "road_trip");
 
   // Mark changes
   const markChanged = () => setHasChanges(true);
@@ -207,7 +206,6 @@ export default function ActivityViewPanel({ activityId, onViewRelated }: Activit
             onExpensesChange={(v) => { setExpenses(v); markChanged(); }}
             relatedActivities={relatedActivities}
             onRelatedActivitiesChange={(v) => { setRelatedActivities(v); markChanged(); }}
-            showExpenses={showExpenses}
             onViewActivity={onViewRelated}
           />
         </div>


### PR DESCRIPTION
## Summary
- Removed restriction that limited expense logging to only `conference` and `road_trip` activity types
- All activity types (meetings, campaigns, gift drops, thought leadership, etc.) can now log expenses
- Cleaned up dead `showExpenses` prop from `ActivityFormTabs`

## Test plan
- [ ] Open any non-conference/road_trip activity and verify the Expenses tab renders the line items form
- [ ] Confirm conference and road_trip activities still work as before
- [ ] Add/edit/delete expense line items on a meeting or gift_drop activity

🤖 Generated with [Claude Code](https://claude.com/claude-code)