### PR TITLE
fix(activities): rating validation error on edit

### DIFF
--- a/src/features/activities/components/ActivityFormModal.tsx
+++ b/src/features/activities/components/ActivityFormModal.tsx
@@ -266,7 +266,7 @@ export default function ActivityFormModal({
           status,
           outcomeType: selectedOutcomes.length > 0 ? selectedOutcomes[0] : null,
           outcome: outcomeNote.trim() || null,
-          rating: outcomeRating > 0 ? outcomeRating : 0,
+          rating: outcomeRating > 0 ? outcomeRating : undefined,
           metadata: hasMetadata ? metadata : null,
           attendeeUserIds: attendeeUserIds.length > 0 ? attendeeUserIds : [],
           expenses: expenses.filter((e) => e.description.trim()),


### PR DESCRIPTION
## Summary
- Edit mode was sending `rating: 0` when no rating was set, causing the API to reject the request with `400: rating must be an integer between 1 and 5`
- Changed to send `undefined` (matching the create path behavior) so the API skips validation when rating is not provided

## Root cause
`ActivityFormModal.tsx` line 269: `outcomeRating > 0 ? outcomeRating : 0` — the fallback `0` fails API validation (`0 < 1`). Create path already used `undefined` correctly.

## Test plan
- [ ] Edit an existing activity without setting a rating → saves without error
- [ ] Edit an activity and set a rating (1-5) → saves correctly
- [ ] Create a new activity without rating → still works
- [ ] Create a new activity with rating → still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)