### PR TITLE
fix(schema): graduation_rate column name mismatch

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -107,7 +107,7 @@ model District {
 
   // ===== Graduation Data =====
   // Source: Urban Institute API (graduation endpoint)
-  graduationRateTotal Decimal? @map("graduation_rate_total") @db.Decimal(5, 2)
+  graduationRateTotal Decimal? @map("graduation_rate") @db.Decimal(5, 2)
   graduationDataYear  Int?     @map("graduation_data_year")
 
   // ===== Staffing & Salaries =====


### PR DESCRIPTION
## Summary
- Production DB has `graduation_rate` but Prisma schema mapped to `graduation_rate_total` (old name)
- This causes **500 errors** on any endpoint that includes district data via Prisma (profile, activities, district details, etc.)
- The column was renamed in production per the db-normalization spec, but the schema wasn't updated

## Root cause
`prisma/schema.prisma` line 110: `@map("graduation_rate_total")` → should be `@map("graduation_rate")`

Confirmed via Supabase logs showing repeated `ERROR: column districts.graduation_rate_total does not exist`

## Test plan
- [ ] Profile page loads with avatar, name, and financial data
- [ ] District detail panel loads without errors
- [ ] Activity creation/editing works (includes district data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)