### PR TITLE
feat: dismiss unmatched opportunities

### DIFF
--- a/src/app/admin/unmatched-opportunities/page.tsx
+++ b/src/app/admin/unmatched-opportunities/page.tsx
@@ -225,6 +225,22 @@ async function resolveOpportunity(
   return res.json();
 }
 
+async function dismissOpportunity(
+  id: string,
+  dismissAll: boolean,
+): Promise<{ dismissedCount: number; accountName: string | null }> {
+  const res = await fetch(`/api/admin/unmatched-opportunities/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ dismiss: true, dismissAll }),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => null);
+    throw new Error(err?.error || `Failed to dismiss (${res.status})`);
+  }
+  return res.json();
+}
+
 // ---------------------------------------------------------------------------
 // Currency formatter (no decimals per project preference)
 // ---------------------------------------------------------------------------
@@ -476,7 +492,14 @@ function ReasonDropdown({
 // Status badge
 // ---------------------------------------------------------------------------
 
-function StatusBadge({ resolved }: { resolved: boolean }) {
+function StatusBadge({ resolved, resolvedDistrictLeaid }: { resolved: boolean; resolvedDistrictLeaid?: string | null }) {
+  if (resolved && !resolvedDistrictLeaid) {
+    return (
+      <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold bg-[#F5F4F7] text-[#8A80A8] border border-[#A69DC0]/30">
+        Dismissed
+      </span>
+    );
+  }
   if (resolved) {
     return (
       <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold bg-[#F7FFF2] text-[#69B34A] border border-[#8AC670]/30">
@@ -1194,6 +1217,7 @@ export default function UnmatchedOpportunitiesPage() {
 
   const [activeCard, setActiveCard] = useState<CardKey | null>(null);
   const [resolvingOpp, setResolvingOpp] = useState<UnmatchedOpportunity | null>(null);
+  const [dismissingOpp, setDismissingOpp] = useState<UnmatchedOpportunity | null>(null);
   const [toast, setToast] = useState<string | null>(null);
 
   useEffect(() => {
@@ -1289,6 +1313,23 @@ export default function UnmatchedOpportunitiesPage() {
     },
   });
 
+  const dismissMutation = useMutation({
+    mutationFn: ({ id, dismissAll }: { id: string; dismissAll: boolean }) =>
+      dismissOpportunity(id, dismissAll),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ["unmatched-opportunities"] });
+      queryClient.invalidateQueries({ queryKey: ["unmatched-opportunities-summary"] });
+      const count = data.dismissedCount ?? 1;
+      const countLabel = count > 1 ? `${count} opportunities` : "1 opportunity";
+      setToast(`Dismissed ${countLabel}${data.accountName ? ` for ${data.accountName}` : ""}`);
+      setDismissingOpp(null);
+    },
+    onError: (error) => {
+      setToast(error.message || "Failed to dismiss opportunity");
+      setDismissingOpp(null);
+    },
+  });
+
   const handleReasonUpdate = useCallback(
     (id: string, reason: string | null) => {
       reasonMutation.mutate({ id, reason });
@@ -1348,9 +1389,10 @@ export default function UnmatchedOpportunitiesPage() {
       if (!leaid) return <span className="text-[#A69DC0]">&mdash;</span>;
       return <span className="tabular-nums font-medium text-[#6E6390]">{leaid}</span>;
     },
-    resolved: ({ value }) => {
+    resolved: ({ value, row }) => {
       const isResolved = value as boolean;
-      return <StatusBadge resolved={isResolved} />;
+      const leaid = row.resolvedDistrictLeaid as string | null;
+      return <StatusBadge resolved={isResolved} resolvedDistrictLeaid={leaid} />;
     },
     reason: ({ value, row }) => (
       <ReasonDropdown
@@ -1367,27 +1409,38 @@ export default function UnmatchedOpportunitiesPage() {
   const renderRowAction = useCallback((row: Record<string, unknown>) => {
     const isResolved = row.resolved as boolean;
     if (isResolved) return null;
+
+    const oppData: UnmatchedOpportunity = {
+      id: row.id as string,
+      name: row.name as string | null,
+      accountName: row.accountName as string | null,
+      state: row.state as string | null,
+      schoolYr: row.schoolYr as string | null,
+      stage: row.stage as string | null,
+      netBookingAmount: row.netBookingAmount as string | null,
+      reason: row.reason as string | null,
+      resolved: row.resolved as boolean,
+      resolvedDistrictLeaid: row.resolvedDistrictLeaid as string | null,
+    };
+
     return (
-      <button
-        onClick={(e) => {
-          e.stopPropagation();
-          setResolvingOpp({
-            id: row.id as string,
-            name: row.name as string | null,
-            accountName: row.accountName as string | null,
-            state: row.state as string | null,
-            schoolYr: row.schoolYr as string | null,
-            stage: row.stage as string | null,
-            netBookingAmount: row.netBookingAmount as string | null,
-            reason: row.reason as string | null,
-            resolved: row.resolved as boolean,
-            resolvedDistrictLeaid: row.resolvedDistrictLeaid as string | null,
-          });
-        }}
-        className="px-2.5 py-1 text-xs font-medium text-white bg-[#403770] hover:bg-[#322a5a] rounded-lg transition-colors"
-      >
-        Resolve
-      </button>
+      <div className="flex items-center gap-1.5">
+        <button
+          onClick={(e) => { e.stopPropagation(); setResolvingOpp(oppData); }}
+          className="px-2.5 py-1 text-xs font-medium text-white bg-[#403770] hover:bg-[#322a5a] rounded-lg transition-colors"
+        >
+          Resolve
+        </button>
+        <button
+          onClick={(e) => { e.stopPropagation(); setDismissingOpp(oppData); }}
+          className="px-2 py-1 text-xs font-medium text-[#8A80A8] hover:text-[#F37167] hover:bg-[#fef1f0] rounded-lg transition-colors"
+          title="Dismiss — stop syncing this opportunity"
+        >
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
     );
   }, []);
 
@@ -1458,6 +1511,45 @@ export default function UnmatchedOpportunitiesPage() {
           onSelect={handleResolve}
           onClose={() => setResolvingOpp(null)}
         />
+      )}
+
+      {/* Dismiss confirmation dialog */}
+      {dismissingOpp && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={() => setDismissingOpp(null)}>
+          <div className="bg-white rounded-xl shadow-xl p-6 max-w-sm w-full mx-4" onClick={(e) => e.stopPropagation()}>
+            <h3 className="text-base font-semibold text-[#403770] mb-2">Dismiss opportunity?</h3>
+            <p className="text-sm text-[#6E6390] mb-1">
+              <span className="font-semibold">{dismissingOpp.accountName ?? "Unknown account"}</span>
+            </p>
+            <p className="text-sm text-[#8A80A8] mb-5">
+              Dismissed opportunities will stop syncing into the planning tool.
+            </p>
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => setDismissingOpp(null)}
+                className="px-3 py-1.5 text-sm font-medium text-[#6E6390] hover:bg-[#F5F4F7] rounded-lg transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => dismissMutation.mutate({ id: dismissingOpp.id, dismissAll: false })}
+                disabled={dismissMutation.isPending}
+                className="px-3 py-1.5 text-sm font-medium text-[#F37167] border border-[#f58d85]/40 hover:bg-[#fef1f0] rounded-lg transition-colors disabled:opacity-50"
+              >
+                {dismissMutation.isPending ? "Dismissing..." : "Dismiss this opp"}
+              </button>
+              {dismissingOpp.accountName && (
+                <button
+                  onClick={() => dismissMutation.mutate({ id: dismissingOpp.id, dismissAll: true })}
+                  disabled={dismissMutation.isPending}
+                  className="px-3 py-1.5 text-sm font-medium text-white bg-[#F37167] hover:bg-[#e0615a] rounded-lg transition-colors disabled:opacity-50"
+                >
+                  {dismissMutation.isPending ? "Dismissing..." : "Dismiss all for account"}
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
       )}
 
       {/* Success toast */}

--- a/src/app/api/admin/unmatched-opportunities/[id]/route.ts
+++ b/src/app/api/admin/unmatched-opportunities/[id]/route.ts
@@ -17,10 +17,43 @@ export async function PATCH(
 
     const { id } = await params;
     const body = await request.json();
-    const { resolvedDistrictLeaid, reason } = body as {
+    const { resolvedDistrictLeaid, reason, dismiss, dismissAll } = body as {
       resolvedDistrictLeaid?: string;
       reason?: string | null;
+      dismiss?: boolean;
+      dismissAll?: boolean;
     };
+
+    // Dismiss operation — mark as resolved without a district
+    if (dismiss === true) {
+      const source = await prisma.unmatchedOpportunity.findUnique({
+        where: { id },
+        select: { accountName: true },
+      });
+      if (!source) {
+        return NextResponse.json({ error: "Opportunity not found" }, { status: 404 });
+      }
+
+      // Bulk dismiss all for same accountName, or just this one
+      const where =
+        dismissAll && source.accountName
+          ? {
+              accountName: { equals: source.accountName, mode: "insensitive" as const },
+              resolved: false,
+            }
+          : { id };
+
+      const { count } = await prisma.unmatchedOpportunity.updateMany({
+        where,
+        data: { resolved: true },
+      });
+
+      return NextResponse.json({
+        dismissed: true,
+        dismissedCount: count,
+        accountName: source.accountName,
+      });
+    }
 
     // Reason-only update (no resolution)
     if (reason !== undefined && !resolvedDistrictLeaid) {

--- a/src/features/shared/components/DataGrid/DataGrid.tsx
+++ b/src/features/shared/components/DataGrid/DataGrid.tsx
@@ -174,7 +174,7 @@ export function DataGrid({
         id: "__actions",
         header: () => null,
         cell: () => null,
-        size: 80,
+        size: 112,
       });
     }
 
@@ -276,7 +276,7 @@ export function DataGrid({
                       return (
                         <th
                           key={header.id}
-                          className="w-20 bg-[#F7F5FA] sticky top-0 z-10"
+                          className="w-28 bg-[#F7F5FA] sticky top-0 z-10"
                         />
                       );
                     }
@@ -558,8 +558,10 @@ export function DataGrid({
                           // Actions cell
                           if (cell.column.id === "__actions" && renderRowAction) {
                             return (
-                              <td key={cell.id} className="w-20 px-3 py-3 text-right">
-                                {renderRowAction(row.original)}
+                              <td key={cell.id} className="w-28 px-3 py-3">
+                                <div className="flex items-center justify-end">
+                                  {renderRowAction(row.original)}
+                                </div>
                               </td>
                             );
                           }


### PR DESCRIPTION
## Summary
- Adds a "Dismiss" action (X button) next to Resolve on unmatched opportunities
- Confirmation dialog offers "Dismiss this opp" (single) or "Dismiss all for account" (bulk)
- Dismissed opps show a gray "Dismissed" badge, distinct from green "Resolved"
- No schema or sync changes needed — `resolved=true` with null `resolvedDistrictLeaid` is naturally respected by the existing sync guards

## Test plan
- [ ] Click X on an unresolved opp → confirmation dialog appears
- [ ] "Dismiss this opp" → only that opp is dismissed, toast shows count
- [ ] "Dismiss all for account" → all opps for that account dismissed
- [ ] Dismissed rows show gray "Dismissed" badge
- [ ] Summary cards update (dismissed opps no longer counted)
- [ ] Filter to resolved=true → both dismissed and resolved opps visible with distinct badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)