### PR TITLE
feat(calendar): backfill wizard + auto-sync + symmetric window

### DIFF
--- a/Docs/superpowers/plans/2026-04-09-google-calendar-sync-plan.md
+++ b/Docs/superpowers/plans/2026-04-09-google-calendar-sync-plan.md
@@ -1,0 +1,873 @@
+# Implementation Plan: Google Calendar Sync — Backfill Wizard & Auto-Sync
+
+**Date:** 2026-04-09
+**Spec:** [`docs/superpowers/specs/2026-04-09-google-calendar-sync-spec.md`](../specs/2026-04-09-google-calendar-sync-spec.md)
+**Backend context:** [`docs/superpowers/specs/2026-04-09-google-calendar-sync-enhancement-backend-context.md`](../specs/2026-04-09-google-calendar-sync-enhancement-backend-context.md)
+**Branch:** `worktree-google-calendar-sync`
+
+## Execution Strategy
+
+Work is split into **3 phases** with clean cut points:
+
+- **Phase 1: Backend foundation** — schema migration + sync engine changes + new API routes. Unlocks everything downstream.
+- **Phase 2: Frontend wizard** — the BackfillSetupModal and its sub-components. Largest surface area but all isolated under `src/features/calendar/components/backfill/`. Can be worked on in parallel with Phase 3 once Phase 1 is done.
+- **Phase 3: Integration & auto-sync** — wire hooks into `HomeView`, adjust OAuth callback, toast, settings touch-ups. Depends on Phase 1 (API) and Phase 2 (modal component exists).
+
+Phase 2 and the non-OAuth parts of Phase 3 can run in parallel subagents.
+
+---
+
+## Phase 1: Backend Foundation
+
+### Task 1.1 — Schema migration
+
+**Files:**
+- `prisma/schema.prisma`
+- `prisma/migrations/manual/2026-04-09-calendar-backfill-fields.sql` (new manual migration file)
+
+**Changes:**
+1. Add two nullable DateTime fields to `CalendarConnection` model:
+   ```prisma
+   backfillStartDate   DateTime? @map("backfill_start_date")
+   backfillCompletedAt DateTime? @map("backfill_completed_at")
+   ```
+2. Create the manual SQL migration:
+   ```sql
+   ALTER TABLE calendar_connections
+     ADD COLUMN backfill_start_date    TIMESTAMP(3),
+     ADD COLUMN backfill_completed_at  TIMESTAMP(3);
+   ```
+3. Run `npx prisma generate` to regenerate the Prisma client.
+
+**Notes:**
+- This repo uses `prisma/migrations/manual/` for DDL that is run out-of-band
+  (see existing files like `phase1_schema_normalization_ddl.sql`). Follow
+  that pattern — no `prisma migrate dev` / `deploy`.
+- Verify the Prisma client picks up the new fields by running
+  `npx tsc --noEmit` after regeneration.
+
+**Testing:** None required for the migration itself. Downstream tests will
+cover the new fields.
+
+**Completion check:** `npx prisma generate` succeeds, `npx tsc --noEmit`
+passes, Prisma client types include `backfillStartDate` and
+`backfillCompletedAt` on `CalendarConnection`.
+
+---
+
+### Task 1.2 — Sync engine: configurable window + dedupe
+
+**File:** `src/features/calendar/lib/sync.ts`
+
+**Changes:**
+
+1. **Replace hardcoded window (lines ~254-257)** with conditional logic:
+   ```ts
+   const timeMax = new Date();
+   timeMax.setDate(timeMax.getDate() + 14);
+
+   let timeMin: Date;
+   if (calendarConnection.backfillStartDate && !calendarConnection.backfillCompletedAt) {
+     timeMin = calendarConnection.backfillStartDate;
+   } else if (calendarConnection.lastSyncAt) {
+     timeMin = new Date(calendarConnection.lastSyncAt);
+     timeMin.setDate(timeMin.getDate() - 2);
+   } else {
+     timeMin = new Date();
+     timeMin.setDate(timeMin.getDate() - 7);
+   }
+   ```
+
+2. **Add batch Activity dedupe** — after fetching `googleEvents` from Google
+   but before the per-event loop (~line 273), fetch existing Activities:
+   ```ts
+   const googleIds = googleEvents.map(e => e.id);
+   const alreadyLogged = new Set(
+     (await prisma.activity.findMany({
+       where: { googleEventId: { in: googleIds } },
+       select: { googleEventId: true },
+     }))
+       .map(a => a.googleEventId)
+       .filter((id): id is string => id !== null)
+   );
+   ```
+
+3. **Inside the per-event loop**, skip events already logged as Activities:
+   ```ts
+   for (const event of googleEvents) {
+     result.eventsProcessed++;
+     if (alreadyLogged.has(event.id)) continue;
+     // ... existing logic
+   }
+   ```
+
+4. **Update `CalendarConnection.lastSyncAt`** alongside `UserIntegration.lastSyncAt`
+   (currently only the latter is updated at line ~386):
+   ```ts
+   await prisma.calendarConnection.update({
+     where: { id: calendarConnection.id },
+     data: { lastSyncAt: syncTimestamp },
+   });
+   ```
+
+**Testing (co-located in `src/features/calendar/lib/__tests__/sync.test.ts`):**
+
+Create the test file if it doesn't exist. Mock `@/lib/prisma`, mock
+`@/features/calendar/lib/google` (especially `fetchCalendarEvents` and
+`getValidAccessToken`), and mock `@/features/integrations/lib/encryption`.
+
+Tests:
+- **Window selection (parameterized):**
+  1. `backfillStartDate = 30d ago, backfillCompletedAt = null` → timeMin is 30d ago
+  2. `backfillStartDate = 30d ago, backfillCompletedAt = set` → timeMin is lastSyncAt - 2d
+  3. `backfillStartDate = null, lastSyncAt = 1d ago` → timeMin is 3d ago
+  4. `backfillStartDate = null, lastSyncAt = null` → timeMin is 7d ago (fallback)
+- **Dedupe:**
+  1. 3 Google events, 1 already has a matching Activity → staging called for 2
+  2. 3 Google events, 0 matches → staging called for 3
+  3. Empty Google response → no dedupe query fired (optional optimization)
+- **`CalendarConnection.lastSyncAt` updated** after successful sync.
+- **`syncDirection === "one_way"`** still short-circuits (regression guard).
+
+**Completion check:** `npx vitest run src/features/calendar/lib/__tests__/sync.test.ts`
+passes.
+
+---
+
+### Task 1.3 — OAuth callback: defer sync, upsert CalendarConnection
+
+**File:** `src/app/api/calendar/callback/route.ts`
+
+**Changes:**
+
+1. **Remove the auto-sync call** after token upsert (currently lines
+   105-110). The wizard will trigger sync via `POST /api/calendar/backfill/start`.
+
+2. **Add `CalendarConnection` upsert** alongside the existing `UserIntegration`
+   upsert. The sync engine reads from `CalendarConnection` for
+   `companyDomain`, `syncDirection`, `syncedActivityTypes`, `reminderMinutes`,
+   `backfillStartDate`, `backfillCompletedAt`. Without this, first-time users
+   hit the `"No calendar connection found"` error path.
+
+   Add after the `UserIntegration.upsert`:
+   ```ts
+   await prisma.calendarConnection.upsert({
+     where: { userId: user.id },
+     update: {
+       googleAccountEmail: tokens.email,
+       accessToken: encrypt(tokens.accessToken),
+       refreshToken: encrypt(tokens.refreshToken),
+       tokenExpiresAt: tokens.expiresAt,
+       companyDomain,
+       status: "connected",
+       syncEnabled: true,
+     },
+     create: {
+       userId: user.id,
+       googleAccountEmail: tokens.email,
+       accessToken: encrypt(tokens.accessToken),
+       refreshToken: encrypt(tokens.refreshToken),
+       tokenExpiresAt: tokens.expiresAt,
+       companyDomain,
+       status: "connected",
+       syncEnabled: true,
+       // backfillStartDate + backfillCompletedAt remain NULL — user picks in wizard
+     },
+   });
+   ```
+
+3. **Change the success redirect** to route through the home tab so the
+   BackfillSetupModal can mount. Replace both redirects with:
+   ```ts
+   return NextResponse.redirect(
+     `${origin}/?tab=home&calendarJustConnected=true${returnTo === "settings" ? "&from=settings" : ""}`
+   );
+   ```
+
+**Testing:** The existing `e2e/tests/calendar-sync.spec.ts` covers the OAuth
+flow end-to-end — ensure it still passes after the changes. Add a unit test
+only if the callback's logic branches meaningfully (it doesn't — so E2E is
+sufficient).
+
+**Completion check:** Callback upserts both tables; E2E test that mocks OAuth
+still passes.
+
+---
+
+### Task 1.4 — New API route: `POST /api/calendar/backfill/start`
+
+**File:** `src/app/api/calendar/backfill/start/route.ts` (new)
+
+**Responsibilities:**
+1. Auth via `getUser()` (mirror `src/app/api/calendar/sync/route.ts`).
+2. Parse body `{ days: number }`; validate days ∈ `[7, 30, 60, 90]` (reject otherwise with 400).
+3. Compute `backfillStartDate = new Date(now - days * 86400000)`.
+4. Update `CalendarConnection` (by `userId`) with the new `backfillStartDate`
+   and set `backfillCompletedAt = null`.
+5. Call `syncCalendarEvents(user.id)` — returns a `SyncResult`.
+6. Query `prisma.calendarEvent.count({ where: { userId, status: "pending" } })`
+   for `pendingCount`.
+7. Return `{ ...syncResult, pendingCount }`.
+
+**Error handling:**
+- Unauthed → 401
+- Invalid `days` → 400
+- No `CalendarConnection` found → 404 "Not connected"
+- Sync errors → 500 with `{ error, syncResult }` so the UI can show partial state
+
+**Testing:** Optional unit test for validation; covered by E2E in Phase 3.
+
+---
+
+### Task 1.5 — New API route: `POST /api/calendar/backfill/complete`
+
+**File:** `src/app/api/calendar/backfill/complete/route.ts` (new)
+
+**Responsibilities:**
+1. Auth via `getUser()`.
+2. Update `CalendarConnection` by `userId`: set `backfillCompletedAt = new Date()`.
+3. Return `{ success: true }`.
+
+**Error handling:**
+- Unauthed → 401
+- No `CalendarConnection` found → 404
+
+**Testing:** Covered by E2E; no dedicated unit test needed.
+
+---
+
+## Phase 2: Frontend Wizard Components
+
+> All files live under `src/features/calendar/components/backfill/`. Create
+> the directory. All components use tokens from
+> `Documentation/UI Framework/tokens.md`:
+> - Plum `#403770`, Coral `#F37167`, Mint bg `#EDFFE3`, Off-white `#FFFCFA`
+> - Borders: `#D4CFE2` (default), `#C2BBD4` (strong)
+> - Text: `#403770` (primary), `#6E6390` (body), `#8A80A8` (secondary)
+> - NO Tailwind grays, NO fonts other than Plus Jakarta Sans
+> - `rounded-2xl` for modal, `rounded-lg` for buttons/cards, `shadow-xl` for modal
+
+### Task 2.1 — New hooks in `queries.ts`
+
+**File:** `src/features/calendar/lib/queries.ts`
+
+Add at the bottom of the file:
+
+1. **`useAutoSyncCalendarOnMount()`**:
+   ```ts
+   export function useAutoSyncCalendarOnMount() {
+     const { data } = useCalendarConnection();
+     const sync = useTriggerCalendarSync();
+     const ranRef = useRef(false);
+     const onNewEventsRef = useRef<((n: number) => void) | null>(null);
+
+     useEffect(() => {
+       if (ranRef.current) return;
+       if (!data?.connected) return;
+       if (!data.connection?.syncEnabled) return;
+       // Don't auto-sync while backfill wizard is still pending — wizard owns sync
+       if (!data.connection?.backfillCompletedAt) return;
+       ranRef.current = true;
+       sync.mutate(undefined, {
+         onSuccess: (result) => {
+           if (result.newEvents > 0 && onNewEventsRef.current) {
+             onNewEventsRef.current(result.newEvents);
+           }
+         },
+       });
+     }, [data, sync]);
+
+     return {
+       setOnNewEvents: (cb: (n: number) => void) => {
+         onNewEventsRef.current = cb;
+       },
+     };
+   }
+   ```
+
+2. **`useBackfillStatus()`**:
+   ```ts
+   export function useBackfillStatus() {
+     const { data, isLoading } = useCalendarConnection();
+     return {
+       isLoading,
+       connected: !!data?.connected,
+       needsSetup:
+         !!data?.connected &&
+         !data.connection?.backfillStartDate &&
+         !data.connection?.backfillCompletedAt,
+       needsResume:
+         !!data?.connected &&
+         !!data.connection?.backfillStartDate &&
+         !data.connection?.backfillCompletedAt,
+       backfillCompletedAt: data?.connection?.backfillCompletedAt ?? null,
+     };
+   }
+   ```
+
+3. **`useStartBackfill()`**:
+   ```ts
+   export function useStartBackfill() {
+     const queryClient = useQueryClient();
+     return useMutation({
+       mutationFn: (days: 7 | 30 | 60 | 90) =>
+         fetchJson<CalendarSyncResult & { pendingCount: number }>(
+           `${API_BASE}/calendar/backfill/start`,
+           { method: "POST", body: JSON.stringify({ days }) }
+         ),
+       onSuccess: () => {
+         queryClient.invalidateQueries({ queryKey: ["calendarConnection"] });
+         queryClient.invalidateQueries({ queryKey: ["calendarEvents"] });
+       },
+     });
+   }
+   ```
+
+4. **`useCompleteBackfill()`**:
+   ```ts
+   export function useCompleteBackfill() {
+     const queryClient = useQueryClient();
+     return useMutation({
+       mutationFn: () =>
+         fetchJson<{ success: boolean }>(
+           `${API_BASE}/calendar/backfill/complete`,
+           { method: "POST" }
+         ),
+       onSuccess: () => {
+         queryClient.invalidateQueries({ queryKey: ["calendarConnection"] });
+       },
+     });
+   }
+   ```
+
+**Imports to add at the top:** `useRef, useEffect` from `react`; the existing
+queries module already imports `useQueryClient, useMutation`.
+
+**Also update `CalendarConnection` type** in
+`src/features/shared/types/api-types.ts` to add the two new nullable fields.
+Check the file first — type may be derived from Prisma or hand-written.
+
+**Testing:** Co-located tests for each hook using MSW or a mocked
+`fetchJson` + testing-library's `renderHook`.
+- `useAutoSyncCalendarOnMount`: fires once, respects guard flags, skips when
+  `backfillCompletedAt === null`.
+- `useBackfillStatus`: parameterized over connection shapes.
+- Mutation hooks: fire the right URL + body.
+
+---
+
+### Task 2.2 — `BackfillWindowPicker.tsx`
+
+**File:** `src/features/calendar/components/backfill/BackfillWindowPicker.tsx` (new)
+
+**Props:**
+```ts
+interface BackfillWindowPickerProps {
+  onStart: (days: 7 | 30 | 60 | 90) => void;
+  onCancel: () => void;
+  isLoading: boolean;
+}
+```
+
+**Layout:**
+- Heading: "Get your calendar caught up"
+- Subtitle: "Choose how far back you want to sync events"
+- 2×2 grid of preset cards (7/30/60/90), each with:
+  - Label ("Last 30 days")
+  - Approximate count range ("~20-40 events")
+  - Subtitle ("Monthly review")
+  - Selection ring when active
+  - ★ badge on the 30-day card by default
+- Footer: `Maybe later` (ghost) + `Start sync →` (coral, disabled until selection)
+
+**State:**
+- `selected: 7 | 30 | 60 | 90 | null` — starts at `30`
+- Click on card updates selection
+- Keyboard: Tab/Arrow to move between cards, Enter to select
+
+**Styles:**
+- Modal body `bg-white rounded-2xl p-8 max-w-2xl shadow-xl`
+- Card default: `bg-white border border-[#D4CFE2] rounded-lg p-6 text-left hover:border-[#403770] transition-colors`
+- Card selected: `bg-[#F7F5FA] border-[#403770] border-2 ring-2 ring-[#403770]/10`
+- Star badge: coral filled, top-right corner
+- Start button: `bg-[#F37167] text-white hover:bg-[#e0564c] disabled:opacity-50`
+
+**Testing:**
+- Renders 4 cards
+- 30-day card has ★ badge by default
+- Clicking a card moves the ring
+- `onStart(days)` called with selected value
+- `onCancel` called on "Maybe later"
+- Keyboard navigation works
+
+---
+
+### Task 2.3 — `BackfillEventCard.tsx`
+
+**File:** `src/features/calendar/components/backfill/BackfillEventCard.tsx` (new)
+
+**Props:**
+```ts
+interface BackfillEventCardProps {
+  event: CalendarEvent; // from api-types
+  onConfirm: (overrides: ConfirmOverrides) => void;
+  onSkip: () => void;
+  onDismiss: () => void;
+  isSaving: boolean;
+}
+
+interface ConfirmOverrides {
+  activityType: string;
+  title: string;
+  planIds: string[];
+  districtLeaids: string[];
+  notes: string | null;
+}
+```
+
+**Layout:**
+```
+┌─ confidence banner (if any) ────────────────┐
+│  ✨ Strong match — found from 2 attendees   │
+└──────────────────────────────────────────────┘
+┌─ Card body ─────────────────────────────────┐
+│  Title (large, plum, editable inline)       │
+│  🗓 Date • Time → Time (duration)          │
+│                                              │
+│  Activity type  [ dropdown ▾ ]              │
+│  Plan           [ dropdown ▾ ]              │
+│  District       [ MultiSelect ]             │
+│                                              │
+│  Attendees (2 external)  — read-only list  │
+│  ● J. Smith • Superintendent                │
+│  ● R. Doe   • Asst Principal                │
+│                                              │
+│  Notes   [ textarea, auto-grow ]            │
+└──────────────────────────────────────────────┘
+```
+
+**Local state:**
+- `title, activityType, planIds, districtLeaids, notes` — initialized from
+  suggestions on mount; resets whenever `event.id` changes.
+
+**Sources for editable fields:**
+- `activityType`: `event.suggestedActivityType` ?? `"program_check_in"`
+- `planIds`: `event.suggestedPlanId ? [event.suggestedPlanId] : []` — dropdown populated via `useTerritoryPlans()` with `{ status: "working" }`
+- `districtLeaids`: `[event.suggestedDistrictId]` if present
+- `notes`: `event.description ?? ""`
+
+**Reuses:**
+- `useTerritoryPlans` from `@/features/plans/lib/queries` (or wherever it lives)
+- `ACTIVITY_TYPE_LABELS`, `ACTIVITY_TYPE_ICONS` from `@/features/activities/types`
+- `MultiSelect` from `@/features/shared/components/MultiSelect`
+
+**Confidence banner colors:**
+- high: `bg-[#EDFFE3] text-[#69B34A] border-[#8AA891]/30` + ✨
+- medium: `bg-[#e8f1f5] text-[#6EA3BE] border-[#8bb5cb]/30` + 💡
+- low: `bg-[#fffaf1] text-[#b88a00] border-[#ffd98d]/30` + ❔
+- none: hidden
+
+**Styles:**
+- Card: `bg-white rounded-2xl border border-[#D4CFE2] p-6`
+- Field label: `text-xs font-medium text-[#544A78] uppercase tracking-wider`
+- Dropdown/input: `bg-white border border-[#C2BBD4] rounded-lg px-3 py-2 text-sm text-[#403770]`
+- Focus: `focus:ring-2 focus:ring-[#F37167] focus:border-[#F37167]`
+
+**Testing:**
+- Pre-fills all fields from suggestions
+- Editing a field updates local state but doesn't call `onConfirm`
+- Clicking Save calls `onConfirm` with current local state
+- Resets when a new event is passed in via props
+- Skip/Dismiss don't call onConfirm
+- isSaving disables buttons and shows spinner on Save
+
+---
+
+### Task 2.4 — `BackfillWizard.tsx`
+
+**File:** `src/features/calendar/components/backfill/BackfillWizard.tsx` (new)
+
+**Props:**
+```ts
+interface BackfillWizardProps {
+  events: CalendarEvent[]; // pending events from inbox query
+  onComplete: () => void;  // called when user finishes the last event
+  onClose: () => void;     // "Save & finish later"
+}
+```
+
+**State:**
+- `currentIndex: number` — starts at 0
+- `confirmedIds: Set<string>`, `skippedIds: Set<string>`, `dismissedIds: Set<string>`
+
+**Layout:**
+- Header strip (sticky):
+  - Progress bar + "Event N of M • K%"
+  - Counters: "X confirmed • Y skipped"
+  - Close button (×) → calls `onClose`
+- Body: `<BackfillEventCard event={events[currentIndex]} ... />`
+- Action row (sticky bottom, or inside the card):
+  - `‹ Prev` (disabled at index 0) → decrement
+  - `Skip` → add to skippedIds, advance
+  - `Dismiss` → call `useDismissCalendarEvent`, add to dismissedIds, advance
+  - `★ Save & Next` → calls `useConfirmCalendarEvent` via card's `onConfirm`, adds to confirmedIds, advances
+- Footer: `Save & finish later` (ghost link) → `onClose`
+
+**Advance logic:**
+- After each action, increment `currentIndex`
+- If `currentIndex >= events.length` → call `onComplete`
+
+**Keyboard handlers** (attached via `useEffect` to `document`):
+- `Y` or `Enter` → Save & Next (if not saving)
+- `S` → Skip
+- `X` → Dismiss
+- `ArrowLeft` → Prev
+- `ArrowRight` → next (Save & Next if current is not yet resolved)
+- `Escape` → onClose
+
+Cleanup listeners on unmount. Don't trigger shortcuts if focus is inside a
+dropdown/textarea.
+
+**Testing:**
+- Renders first event
+- Clicking Skip advances + updates counter
+- Clicking Save calls confirm mutation then advances
+- Clicking Dismiss calls dismiss mutation then advances
+- Keyboard shortcuts fire the right handlers
+- Escape closes the wizard
+- Last event → `onComplete` called
+- Prev button disabled at index 0
+
+---
+
+### Task 2.5 — `BackfillCompletionScreen.tsx`
+
+**File:** `src/features/calendar/components/backfill/BackfillCompletionScreen.tsx` (new)
+
+**Props:**
+```ts
+interface BackfillCompletionScreenProps {
+  confirmed: number;
+  dismissed: number;
+  skipped: number;
+  onClose: () => void;
+}
+```
+
+**Layout:**
+- Centered `🎉` emoji (large, text-6xl)
+- Heading: "You're all caught up"
+- Body: `{confirmed} activities logged from {confirmed + dismissed + skipped} events`
+- Subtext: `{dismissed} dismissed • {skipped} skipped for later`
+- Primary CTA: `Go to Activities →`
+- `useEffect` auto-closes after 3000ms via `onClose`
+
+**Testing:**
+- Displays correct counts
+- Clicking CTA calls onClose
+- Auto-closes after 3s (use fake timers in test)
+
+---
+
+### Task 2.6 — `BackfillSetupModal.tsx`
+
+**File:** `src/features/calendar/components/backfill/BackfillSetupModal.tsx` (new)
+
+**The orchestrator.** Manages step state and renders the right sub-component.
+
+**Props:**
+```ts
+interface BackfillSetupModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  initialStep?: "picker" | "wizard"; // for resume flow, default "picker"
+}
+```
+
+**Internal state:**
+- `step: "picker" | "loading" | "wizard" | "empty" | "complete" | "error"`
+- `selectedDays: 7 | 30 | 60 | 90 | null`
+- counters from wizard
+
+**Step transitions:**
+1. `picker` → user clicks Start → call `useStartBackfill.mutate(days)` → `loading`
+2. `loading` → onSuccess:
+   - `pendingCount === 0` → `empty`
+   - `pendingCount > 0` → `wizard`
+   - On error → `error`
+3. `wizard` → last event → call `useCompleteBackfill.mutate()` → `complete`
+4. `complete` → auto-close after 3s → fire `onClose`
+5. `empty` → "All caught up" copy + Close button
+
+**Resume flow:**
+- If `initialStep === "wizard"`, skip picker + loading; fetch pending events
+  via `useCalendarInbox("pending")` and go straight to the wizard.
+
+**Modal shell:**
+- `fixed inset-0 z-50 flex items-center justify-center bg-[#403770]/40 backdrop-blur-sm`
+- Inner: `bg-white rounded-2xl shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto mx-4`
+- Close button (×) top-right
+- Mobile: full-screen (`md:max-w-2xl md:rounded-2xl rounded-none max-w-full max-h-full`)
+
+**Focus trap + Escape:**
+- Focus the primary CTA on mount
+- Escape key closes (via onClose)
+- Use `useEffect` to add/remove body scroll lock
+
+**Testing:**
+- Step transitions fire at the right moments
+- Loading state displays correct copy
+- Wizard opens with events from inbox query
+- `complete` state calls `useCompleteBackfill`
+- Auto-close after 3s on complete
+- Modal closes on backdrop click, ×, and Escape
+
+---
+
+## Phase 3: Integration & Polish
+
+### Task 3.1 — `CalendarSyncToast.tsx` + shared toast
+
+**Files:**
+- `src/features/calendar/components/CalendarSyncToast.tsx` (new)
+- (optional) `src/features/shared/components/Toast.tsx` if no shared primitive exists
+
+**Scan first:** search `src/features/shared/components/` for any existing
+Toast/Notification component. If one exists, reuse it. If not, build a simple
+one in shared.
+
+**`CalendarSyncToast` props:**
+```ts
+interface CalendarSyncToastProps {
+  visible: boolean;
+  newEventCount: number;
+  onDismiss: () => void;
+  onReview: () => void;
+}
+```
+
+**Behavior:**
+- Slide in from bottom-right on `visible` true
+- Auto-dismiss after 6s via internal `setTimeout`
+- Clear timer on unmount or on user interaction
+- `Review` button → `onReview` callback (parent navigates)
+- × button → `onDismiss`
+
+**Styles:**
+- Container: `fixed bottom-6 right-6 z-40 bg-white rounded-xl border border-[#D4CFE2] shadow-xl p-4 max-w-sm`
+- Icon: 📅 in a plum bg circle
+- Headline: `text-sm font-semibold text-[#403770]`
+- Subtext: `text-xs text-[#8A80A8]`
+- CTA: `text-xs font-medium text-[#F37167] hover:text-[#e0564c]`
+- Entry: `animate-in slide-in-from-bottom-4 duration-300`
+
+**Testing:**
+- Renders when visible
+- Auto-dismisses after 6s (fake timers)
+- CTA calls onReview
+- × calls onDismiss
+
+---
+
+### Task 3.2 — Wire into `HomeView.tsx`
+
+**File:** `src/features/shared/components/views/HomeView.tsx`
+
+**Changes:**
+
+1. **Imports:**
+   ```ts
+   import { useRouter, useSearchParams } from "next/navigation";
+   import {
+     useAutoSyncCalendarOnMount,
+     useBackfillStatus,
+   } from "@/features/calendar/lib/queries";
+   import BackfillSetupModal from "@/features/calendar/components/backfill/BackfillSetupModal";
+   import CalendarSyncToast from "@/features/calendar/components/CalendarSyncToast";
+   ```
+
+2. **Inside `HomeView` component:**
+   ```ts
+   const router = useRouter();
+   const searchParams = useSearchParams();
+   const backfillStatus = useBackfillStatus();
+   const autoSync = useAutoSyncCalendarOnMount();
+
+   const [backfillModalOpen, setBackfillModalOpen] = useState(false);
+   const [toastVisible, setToastVisible] = useState(false);
+   const [toastCount, setToastCount] = useState(0);
+
+   // Open the backfill modal when connection just happened or needs resume
+   useEffect(() => {
+     const justConnected = searchParams.get("calendarJustConnected") === "true";
+     if (justConnected || backfillStatus.needsSetup || backfillStatus.needsResume) {
+       setBackfillModalOpen(true);
+     }
+     if (justConnected) {
+       // Strip the param
+       const next = new URLSearchParams(searchParams.toString());
+       next.delete("calendarJustConnected");
+       router.replace(`?${next.toString()}`, { scroll: false });
+     }
+   }, [searchParams, router, backfillStatus.needsSetup, backfillStatus.needsResume]);
+
+   // Hook auto-sync's new-events callback to the toast
+   useEffect(() => {
+     autoSync.setOnNewEvents((n) => {
+       setToastCount(n);
+       setToastVisible(true);
+     });
+   }, [autoSync]);
+   ```
+
+3. **JSX (near the root):**
+   ```tsx
+   <BackfillSetupModal
+     isOpen={backfillModalOpen}
+     onClose={() => setBackfillModalOpen(false)}
+     initialStep={backfillStatus.needsResume ? "wizard" : "picker"}
+   />
+   <CalendarSyncToast
+     visible={toastVisible}
+     newEventCount={toastCount}
+     onDismiss={() => setToastVisible(false)}
+     onReview={() => {
+       setToastVisible(false);
+       router.push("?tab=activities");
+     }}
+   />
+   ```
+
+**Testing:**
+- HomeView test file (`src/features/shared/components/views/__tests__/HomeView.test.tsx`) — extend if it exists, or add:
+  - Mount with `calendarJustConnected=true` → modal opens
+  - Mount with `backfillStatus.needsResume === true` → modal opens at wizard step
+  - Mock `useAutoSyncCalendarOnMount` to fire new events → toast appears
+
+---
+
+### Task 3.3 — `ConnectionStatusCard` resume link
+
+**File:** `src/features/calendar/components/ConnectionStatusCard.tsx`
+
+**Changes:**
+
+Below the `Sync Now / Disconnect` button row, add a conditional small link:
+```tsx
+{connection.backfillStartDate && !connection.backfillCompletedAt && (
+  <button
+    onClick={() => { /* open modal — see below */ }}
+    className="mt-3 text-xs text-[#F37167] hover:text-[#e0564c] font-medium"
+  >
+    Resume calendar setup →
+  </button>
+)}
+```
+
+**Plumbing:** The card doesn't control the modal today. Options:
+- (a) Lift modal state to a shared context
+- (b) Broadcast via a window event or Zustand
+- (c) Navigate to `?tab=home&resumeBackfill=true` and let HomeView catch it
+
+**Pick (c)** — simplest, no new plumbing:
+```tsx
+onClick={() => router.push("/?tab=home&resumeBackfill=true")}
+```
+
+Then in HomeView, also detect `?resumeBackfill=true` alongside
+`calendarJustConnected=true`.
+
+**Testing:** Manual — verify link appears only when `backfillStartDate &&
+!backfillCompletedAt` and navigates correctly. No unit test required.
+
+---
+
+### Task 3.4 — Update CalendarConnection type
+
+**File:** `src/features/shared/types/api-types.ts`
+
+Find the `CalendarConnection` type and add:
+```ts
+backfillStartDate: string | null;
+backfillCompletedAt: string | null;
+```
+
+Search first to find its exact location. If derived from Prisma, nothing to do.
+
+**Testing:** `npx tsc --noEmit` passes.
+
+---
+
+## Test Strategy Summary
+
+| Layer | Location | Covers |
+|-------|----------|--------|
+| Unit (sync engine) | `src/features/calendar/lib/__tests__/sync.test.ts` | Window selection, dedupe, lastSyncAt update |
+| Unit (hooks) | `src/features/calendar/lib/__tests__/queries.test.ts` | All 4 new hooks |
+| Unit (components) | `src/features/calendar/components/backfill/__tests__/*.test.tsx` | Each backfill component in isolation |
+| Unit (HomeView integration) | `src/features/shared/components/views/__tests__/HomeView.test.tsx` | Modal opens on right flags; toast fires |
+| E2E | `e2e/tests/calendar-backfill.spec.ts` | End-to-end happy path + resume + dedupe |
+
+Run after implementation:
+```bash
+npx vitest run
+npx playwright test e2e/tests/calendar-backfill.spec.ts
+npm run build
+```
+
+---
+
+## Dependencies & Ordering
+
+```
+    ┌─ 1.1 Schema ────────────────────┐
+    │                                  │
+    ▼                                  ▼
+  1.2 Sync engine         1.3 OAuth callback
+    │                                  │
+    ▼                                  ▼
+  1.4 /backfill/start     1.5 /backfill/complete
+    │                                  │
+    └──────────┬───────────────────────┘
+               │
+               ▼
+  ┌────────────┴────────────┐
+  │                          │
+  ▼                          ▼
+Phase 2 (frontend wizard)  Phase 3 (integration)
+  2.1 hooks                  3.1 toast
+  2.2 WindowPicker           3.2 HomeView wiring
+  2.3 EventCard              3.3 ConnectionStatusCard
+  2.4 Wizard                 3.4 types
+  2.5 CompletionScreen
+  2.6 SetupModal
+```
+
+**Parallelization plan for implementer dispatch:**
+- **Round 1:** Task 1.1 alone (schema must land first — Prisma client regen blocks everything)
+- **Round 2:** Tasks 1.2, 1.3, 1.4, 1.5 in parallel (all backend, all independent after schema)
+- **Round 3:** Task 2.1 (hooks + types) alone — unblocks all UI work
+- **Round 4:** Tasks 2.2, 2.3, 2.5, 3.1 in parallel (isolated leaf components)
+- **Round 5:** Task 2.4 (depends on 2.3), Task 2.6 (depends on 2.2, 2.4, 2.5)
+- **Round 6:** Tasks 3.2, 3.3, 3.4 (final wiring) in parallel
+
+Alternatively, dispatch **backend** and **frontend** as two parallel subagents
+with clear handoffs at each round boundary. Given the tight coupling between
+components, a single subagent walking the phases sequentially may be less
+error-prone than aggressive parallelization.
+
+**Recommended:** one backend subagent (Phase 1), one frontend subagent
+(Phase 2 + 3), dispatched in series with a checkpoint between them.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Google API rate limits hit on 90-day backfill | Pagination already handled; 90d = ~100 events max for most users; acceptable |
+| `CalendarConnection` missing on existing users | Task 1.3 upsert ensures it exists after callback. Existing disconnected users unaffected. |
+| Resume flow loads stale inbox data | `useCalendarInbox("pending")` query is already invalidated on sync success; no special handling needed |
+| Type field drift between Prisma and `api-types.ts` | Regenerate Prisma client in Task 1.1; update types in Task 3.4 before component work |
+| Toast collides with existing notifications | Scan for existing Toast in Task 3.1; reuse if present |
+| Wizard keyboard shortcuts trigger inside form inputs | Skip shortcuts when `document.activeElement` is an input/textarea/select |

--- a/Docs/superpowers/specs/2026-04-09-google-calendar-sync-enhancement-backend-context.md
+++ b/Docs/superpowers/specs/2026-04-09-google-calendar-sync-enhancement-backend-context.md
@@ -1,0 +1,431 @@
+# Backend Context: Google Calendar Sync Enhancement
+
+**Date:** 2026-04-09
+**Feature:** google-calendar-sync (enhancement of existing feature)
+**Base branch:** main
+
+Context document for the implementation subagent. This is an **enhancement** to an
+already-shipped Google Calendar sync — most infrastructure exists; we're adding
+configurable backfill, auto-sync on mount, and a guided first-time logging
+exercise.
+
+---
+
+## 1. Current Schema (as of 2026-04-09)
+
+### `UserIntegration` — `prisma/schema.prisma:834`
+
+Token storage for all integrations (gmail, google_calendar, slack, mixmax).
+
+```
+id             String    @id @default(uuid())
+userId         String    @map("user_id") @db.Uuid
+service        String    @db.VarChar(30)          // "google_calendar"
+accountEmail   String?   @map("account_email")
+accountName    String?   @map("account_name")
+accessToken    String    @db.Text                  // encrypted (AES-256-GCM)
+refreshToken   String?   @db.Text                  // encrypted
+tokenExpiresAt DateTime? @map("token_expires_at")
+scopes         String[]  @default([])
+metadata       Json?                               // { companyDomain: "fullmindlearning.com" }
+syncEnabled    Boolean   @default(true)
+status         String    @default("connected")    // connected | disconnected | error
+lastSyncAt     DateTime? @map("last_sync_at")
+@@unique([userId, service])
+```
+
+### `CalendarConnection` — `prisma/schema.prisma:1019`
+
+Calendar-specific settings + the *legacy* token store (kept for back-compat; the
+active tokens live on `UserIntegration`).
+
+```
+id                     String    @id @default(uuid())
+userId                 String    @unique @db.Uuid
+googleAccountEmail     String    @db.VarChar(255)
+accessToken            String                       // encrypted — LEGACY, prefer UserIntegration
+refreshToken           String                       // encrypted — LEGACY
+tokenExpiresAt         DateTime
+companyDomain          String    @db.VarChar(100)   // filters internal attendees
+syncEnabled            Boolean   @default(true)
+lastSyncAt             DateTime?
+status                 String    @default("connected")  // connected | disconnected | error
+syncDirection          String    @default("two_way")    // one_way (app→cal) | two_way
+syncedActivityTypes    String[]  @default([])           // [] = all types
+reminderMinutes        Int       @default(15)
+secondReminderMinutes  Int?
+createdAt              DateTime  @default(now())
+updatedAt              DateTime  @updatedAt
+events                 CalendarEvent[]
+```
+
+### `CalendarEvent` — `prisma/schema.prisma:1049`
+
+Staging table for pulled Google events awaiting rep review.
+
+```
+id                    String   @id @default(uuid())
+userId                String   @db.Uuid
+connectionId          String?
+googleEventId         String
+title                 String   @db.VarChar(500)
+description           String?
+startTime             DateTime
+endTime               DateTime
+location              String?  @db.VarChar(500)
+attendees             Json     @default("[]")          // [{ email, name, responseStatus }]
+status                String   @default("pending")     // pending | confirmed | dismissed | cancelled
+suggestedActivityType String?  @db.VarChar(30)
+suggestedDistrictId   String?  @db.VarChar(7)
+suggestedContactIds   Json?
+suggestedPlanId       String?
+matchConfidence       String   @default("none")        // high | medium | low | none
+activityId            String?                          // populated on confirm
+lastSyncedAt          DateTime
+@@unique([connectionId, googleEventId])
+@@index([userId, status])
+```
+
+### `Activity` — `prisma/schema.prisma:609` (relevant fields only)
+
+```
+id               String    @id @default(uuid())
+type             String    @db.VarChar(30)
+title            String    @db.VarChar(255)
+startDate        DateTime? @map("start_date")
+endDate          DateTime? @map("end_date")
+status           String    @default("planned")
+createdByUserId  String?   @db.Uuid
+googleEventId    String?   @unique @map("google_event_id")  // ★ already unique — trivial dedupe
+source           String    @default("manual") @db.VarChar(30)  // manual | calendar_sync
+```
+
+The `@unique` constraint on `googleEventId` means we can skip in Prisma with a
+single `findUnique`.
+
+---
+
+## 2. Current Sync Flow
+
+### OAuth entrypoint — `src/app/api/calendar/connect/route.ts`
+- `GET` builds a Google OAuth URL via `getAuthUrl(redirectUri, state)`.
+- `state` is base64url-encoded JSON `{ userId, nonce, returnTo }` for CSRF.
+- `returnTo` is read from query param (e.g. `?returnTo=settings`).
+- Redirects to Google.
+
+### OAuth callback — `src/app/api/calendar/callback/route.ts`
+1. Receives `?code=...&state=...`.
+2. Verifies `state.userId === session.user.id`.
+3. Exchanges code via `exchangeCodeForTokens(code, redirectUri)` →
+   `{ accessToken, refreshToken, expiresAt, email }`.
+4. Computes `companyDomain` from `session.user.email`.
+5. **Upserts `UserIntegration`** with encrypted tokens + metadata.
+   (Does NOT touch `CalendarConnection` — but sync expects one. **This is a
+   gap**: callback must also upsert `CalendarConnection` so sync works. Check
+   current behavior; there may be a fallback.)
+6. Calls `syncCalendarEvents(user.id)` immediately — non-fatal on error.
+7. Redirects to:
+   - `?tab=profile&section=calendar-sync&calendarConnected=true` if `returnTo=settings`
+   - `?tab=activities&calendarConnected=true` otherwise
+
+### Manual sync — `src/app/api/calendar/sync/route.ts`
+- `POST` → authed → `syncCalendarEvents(user.id)` → returns `SyncResult`.
+
+### Status — `src/app/api/calendar/status/route.ts`
+- `GET` returns `{ connected: boolean, connection: CalendarConnection | null, pendingCount: number }`.
+- `PATCH` updates connection settings (syncEnabled, companyDomain, syncDirection, syncedActivityTypes, reminderMinutes, secondReminderMinutes).
+
+### Inbox list — `src/app/api/calendar/events/route.ts`
+- `GET ?status=pending` returns staged events with enriched
+  district/contact/plan names for the cards.
+
+### Event confirm — `src/app/api/calendar/events/[id]/route.ts`
+- `POST` → `confirmCalendarEvent(userId, eventId, overrides?)` → creates Activity.
+- `PATCH` → `dismissCalendarEvent(userId, eventId)`.
+
+### Batch confirm — `src/app/api/calendar/events/batch-confirm/route.ts`
+- `POST` → `batchConfirmHighConfidence(userId)` → confirms all pending events with `matchConfidence === "high"`.
+
+### Disconnect — `src/app/api/calendar/disconnect/route.ts`
+- Sets `UserIntegration.syncEnabled = false` + `status = "disconnected"`.
+
+### Sync engine — `src/features/calendar/lib/sync.ts`
+
+`syncCalendarEvents(userId)`:
+1. Loads `UserIntegration` (google_calendar) + `CalendarConnection` for user.
+2. Short-circuits if `syncDirection === "one_way"` (push-only mode).
+3. Decrypts tokens, calls `getValidAccessToken()` (refreshes if within 5 min of expiry).
+4. **Hardcoded window (lines 254-257):**
+   ```ts
+   const timeMin = new Date(); timeMin.setDate(timeMin.getDate() - 7);
+   const timeMax = new Date(); timeMax.setDate(timeMax.getDate() + 14);
+   ```
+5. `fetchCalendarEvents(accessToken, timeMin, timeMax)` paginates primary calendar.
+6. For each event:
+   - `filterExternalAttendees(attendees, companyDomain)` — skip if empty (internal meeting).
+   - `matchAttendeesToContacts(userId, externalAttendees)` — returns `{ confidence, suggestedDistrictId, suggestedContactIds, suggestedPlanId }`.
+   - `detectActivityType(title, count)` — keyword + attendee-count heuristic.
+   - Upsert into `CalendarEvent` (staging), keyed by `(connectionId, googleEventId)`.
+7. Marks staged `pending` events whose `googleEventId` no longer appears in the fetched list as `cancelled`.
+8. Updates `UserIntegration.lastSyncAt`.
+
+### Google client — `src/features/calendar/lib/google.ts`
+- `getAuthUrl(redirectUri, state)` — `access_type: "offline"`, `prompt: "consent"`.
+- `exchangeCodeForTokens(code, redirectUri)` — returns `{ accessToken, refreshToken, expiresAt, email }`.
+- `refreshAccessToken(refreshToken)` — returns `{ accessToken, expiresAt }`.
+- `isTokenExpired(expiresAt)` — returns true if within 5 min of expiry.
+- `getValidAccessToken({ accessToken, refreshToken, tokenExpiresAt })` — returns valid token or `null` on refresh failure.
+- `fetchCalendarEvents(accessToken, timeMin, timeMax)` — paginates through primary calendar; filters out all-day + cancelled events.
+- `filterExternalAttendees(attendees, companyDomain)` — excludes `self` + same-domain.
+- `createCalendarEvent`, `updateCalendarEvent`, `deleteCalendarEvent` — used by push.ts (write sync).
+
+### Encryption — `src/features/integrations/lib/encryption.ts`
+- `encrypt(plaintext)` / `decrypt(ciphertext)` — AES-256-GCM using `process.env.ENCRYPTION_KEY` (64 hex chars).
+- Format: `iv:authTag:ciphertext` (all hex).
+
+---
+
+## 3. Auth Pattern
+
+All calendar routes use `getUser()` from `@/lib/supabase/server`, which returns
+the Supabase session user or `null`. Unauthed requests return `401 { error }`.
+`user.id` (uuid) is the key for `UserIntegration.userId` and
+`CalendarConnection.userId`.
+
+---
+
+## 4. Schema Changes Needed
+
+Additions to `CalendarConnection`:
+
+```prisma
+model CalendarConnection {
+  // ...existing fields...
+  backfillStartDate   DateTime? @map("backfill_start_date")
+  backfillCompletedAt DateTime? @map("backfill_completed_at")
+}
+```
+
+**Rationale:**
+- `backfillStartDate`: the `timeMin` the user picked during first-connect
+  setup (e.g., `now() - 30 days`). Used by the sync engine on the initial
+  backfill run. `NULL` after the backfill pass is done — incremental sync
+  uses `lastSyncAt - 2 days` (buffer for stragglers).
+- `backfillCompletedAt`: set when the user finishes (or explicitly skips) the
+  first-time logging exercise. While `NULL`, the setup modal reopens on app
+  mount until resolved. Separate from `backfillStartDate` because the user
+  may close the modal mid-exercise and return later.
+
+**Indexes:** no new indexes needed — queries go through the `userId` unique key.
+
+**Draft migration SQL:**
+
+```sql
+ALTER TABLE calendar_connections
+  ADD COLUMN backfill_start_date    TIMESTAMP(3),
+  ADD COLUMN backfill_completed_at  TIMESTAMP(3);
+```
+
+**Callback fix (unrelated but blocking):** the current callback only upserts
+`UserIntegration`, not `CalendarConnection` — verify what happens on first
+connect, because `syncCalendarEvents` short-circuits without a
+`CalendarConnection`. If the callback is missing that upsert, the implementer
+must add it.
+
+---
+
+## 5. Sync Engine Changes Needed
+
+Target: `src/features/calendar/lib/sync.ts`.
+
+### Change 1: Replace hardcoded window (lines 254-257)
+
+```ts
+// BEFORE
+const timeMin = new Date();
+timeMin.setDate(timeMin.getDate() - 7);
+const timeMax = new Date();
+timeMax.setDate(timeMax.getDate() + 14);
+
+// AFTER
+const timeMax = new Date();
+timeMax.setDate(timeMax.getDate() + 14);
+
+let timeMin: Date;
+if (calendarConnection.backfillStartDate && !calendarConnection.backfillCompletedAt) {
+  // Initial backfill: use the user-chosen window
+  timeMin = calendarConnection.backfillStartDate;
+} else if (calendarConnection.lastSyncAt) {
+  // Incremental: last sync time minus 2-day buffer for late-arriving updates
+  timeMin = new Date(calendarConnection.lastSyncAt);
+  timeMin.setDate(timeMin.getDate() - 2);
+} else {
+  // Fallback (no backfill chosen, no prior sync) — preserve old 7-day behavior
+  timeMin = new Date();
+  timeMin.setDate(timeMin.getDate() - 7);
+}
+```
+
+### Change 2: Dedupe against Activities (inside the per-event loop, around line 299)
+
+Before looking up `existingEvent` in `CalendarEvent`, check if an Activity
+already exists for this `googleEventId`:
+
+```ts
+const existingActivity = await prisma.activity.findUnique({
+  where: { googleEventId: event.id },
+  select: { id: true },
+});
+if (existingActivity) continue; // user already logged this manually — skip staging
+```
+
+This is a tight inner-loop query; Prisma hits the `@unique` index so it's cheap
+(~1ms). If the implementer wants to optimize, batch-prefetch all
+`googleEventId`s for the window:
+
+```ts
+const googleIds = googleEvents.map(e => e.id);
+const alreadyLogged = new Set(
+  (await prisma.activity.findMany({
+    where: { googleEventId: { in: googleIds } },
+    select: { googleEventId: true },
+  })).map(a => a.googleEventId)
+);
+// then inside the loop: if (alreadyLogged.has(event.id)) continue;
+```
+
+Recommend the batch approach.
+
+### Change 3: Close out backfill on last event
+
+Not in the sync engine. The `backfillCompletedAt` is set by a separate API
+route (e.g., `POST /api/calendar/backfill/complete`) when the user finishes or
+skips the wizard.
+
+### Change 4: Update `CalendarConnection.lastSyncAt` too
+
+Currently sync updates `UserIntegration.lastSyncAt` (line 386). It should also
+update `CalendarConnection.lastSyncAt` — the status route reads from
+`CalendarConnection`.
+
+---
+
+## 6. Auto-Sync Trigger Strategy
+
+**Recommendation: client-side mutation on mount, fired from `HomeView.tsx`
+(or the route entry component that runs once after login).**
+
+### Where to hook
+
+`src/app/providers.tsx` is the QueryClient provider wrapper — too early
+(no session context yet). `src/features/shared/components/views/HomeView.tsx`
+mounts once after auth and already imports calendar hooks — this is the
+cleanest injection point.
+
+Add a new hook `useAutoSyncCalendarOnMount()` in
+`src/features/calendar/lib/queries.ts`:
+
+```ts
+export function useAutoSyncCalendarOnMount() {
+  const { data: connection } = useCalendarConnection();
+  const sync = useTriggerCalendarSync();
+  const ran = useRef(false);
+
+  useEffect(() => {
+    if (ran.current) return;
+    if (!connection?.connected) return;
+    if (!connection.connection?.syncEnabled) return;
+    ran.current = true;
+    sync.mutate();
+  }, [connection, sync]);
+}
+```
+
+Then call `useAutoSyncCalendarOnMount()` once at the top of `HomeView`.
+
+**Why not server-side?** Server-side (middleware or server action in layout)
+means every navigation could trigger a sync. Client-side on HomeView mount gives
+us exactly one sync per login session, which matches user intent.
+
+**Throttling:** the `useRef` guards against re-running across renders within
+the same session. If the user hard-refreshes, a new sync fires — this is
+acceptable and desired.
+
+### Toast on new events
+
+After `sync.mutate()` resolves successfully, check `inboxData.pendingCount`
+(or the returned `SyncResult.newEvents`) and fire a toast. The codebase uses
+hand-rolled toast components — look for an existing toast pattern in
+`HomeView` or add a lightweight one if missing.
+
+---
+
+## 7. Activity Dedupe Query
+
+Already covered in §5. Exact batch query:
+
+```ts
+const googleIds = googleEvents.map(e => e.id);
+const alreadyLogged = await prisma.activity.findMany({
+  where: { googleEventId: { in: googleIds } },
+  select: { googleEventId: true },
+});
+const alreadyLoggedSet = new Set(alreadyLogged.map(a => a.googleEventId));
+```
+
+Relies on the `@unique` constraint on `Activity.googleEventId` (schema line
+623). No additional index needed.
+
+---
+
+## 8. Testing Conventions
+
+The calendar feature has unit tests under `src/features/calendar/lib/__tests__/`
+(verify; directory may or may not exist yet). Gmail sync has
+`src/features/integrations/lib/__tests__/gmail-sync.test.ts` which is the
+canonical pattern for mocked integration sync tests.
+
+**Conventions:**
+- Vitest + Testing Library + jsdom.
+- Prisma is mocked via `vi.mock('@/lib/prisma', ...)`.
+- Google API is mocked by mocking the wrapper module (e.g. `@/features/calendar/lib/google`) rather than `googleapis` directly.
+- Tests co-located in `__tests__/` next to source.
+- For the new backfill logic: parameterize tests over `{ backfillStartDate, backfillCompletedAt, lastSyncAt }` tuples to verify `timeMin` selection.
+
+---
+
+## 9. E2E Test Infrastructure
+
+- `e2e/tests/calendar-sync.spec.ts` — connect flow, sync, confirm, dismiss, batch confirm.
+- `e2e/helpers/mock-google.ts` — `buildCalendarEvent(...)`, `buildEventMutationResponse(...)`, three scenarios (`highConfidence`, `mediumConfidence`, `lowConfidence`).
+- `e2e/pages/CalendarInboxPage.ts` — page object for inbox interactions.
+- `e2e/global-setup.ts` + `e2e/helpers/seed-data.ts` — seed users + districts + contacts.
+
+**Extensions needed for the backfill flow:**
+1. New page object `CalendarBackfillWizardPage.ts` with methods: `pickWindow(days)`, `clickConfirm()`, `clickSkip()`, `clickDismiss()`, `waitForProgress(n, total)`.
+2. New test `e2e/tests/calendar-backfill.spec.ts` covering: connect → pick 30-day window → wizard opens with N events → confirm some → skip some → dismiss some → wizard closes → `backfillCompletedAt` set → CalendarInbox shows empty state.
+3. Mock `buildCalendarEvent` to accept `daysAgo` so we can seed events at specific points in the backfill window.
+
+---
+
+## 10. Environment Variables
+
+Referenced in `src/features/calendar/lib/google.ts`:
+- `GOOGLE_CALENDAR_CLIENT_ID`
+- `GOOGLE_CALENDAR_CLIENT_SECRET`
+- `NEXT_PUBLIC_SITE_URL` (for redirect URI in production)
+
+Referenced in `src/features/integrations/lib/encryption.ts`:
+- `ENCRYPTION_KEY` (64 hex chars, AES-256-GCM)
+
+All already configured — no new env vars needed for this enhancement.
+
+---
+
+## Key Findings Summary
+
+1. **Foundation is solid.** OAuth, encryption, sync engine, staging table, smart matching, inbox UI, batch confirm — all exist and work. Enhancement is narrow: configurable window + auto-mount sync + first-time wizard.
+2. **Schema additions are minimal.** Two nullable DateTime fields on `CalendarConnection` (`backfillStartDate`, `backfillCompletedAt`) carry all the new state.
+3. **Sync engine change is surgical.** Replace 4 lines of hardcoded `timeMin` with a conditional, add a batch dedupe query against `Activity.googleEventId` (already unique-indexed).
+4. **Auto-sync is a single `useEffect` hook** mounted in `HomeView` — no server-side plumbing required.
+5. **Dedupe is free** thanks to `Activity.googleEventId @unique` (schema line 623).

--- a/Docs/superpowers/specs/2026-04-09-google-calendar-sync-spec.md
+++ b/Docs/superpowers/specs/2026-04-09-google-calendar-sync-spec.md
@@ -1,0 +1,338 @@
+# Feature Spec: Google Calendar Sync — Backfill Wizard & Auto-Sync
+
+**Date:** 2026-04-09
+**Slug:** google-calendar-sync
+**Branch:** `worktree-google-calendar-sync` (git worktree)
+**Status:** Approved for implementation
+
+## Overview
+
+Enhancement to the existing Google Calendar sync feature. The base
+infrastructure (OAuth, sync engine, staging table, inbox UI, smart matching)
+already ships. This spec covers three additions:
+
+1. **First-connect backfill wizard** — after OAuth, the user picks how far back
+   to sync (7/30/60/90 days) and walks through a one-at-a-time guided logging
+   exercise to turn past calendar events into Activities.
+2. **Auto-sync on app mount** — after the user logs in, the app fires a single
+   incremental sync automatically and surfaces new events via a bottom-right
+   toast.
+3. **Persistent connection** — the calendar stays connected across sessions
+   until the user explicitly disconnects (behavior already exists; this spec
+   codifies it).
+
+## Requirements
+
+- **Configurable backfill window:** users pick from 4 presets on first connect:
+  7, 30, 60, or 90 days. Default selected: 30 days.
+- **Guided logging exercise:** after the initial sync pulls events, a
+  full-screen modal walks the user through each event one at a time with all
+  fields pre-populated from smart-matching suggestions.
+- **Inline review UX:** every key field (activity type, plan, district,
+  contacts, notes) is editable directly on the wizard card — no intermediate
+  edit step. Three actions per event: Skip, Dismiss, Save & Next.
+- **Resumable state:** if the user closes the modal mid-exercise, re-opening
+  the app brings them back to the wizard at the same event until
+  `backfillCompletedAt` is set.
+- **Auto-sync on mount:** one sync per page load, fired client-side from
+  `HomeView`. Guarded by `useRef` so it runs once per mount.
+- **Post-sync toast:** if the incremental sync finds new events, a bottom-right
+  toast slides in with a link to the Calendar Inbox. Non-blocking, non-modal.
+- **Dedupe vs manual activities:** events that already have an `Activity`
+  record with the same `googleEventId` are silently skipped during staging.
+- **Persistent connection:** tokens stay valid via refresh token; user
+  disconnects explicitly from settings.
+
+### Out of Scope
+
+- Background cron sync (mount-triggered only for v1)
+- Google Calendar push notification webhooks
+- Multiple calendars per user (primary only)
+- Bidirectional conflict resolution after backfill
+- "Un-dismiss" or "review dismissed" flows
+- Team/shared calendar backfill
+- Toast deduplication across multiple tabs
+
+## Visual Design
+
+**Approved approach:** Direction B — *Inline Review* wizard. Full-screen modal
+with a deliberate, rich card that exposes every field for editing before the
+user commits. Three-button action row (Skip / Dismiss / Save & Next). Warm
+"Mr. Menke" coaching tone in copy.
+
+### Key architectural decisions
+
+- **Full-screen modal, not a dedicated route.** Keeps state ephemeral, lets
+  the user dismiss and resume, avoids new routing surface area.
+- **Step state in component local state**, persisted to the database only via
+  `backfillStartDate` / `backfillCompletedAt` on `CalendarConnection`. The
+  modal is stateless between sessions beyond those two flags.
+- **Auto-sync triggered from `HomeView`, not root layout.** HomeView mounts
+  once after auth and already imports calendar hooks — cleanest injection
+  point. `useRef` guards prevent double-firing.
+- **Backfill uses `CalendarConnection.backfillStartDate` as `timeMin`** on the
+  first sync pass; subsequent incremental syncs use `lastSyncAt - 2 days`.
+- **Dedupe via batch query** against `Activity.googleEventId` (already
+  `@unique` in schema) before staging events.
+
+## User Flow
+
+```
+Settings: [Connect Google Calendar] ──▶ OAuth consent
+                                              │
+                                              ▼
+                           Callback: upsert UserIntegration + CalendarConnection
+                                              │
+                                              ▼
+            Redirect to ?tab=home&calendarJustConnected=true (NO immediate sync)
+                                              │
+                                              ▼
+               HomeView mounts → detects flag → opens BackfillSetupModal
+                                              │
+                                              ▼
+              ┌─ Step 1: Window Picker (default = 30 days) ─┐
+              │    [7d]  [30d★]  [60d]  [90d]                │
+              │    [Maybe later]     [Start sync →]          │
+              └──────────────────────────────────────────────┘
+                                              │
+                                              ▼
+                    POST /api/calendar/backfill/start { days }
+                                              │
+                                              ▼
+                    Loading: "Pulling 30 days from Google…"
+                                              │
+                                              ▼
+                   ┌── no events ──▶ 🎉 "All caught up" → close
+                   │
+                   ▼
+              ┌─ Step 2: Wizard ────────────────────────────┐
+              │    Progress: 8 of 47 • 17%                   │
+              │    [rich inline-edit card]                   │
+              │    [Skip] [Dismiss] [★ Save & Next]          │
+              │    "Save & finish later" (footer link)       │
+              └──────────────────────────────────────────────┘
+                                              │
+                                              ▼
+                         (on last event or user clicks "Finish")
+                                              │
+                                              ▼
+                    POST /api/calendar/backfill/complete
+                                              │
+                                              ▼
+                    🎉 Completion screen (auto-close 3s)
+                                              │
+                                              ▼
+                              Land on ?tab=activities
+
+—— subsequent logins ——
+
+      HomeView mount → useAutoSyncCalendarOnMount() fires once
+                                │
+                                ▼
+           Incremental sync (lastSyncAt-2d → now+14d)
+                                │
+                       ┌────────┴────────┐
+                       │                 │
+                 newEvents > 0       newEvents === 0
+                       │                 │
+                       ▼                 ▼
+             Toast: "3 new…"         (silent)
+             + nav badge update
+```
+
+## Component Plan
+
+### New components (in `src/features/calendar/components/backfill/`)
+
+| Component | Purpose |
+|-----------|---------|
+| `BackfillSetupModal.tsx` | Full-screen modal shell; manages step state (picker → loading → wizard → complete); portal pattern mirrored from `ActivityFormModal.tsx` |
+| `BackfillWindowPicker.tsx` | Step 1 — 4 preset cards in a 2×2 grid; 30-day preselected with ★ badge |
+| `BackfillWizard.tsx` | Step 2 — wraps card + progress bar + action row + keyboard handlers |
+| `BackfillEventCard.tsx` | The rich inline-edit card — displays date/time, confidence banner, editable Type/Plan/District/Notes fields, read-only attendees list |
+| `BackfillCompletionScreen.tsx` | 🎉 celebration screen shown after last event; auto-closes after 3s |
+| `CalendarSyncToast.tsx` | Bottom-right toast for post-sync "N new events" prompt (generalize into shared `Toast.tsx` if no similar pattern exists) |
+
+### New hooks (in `src/features/calendar/lib/queries.ts`)
+
+| Hook | Purpose |
+|------|---------|
+| `useAutoSyncCalendarOnMount()` | Fires one sync per mount, reads `newEvents` from result, triggers toast if > 0 |
+| `useBackfillStatus()` | Derives `{ needsSetup, needsResume, backfillCompletedAt }` from the existing connection query |
+| `useStartBackfill()` | Mutation → `POST /api/calendar/backfill/start { days }` |
+| `useCompleteBackfill()` | Mutation → `POST /api/calendar/backfill/complete` |
+
+### Components to extend
+
+| File | Changes |
+|------|---------|
+| `src/features/shared/components/views/HomeView.tsx` | Mount `<BackfillSetupModal />`, call `useAutoSyncCalendarOnMount()`, detect `?calendarJustConnected=true` query param |
+| `src/features/calendar/components/ConnectionStatusCard.tsx` | Add "Resume backfill" link when `backfillCompletedAt === null` |
+| `src/app/api/calendar/callback/route.ts` | Remove immediate `syncCalendarEvents` call (defer to user's window choice); ensure `CalendarConnection` is upserted (not only `UserIntegration`); redirect to `?tab=home&calendarJustConnected=true` |
+| `src/features/calendar/lib/sync.ts` | Replace hardcoded window (lines 254-257) with `backfillStartDate`-driven logic; add batch Activity dedupe query; also update `CalendarConnection.lastSyncAt` |
+
+### Existing components reused
+
+- `useConfirmCalendarEvent`, `useDismissCalendarEvent`, `useCalendarInbox`,
+  `useTriggerCalendarSync`, `useCalendarConnection` — from
+  `src/features/calendar/lib/queries.ts`
+- `MultiSelect`, `AsyncMultiSelect` — shared form controls
+- `ACTIVITY_TYPE_LABELS`, `ACTIVITY_TYPE_ICONS` — from
+  `@/features/activities/types`
+- `fetchJson`, `API_BASE` — from `@/features/shared/lib/api-client`
+- `formatRelativeTime` — can be lifted from `ConnectionStatusCard` if needed
+
+## Backend Design
+
+See: [`docs/superpowers/specs/2026-04-09-google-calendar-sync-enhancement-backend-context.md`](./2026-04-09-google-calendar-sync-enhancement-backend-context.md)
+
+### New schema fields
+
+```prisma
+model CalendarConnection {
+  // ...existing fields...
+  backfillStartDate   DateTime? @map("backfill_start_date")
+  backfillCompletedAt DateTime? @map("backfill_completed_at")
+}
+```
+
+### Migration
+
+```sql
+ALTER TABLE calendar_connections
+  ADD COLUMN backfill_start_date    TIMESTAMP(3),
+  ADD COLUMN backfill_completed_at  TIMESTAMP(3);
+```
+
+### New API routes
+
+| Route | Method | Body | Returns | Purpose |
+|-------|--------|------|---------|---------|
+| `/api/calendar/backfill/start` | POST | `{ days: 7\|30\|60\|90 }` | `SyncResult + { pendingCount }` | Sets `backfillStartDate = now() - days`, triggers initial sync |
+| `/api/calendar/backfill/complete` | POST | — | `{ success: true }` | Sets `backfillCompletedAt = now()` |
+
+### Sync engine changes (in `src/features/calendar/lib/sync.ts`)
+
+1. **Replace hardcoded `timeMin`/`timeMax` (lines 254-257)** with:
+   - If `backfillStartDate && !backfillCompletedAt` → `timeMin = backfillStartDate`
+   - Else if `lastSyncAt` → `timeMin = lastSyncAt - 2 days`
+   - Else → `timeMin = now() - 7 days` (fallback)
+   - `timeMax = now() + 14 days` (unchanged)
+2. **Batch dedupe against Activities** — before per-event staging, query:
+   ```ts
+   const alreadyLogged = new Set(
+     (await prisma.activity.findMany({
+       where: { googleEventId: { in: googleEvents.map(e => e.id) } },
+       select: { googleEventId: true },
+     })).map(a => a.googleEventId)
+   );
+   ```
+   Inside the loop: `if (alreadyLogged.has(event.id)) continue;`
+3. **Update `CalendarConnection.lastSyncAt`** in addition to
+   `UserIntegration.lastSyncAt`.
+
+## States
+
+### BackfillSetupModal
+
+| State | Behavior |
+|-------|----------|
+| **Hidden** | Default. Shown when HomeView detects `needsSetup || needsResume`. |
+| **Step 1: Picker** | Four preset cards, 30-day pre-selected. Start button disabled until selection. |
+| **Loading (sync)** | Centered spinner + "Pulling your last N days from Google…" + subtext. |
+| **Step 2: Wizard** | Card + action row + progress bar. Keyboard active. |
+| **Empty (no events)** | "All caught up — no external meetings in that window." + Close button. |
+| **Last event** | Save & Next triggers fade to BackfillCompletionScreen. |
+| **Error (sync failed)** | Inline error card with Retry button, "Couldn't reach Google." |
+| **Error (confirm failed)** | Red border on card + toast "Couldn't save. Try again." |
+
+### BackfillEventCard (per-event)
+
+| State | Behavior |
+|-------|----------|
+| **Default** | All fields editable, confidence banner at top |
+| **Saving** | Save button → spinner + "Saving…", card locks to pointer-events: none |
+| **Prev of confirmed event** | Read-only overlay with "Undo" link that reverts the Activity |
+| **No match (confidence = none)** | No confidence banner; dropdowns empty but editable |
+
+### CalendarSyncToast
+
+| State | Behavior |
+|-------|----------|
+| **Hidden** | Default |
+| **Visible** | Slides in bottom-right on `sync.onSuccess` when `newEvents > 0`. Auto-dismisses after 6s or on click × |
+| **Click "Review"** | Navigates to `?tab=activities` + scrolls to `CalendarInbox` section |
+
+### Auto-sync on mount
+
+| Condition | Behavior |
+|-----------|----------|
+| Not connected | Skip — no sync |
+| `syncEnabled === false` | Skip — no sync |
+| `backfillCompletedAt === null` | Skip auto-sync (user is in/about to see the wizard); wizard will trigger its own sync |
+| Already ran in this session | Skip — `useRef` guard |
+| Otherwise | Fire `syncCalendarEvents()` incrementally |
+
+## Testing Strategy
+
+### Unit tests (Vitest + Testing Library)
+
+1. **`sync.ts` window logic** (parameterized test):
+   - `{ backfillStartDate: "...", backfillCompletedAt: null }` → timeMin = backfillStartDate
+   - `{ backfillStartDate: "...", backfillCompletedAt: "..." }` → timeMin = lastSyncAt - 2d
+   - `{ backfillStartDate: null, lastSyncAt: "..." }` → timeMin = lastSyncAt - 2d
+   - `{ backfillStartDate: null, lastSyncAt: null }` → timeMin = now() - 7d (fallback)
+2. **`sync.ts` dedupe logic**:
+   - Events with a matching `Activity.googleEventId` are skipped
+   - Events without a match are staged as normal
+3. **`BackfillWindowPicker`**:
+   - 30-day preset pre-selected on mount
+   - Clicking a card moves selection ring
+   - Start button disabled until selection (should always be enabled given default)
+4. **`BackfillEventCard`**:
+   - Pre-fills suggested values from event
+   - Save button calls `useConfirmCalendarEvent` with user-edited values (not originals if user changed them)
+   - Skip advances without calling confirm
+   - Dismiss calls `useDismissCalendarEvent`
+5. **`useAutoSyncCalendarOnMount`**:
+   - Fires once per mount (useRef guard test)
+   - Skips when `!connected`
+   - Skips when `backfillCompletedAt === null`
+6. **`useBackfillStatus`** selector:
+   - Derives correct flags from various connection shapes
+
+### E2E tests (Playwright)
+
+Extend `e2e/tests/calendar-sync.spec.ts` or add `e2e/tests/calendar-backfill.spec.ts`:
+
+1. **Connect → window picker shows** — user completes OAuth, modal opens to Step 1
+2. **Pick 30 days → sync runs → wizard opens** — uses `mock-google.ts` seeded with 5 events across 30 days
+3. **Confirm first event → Activity created** — verify via API assertion
+4. **Skip second event → stays pending** — next card loads
+5. **Dismiss third event → marked dismissed** — next card loads
+6. **Close modal mid-flow → reopen → resumes at same event** — `Save & finish later` → close → navigate away → come back → modal opens at Step 2 at the same card
+7. **Finish last event → completion screen** — `backfillCompletedAt` set
+8. **Subsequent visit → auto-sync + toast** — mock returns 2 new events, toast appears
+9. **Dedupe**: pre-seed an Activity with `googleEventId = "evt-1"`, then sync an event with the same ID → assert it's NOT in the staging table
+
+Page object: `e2e/pages/CalendarBackfillWizardPage.ts` with methods
+`pickWindow(days)`, `clickStartSync()`, `waitForEvent(n, total)`, `confirm()`,
+`skip()`, `dismiss()`, `closeAndResume()`, `undoLast()`.
+
+Extend `e2e/helpers/mock-google.ts` with `buildCalendarEvent({ daysAgo })` so
+events can be seeded relative to the backfill window.
+
+## Success Criteria
+
+- User can connect Google Calendar, pick a window, and complete a logging
+  exercise without leaving the app.
+- `backfillCompletedAt` is set after completion — wizard does not reopen on
+  subsequent mounts.
+- Auto-sync fires once per app mount and surfaces a toast when new events
+  arrive.
+- Events with matching `Activity.googleEventId` are not re-staged.
+- All unit tests pass (`npx vitest run`).
+- All E2E tests pass.
+- `npm run build` clean.
+- Accessibility: keyboard navigation through the wizard works (Y/S/X/←/→/Esc);
+  modal traps focus; color contrast meets WCAG AA against Fullmind tokens.

--- a/Documentation/.md Files/TECHSTACK.md
+++ b/Documentation/.md Files/TECHSTACK.md
@@ -160,6 +160,8 @@ Used for:
 /api/calendar/events        — List staged calendar events (inbox)
 /api/calendar/events/[id]   — Confirm/dismiss a calendar event
 /api/calendar/events/batch-confirm — Bulk-confirm high-confidence events
+/api/calendar/backfill/start    — Start first-time backfill with user-chosen window (7/30/60/90 days)
+/api/calendar/backfill/complete — Mark backfill logging exercise as finished
 
 /api/progress/activities    — Activity metrics (counts, trends, coverage)
 /api/progress/outcomes      — Outcome metrics (funnel, distribution)

--- a/prisma/migrations/manual/2026-04-09-calendar-backfill-fields.sql
+++ b/prisma/migrations/manual/2026-04-09-calendar-backfill-fields.sql
@@ -1,0 +1,15 @@
+-- Calendar Backfill Fields — DDL Changes
+-- Adds two nullable DateTime columns to calendar_connections for the
+-- first-connect backfill wizard + auto-sync enhancement (see
+-- docs/superpowers/specs/2026-04-09-google-calendar-sync-spec.md).
+--
+-- Run this BEFORE deploying the updated Prisma schema. All changes are
+-- additive (nullable columns, no drops, no defaults to backfill).
+
+BEGIN;
+
+ALTER TABLE calendar_connections
+  ADD COLUMN IF NOT EXISTS backfill_start_date   TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS backfill_completed_at TIMESTAMP(3);
+
+COMMIT;

--- a/prisma/migrations/manual/2026-04-09-calendar-backfill-window-days.sql
+++ b/prisma/migrations/manual/2026-04-09-calendar-backfill-window-days.sql
@@ -1,0 +1,15 @@
+-- Calendar Backfill Window Days — DDL Changes
+-- Adds a nullable integer column to calendar_connections storing the
+-- symmetric backfill window size in days (7/30/60/90). Used to drive both
+-- timeMin and timeMax in the sync engine so that the forward-looking window
+-- matches the user's chosen backfill window.
+--
+-- Run this BEFORE deploying the updated Prisma schema. Additive and
+-- idempotent — no drops, no defaults to backfill.
+
+BEGIN;
+
+ALTER TABLE calendar_connections
+  ADD COLUMN IF NOT EXISTS backfill_window_days INTEGER;
+
+COMMIT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1033,6 +1033,7 @@ model CalendarConnection {
   secondReminderMinutes  Int?     @map("second_reminder_minutes")
   backfillStartDate      DateTime? @map("backfill_start_date") // user-chosen timeMin for initial backfill sync; NULL once backfill pass is done
   backfillCompletedAt    DateTime? @map("backfill_completed_at") // set when first-time logging wizard finishes; NULL = wizard still pending
+  backfillWindowDays     Int?      @map("backfill_window_days") // symmetric window (7/30/60/90) — drives both timeMin (initial) and timeMax (all syncs)
   createdAt          DateTime  @default(now()) @map("created_at")
   updatedAt          DateTime  @updatedAt @map("updated_at")
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1031,6 +1031,8 @@ model CalendarConnection {
   syncedActivityTypes    String[] @default([]) @map("synced_activity_types") // empty = all types synced
   reminderMinutes        Int      @default(15) @map("reminder_minutes") // 0 = none
   secondReminderMinutes  Int?     @map("second_reminder_minutes")
+  backfillStartDate      DateTime? @map("backfill_start_date") // user-chosen timeMin for initial backfill sync; NULL once backfill pass is done
+  backfillCompletedAt    DateTime? @map("backfill_completed_at") // set when first-time logging wizard finishes; NULL = wizard still pending
   createdAt          DateTime  @default(now()) @map("created_at")
   updatedAt          DateTime  @updatedAt @map("updated_at")
 

--- a/src/app/api/calendar/backfill/complete/route.ts
+++ b/src/app/api/calendar/backfill/complete/route.ts
@@ -1,0 +1,39 @@
+// POST /api/calendar/backfill/complete — Marks the first-connect backfill wizard finished
+// Sets CalendarConnection.backfillCompletedAt to now so HomeView stops
+// reopening the setup modal on subsequent mounts.
+
+import { NextResponse } from "next/server";
+import { getUser } from "@/lib/supabase/server";
+import prisma from "@/lib/prisma";
+
+export const dynamic = "force-dynamic";
+
+export async function POST() {
+  try {
+    const user = await getUser();
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const existing = await prisma.calendarConnection.findUnique({
+      where: { userId: user.id },
+      select: { id: true },
+    });
+    if (!existing) {
+      return NextResponse.json({ error: "Not connected" }, { status: 404 });
+    }
+
+    await prisma.calendarConnection.update({
+      where: { userId: user.id },
+      data: { backfillCompletedAt: new Date() },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Calendar backfill complete error:", error);
+    return NextResponse.json(
+      { error: "Failed to complete calendar backfill" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/calendar/backfill/start/route.ts
+++ b/src/app/api/calendar/backfill/start/route.ts
@@ -1,0 +1,74 @@
+// POST /api/calendar/backfill/start — Kicks off the first-connect backfill pass
+// Sets the user-chosen timeMin window on CalendarConnection, runs a single
+// sync, and returns the sync result plus the total pending count so the
+// wizard can show progress.
+
+import { NextResponse } from "next/server";
+import { getUser } from "@/lib/supabase/server";
+import prisma from "@/lib/prisma";
+import { syncCalendarEvents } from "@/features/calendar/lib/sync";
+
+export const dynamic = "force-dynamic";
+
+const ALLOWED_DAYS = new Set([7, 30, 60, 90]);
+
+export async function POST(request: Request) {
+  try {
+    const user = await getUser();
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+
+    const days = (body as { days?: unknown })?.days;
+    if (typeof days !== "number" || !ALLOWED_DAYS.has(days)) {
+      return NextResponse.json(
+        { error: "Invalid days — must be 7, 30, 60, or 90" },
+        { status: 400 }
+      );
+    }
+
+    const backfillStartDate = new Date(Date.now() - days * 86_400_000);
+
+    // Ensure the connection exists before we attempt a sync. If the user
+    // never completed OAuth (or the row was deleted), bail early with 404 so
+    // the UI can prompt them to reconnect.
+    const existing = await prisma.calendarConnection.findUnique({
+      where: { userId: user.id },
+      select: { id: true },
+    });
+    if (!existing) {
+      return NextResponse.json(
+        { error: "Not connected" },
+        { status: 404 }
+      );
+    }
+
+    await prisma.calendarConnection.update({
+      where: { userId: user.id },
+      data: {
+        backfillStartDate,
+        backfillCompletedAt: null,
+      },
+    });
+
+    const syncResult = await syncCalendarEvents(user.id);
+    const pendingCount = await prisma.calendarEvent.count({
+      where: { userId: user.id, status: "pending" },
+    });
+
+    return NextResponse.json({ ...syncResult, pendingCount });
+  } catch (error) {
+    console.error("Calendar backfill start error:", error);
+    return NextResponse.json(
+      { error: "Failed to start calendar backfill" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/calendar/backfill/start/route.ts
+++ b/src/app/api/calendar/backfill/start/route.ts
@@ -55,6 +55,7 @@ export async function POST(request: Request) {
       data: {
         backfillStartDate,
         backfillCompletedAt: null,
+        backfillWindowDays: days, // drives forward window on every subsequent sync
       },
     });
 

--- a/src/app/api/calendar/callback/route.ts
+++ b/src/app/api/calendar/callback/route.ts
@@ -5,7 +5,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getUser } from "@/lib/supabase/server";
 import { exchangeCodeForTokens } from "@/features/calendar/lib/google";
-import { syncCalendarEvents } from "@/features/calendar/lib/sync";
 import { encrypt } from "@/features/integrations/lib/encryption";
 import prisma from "@/lib/prisma";
 
@@ -77,12 +76,15 @@ export async function GET(request: NextRequest) {
 
     // Upsert the calendar integration — one per user per service
     // If the user re-connects, we update the existing integration with new tokens
+    const encryptedAccessToken = encrypt(tokens.accessToken);
+    const encryptedRefreshToken = encrypt(tokens.refreshToken);
+
     await prisma.userIntegration.upsert({
       where: { userId_service: { userId: user.id, service: "google_calendar" } },
       update: {
         accountEmail: tokens.email,
-        accessToken: encrypt(tokens.accessToken),
-        refreshToken: encrypt(tokens.refreshToken),
+        accessToken: encryptedAccessToken,
+        refreshToken: encryptedRefreshToken,
         tokenExpiresAt: tokens.expiresAt,
         metadata: { companyDomain },
         status: "connected",
@@ -92,8 +94,8 @@ export async function GET(request: NextRequest) {
         userId: user.id,
         service: "google_calendar",
         accountEmail: tokens.email,
-        accessToken: encrypt(tokens.accessToken),
-        refreshToken: encrypt(tokens.refreshToken),
+        accessToken: encryptedAccessToken,
+        refreshToken: encryptedRefreshToken,
         tokenExpiresAt: tokens.expiresAt,
         metadata: { companyDomain },
         status: "connected",
@@ -101,25 +103,42 @@ export async function GET(request: NextRequest) {
       },
     });
 
-    // Auto-sync calendar events so the inbox is populated immediately
-    try {
-      await syncCalendarEvents(user.id);
-    } catch (syncErr) {
-      // Non-fatal — the user can manually sync later
-      console.error("Auto-sync after connection failed:", syncErr);
-    }
+    // Upsert the CalendarConnection row — the sync engine reads connection-level
+    // fields (syncDirection, companyDomain, backfillStartDate, etc.) from this
+    // table. Without this upsert, first-time users hit "No calendar connection
+    // found" on sync. On create, backfillStartDate and backfillCompletedAt are
+    // left NULL; the wizard sets them when the user picks a window.
+    await prisma.calendarConnection.upsert({
+      where: { userId: user.id },
+      update: {
+        googleAccountEmail: tokens.email,
+        accessToken: encryptedAccessToken,
+        refreshToken: encryptedRefreshToken,
+        tokenExpiresAt: tokens.expiresAt,
+        companyDomain,
+        status: "connected",
+        syncEnabled: true,
+      },
+      create: {
+        userId: user.id,
+        googleAccountEmail: tokens.email,
+        accessToken: encryptedAccessToken,
+        refreshToken: encryptedRefreshToken,
+        tokenExpiresAt: tokens.expiresAt,
+        companyDomain,
+        status: "connected",
+        syncEnabled: true,
+      },
+    });
 
-    // Redirect back to where the user started the flow
-    if (returnTo === "settings") {
-      console.log("[calendar-callback] → SUCCESS, redirecting to settings");
-      return NextResponse.redirect(
-        `${origin}/?tab=profile&section=calendar-sync&calendarConnected=true`
-      );
-    }
-
-    console.log("[calendar-callback] → SUCCESS, redirecting to activities");
+    // Defer the initial sync. The BackfillSetupModal on HomeView will trigger
+    // it via POST /api/calendar/backfill/start once the user picks a window.
+    console.log(
+      "[calendar-callback] → SUCCESS, redirecting to home for backfill wizard"
+    );
+    const fromSettings = returnTo === "settings" ? "&from=settings" : "";
     return NextResponse.redirect(
-      `${origin}/?tab=activities&calendarConnected=true`
+      `${origin}/?tab=home&calendarJustConnected=true${fromSettings}`
     );
   } catch (err) {
     console.error("[calendar-callback] → FAILED. Error:", err);

--- a/src/app/api/calendar/callback/route.ts
+++ b/src/app/api/calendar/callback/route.ts
@@ -19,18 +19,16 @@ export async function GET(request: NextRequest) {
   const state = searchParams.get("state");
   const error = searchParams.get("error");
 
-  console.log("[calendar-callback] hit — params:", { code: code ? "present" : "missing", state: state ? "present" : "missing", error, origin });
-
   // If the user denied access, redirect back with a message
   if (error) {
-    console.log("[calendar-callback] → error from Google:", error);
+    console.warn("[calendar-callback] user denied access:", error);
     return NextResponse.redirect(
       `${origin}/?calendarError=access_denied`
     );
   }
 
   if (!code) {
-    console.log("[calendar-callback] → no code param");
+    console.warn("[calendar-callback] missing code param");
     return NextResponse.redirect(
       `${origin}/?calendarError=no_code`
     );
@@ -38,7 +36,6 @@ export async function GET(request: NextRequest) {
 
   try {
     const user = await getUser();
-    console.log("[calendar-callback] getUser:", user ? user.id : "null");
     if (!user) {
       return NextResponse.redirect(`${origin}/login`);
     }
@@ -51,7 +48,7 @@ export async function GET(request: NextRequest) {
           Buffer.from(state, "base64url").toString()
         );
         if (stateData.userId !== user.id) {
-          console.log("[calendar-callback] → state mismatch:", { stateUserId: stateData.userId, sessionUserId: user.id });
+          console.warn("[calendar-callback] state/user mismatch");
           return NextResponse.redirect(
             `${origin}/?calendarError=state_mismatch`
           );
@@ -65,9 +62,7 @@ export async function GET(request: NextRequest) {
 
     // Exchange the auth code for access + refresh tokens
     const redirectUri = `${origin}/api/calendar/callback`;
-    console.log("[calendar-callback] exchanging code, redirectUri:", redirectUri);
     const tokens = await exchangeCodeForTokens(code, redirectUri);
-    console.log("[calendar-callback] token exchange succeeded, email:", tokens.email);
 
     // Extract the company domain from the user's email
     // This is used to filter out internal attendees when syncing calendar events
@@ -133,15 +128,12 @@ export async function GET(request: NextRequest) {
 
     // Defer the initial sync. The BackfillSetupModal on HomeView will trigger
     // it via POST /api/calendar/backfill/start once the user picks a window.
-    console.log(
-      "[calendar-callback] → SUCCESS, redirecting to home for backfill wizard"
-    );
     const fromSettings = returnTo === "settings" ? "&from=settings" : "";
     return NextResponse.redirect(
       `${origin}/?tab=home&calendarJustConnected=true${fromSettings}`
     );
   } catch (err) {
-    console.error("[calendar-callback] → FAILED. Error:", err);
+    console.error("[calendar-callback] token exchange failed:", err);
     return NextResponse.redirect(
       `${origin}/?calendarError=token_exchange_failed`
     );

--- a/src/app/api/calendar/disconnect/route.ts
+++ b/src/app/api/calendar/disconnect/route.ts
@@ -1,6 +1,7 @@
 // POST /api/calendar/disconnect — Removes the Google Calendar connection
-// Deletes the stored tokens and all pending calendar events
-// Does NOT delete activities that were already created from calendar events
+// Deletes the stored tokens, the calendar connection record, and pending
+// calendar events. Does NOT delete activities that were already created
+// from calendar events.
 
 import { NextResponse } from "next/server";
 import { getUser } from "@/lib/supabase/server";
@@ -15,27 +16,44 @@ export async function POST() {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    // Find the integration to delete
-    const integration = await prisma.userIntegration.findUnique({
-      where: { userId_service: { userId: user.id, service: "google_calendar" } },
-    });
+    // Find either half of the connection (UserIntegration or CalendarConnection).
+    // If neither exists, there's nothing to disconnect.
+    const [integration, calendarConnection] = await Promise.all([
+      prisma.userIntegration.findUnique({
+        where: { userId_service: { userId: user.id, service: "google_calendar" } },
+      }),
+      prisma.calendarConnection.findUnique({
+        where: { userId: user.id },
+      }),
+    ]);
 
-    if (!integration) {
+    if (!integration && !calendarConnection) {
       return NextResponse.json(
         { error: "No calendar connection found" },
         { status: 404 }
       );
     }
 
-    // Delete pending calendar events for this user and then the integration
-    // (CalendarEvent no longer cascades from the integration, so clean up manually)
+    // Delete pending calendar events, the CalendarConnection (which cascades
+    // any remaining CalendarEvent rows via onDelete: Cascade), and the
+    // UserIntegration — all in one transaction so partial failures leave
+    // nothing half-disconnected.
     await prisma.$transaction([
       prisma.calendarEvent.deleteMany({
         where: { userId: user.id, status: "pending" },
       }),
-      prisma.userIntegration.delete({
-        where: { userId_service: { userId: user.id, service: "google_calendar" } },
-      }),
+      ...(calendarConnection
+        ? [prisma.calendarConnection.delete({ where: { userId: user.id } })]
+        : []),
+      ...(integration
+        ? [
+            prisma.userIntegration.delete({
+              where: {
+                userId_service: { userId: user.id, service: "google_calendar" },
+              },
+            }),
+          ]
+        : []),
     ]);
 
     return NextResponse.json({ success: true });

--- a/src/app/api/calendar/disconnect/route.ts
+++ b/src/app/api/calendar/disconnect/route.ts
@@ -34,14 +34,25 @@ export async function POST() {
       );
     }
 
-    // Delete pending calendar events, the CalendarConnection (which cascades
-    // any remaining CalendarEvent rows via onDelete: Cascade), and the
-    // UserIntegration — all in one transaction so partial failures leave
-    // nothing half-disconnected.
+    // Preserve dismissed/confirmed CalendarEvent rows so the user's prior
+    // triage decisions survive a disconnect→reconnect cycle. The sync engine
+    // dedupes by (userId, googleEventId) and will skip any event the user
+    // already handled — but only if the row still exists. Detach them from
+    // the connection (set connection_id = NULL) so the CASCADE DELETE on
+    // CalendarConnection doesn't destroy them.
+    //
+    // Pending rows are throwaway — delete them outright.
     await prisma.$transaction([
+      // 1. Detach non-pending rows so they survive the cascade
+      prisma.calendarEvent.updateMany({
+        where: { userId: user.id, status: { not: "pending" } },
+        data: { connectionId: null },
+      }),
+      // 2. Delete pending rows (inbox clutter the user hasn't acted on)
       prisma.calendarEvent.deleteMany({
         where: { userId: user.id, status: "pending" },
       }),
+      // 3. Delete the connection (cascade now only hits rows still linked — none)
       ...(calendarConnection
         ? [prisma.calendarConnection.delete({ where: { userId: user.id } })]
         : []),

--- a/src/app/api/calendar/status/route.ts
+++ b/src/app/api/calendar/status/route.ts
@@ -34,6 +34,7 @@ export async function GET() {
         createdAt: true,
         backfillStartDate: true,
         backfillCompletedAt: true,
+        backfillWindowDays: true,
       },
     });
 
@@ -65,6 +66,7 @@ export async function GET() {
         createdAt: connection.createdAt.toISOString(),
         backfillStartDate: connection.backfillStartDate?.toISOString() || null,
         backfillCompletedAt: connection.backfillCompletedAt?.toISOString() || null,
+        backfillWindowDays: connection.backfillWindowDays,
       },
       pendingCount,
     });
@@ -171,6 +173,7 @@ export async function PATCH(request: Request) {
         createdAt: true,
         backfillStartDate: true,
         backfillCompletedAt: true,
+        backfillWindowDays: true,
       },
     });
 
@@ -181,6 +184,7 @@ export async function PATCH(request: Request) {
         createdAt: updated.createdAt.toISOString(),
         backfillStartDate: updated.backfillStartDate?.toISOString() || null,
         backfillCompletedAt: updated.backfillCompletedAt?.toISOString() || null,
+        backfillWindowDays: updated.backfillWindowDays,
       },
     });
   } catch (error) {

--- a/src/app/api/calendar/status/route.ts
+++ b/src/app/api/calendar/status/route.ts
@@ -32,6 +32,8 @@ export async function GET() {
         reminderMinutes: true,
         secondReminderMinutes: true,
         createdAt: true,
+        backfillStartDate: true,
+        backfillCompletedAt: true,
       },
     });
 
@@ -61,6 +63,8 @@ export async function GET() {
         reminderMinutes: connection.reminderMinutes,
         secondReminderMinutes: connection.secondReminderMinutes,
         createdAt: connection.createdAt.toISOString(),
+        backfillStartDate: connection.backfillStartDate?.toISOString() || null,
+        backfillCompletedAt: connection.backfillCompletedAt?.toISOString() || null,
       },
       pendingCount,
     });
@@ -165,6 +169,8 @@ export async function PATCH(request: Request) {
         reminderMinutes: true,
         secondReminderMinutes: true,
         createdAt: true,
+        backfillStartDate: true,
+        backfillCompletedAt: true,
       },
     });
 
@@ -172,6 +178,9 @@ export async function PATCH(request: Request) {
       connection: {
         ...updated,
         lastSyncAt: updated.lastSyncAt?.toISOString() || null,
+        createdAt: updated.createdAt.toISOString(),
+        backfillStartDate: updated.backfillStartDate?.toISOString() || null,
+        backfillCompletedAt: updated.backfillCompletedAt?.toISOString() || null,
       },
     });
   } catch (error) {

--- a/src/features/calendar/components/CalendarSyncToast.tsx
+++ b/src/features/calendar/components/CalendarSyncToast.tsx
@@ -1,0 +1,74 @@
+// CalendarSyncToast — Bottom-right non-blocking toast that surfaces new
+// calendar events after an incremental auto-sync. The parent (HomeView)
+// controls visibility; the toast handles its own auto-dismiss timer and
+// animates in from the bottom.
+
+"use client";
+
+import { useEffect } from "react";
+
+interface CalendarSyncToastProps {
+  visible: boolean;
+  newEventCount: number;
+  onDismiss: () => void;
+  onReview: () => void;
+}
+
+const AUTO_DISMISS_MS = 6000;
+
+export default function CalendarSyncToast({
+  visible,
+  newEventCount,
+  onDismiss,
+  onReview,
+}: CalendarSyncToastProps) {
+  // Auto-dismiss after 6 seconds. Restart the timer whenever visibility or
+  // count changes so re-triggering the toast resets the countdown.
+  useEffect(() => {
+    if (!visible) return;
+    const timer = setTimeout(onDismiss, AUTO_DISMISS_MS);
+    return () => clearTimeout(timer);
+  }, [visible, newEventCount, onDismiss]);
+
+  if (!visible) return null;
+
+  const headline =
+    newEventCount === 1 ? "1 new event from your calendar" : `${newEventCount} new events from your calendar`;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed bottom-6 right-6 z-40 bg-white rounded-xl border border-[#D4CFE2] shadow-xl p-4 max-w-sm flex items-start gap-3 animate-in slide-in-from-bottom-4 duration-300"
+      data-testid="calendar-sync-toast"
+    >
+      <div className="w-9 h-9 rounded-full bg-[#403770]/10 flex items-center justify-center flex-shrink-0 text-lg" aria-hidden="true">
+        📅
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-semibold text-[#403770]">{headline}</p>
+        <p className="mt-0.5 text-xs text-[#8A80A8]">
+          Log them now or review later.
+        </p>
+        <button
+          type="button"
+          onClick={onReview}
+          className="mt-2 inline-flex items-center gap-1 text-xs font-semibold text-[#F37167] hover:text-[#e0564c] transition-colors"
+        >
+          Review in inbox
+          <span aria-hidden="true">→</span>
+        </button>
+      </div>
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="Dismiss notification"
+        className="text-[#8A80A8] hover:text-[#403770] transition-colors flex-shrink-0"
+      >
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/src/features/calendar/components/ConnectionStatusCard.tsx
+++ b/src/features/calendar/components/ConnectionStatusCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { useDisconnectCalendar, useTriggerCalendarSync } from "@/features/calendar/lib/queries";
 import type { CalendarConnection } from "@/features/shared/types/api-types";
 
@@ -25,6 +26,10 @@ interface ConnectionStatusCardProps {
 export default function ConnectionStatusCard({ connection }: ConnectionStatusCardProps) {
   const disconnectMutation = useDisconnectCalendar();
   const syncMutation = useTriggerCalendarSync();
+  const router = useRouter();
+
+  const needsResume =
+    !!connection.backfillStartDate && !connection.backfillCompletedAt;
 
   return (
     <div className="bg-white rounded-xl border border-[#D4CFE2] p-5">
@@ -74,6 +79,16 @@ export default function ConnectionStatusCard({ connection }: ConnectionStatusCar
           {disconnectMutation.isPending ? "Disconnecting..." : "Disconnect"}
         </button>
       </div>
+
+      {needsResume && (
+        <button
+          type="button"
+          onClick={() => router.push("/?tab=home&resumeBackfill=true")}
+          className="mt-3 text-xs font-medium text-[#F37167] hover:text-[#e0564c] transition-colors"
+        >
+          Resume calendar setup →
+        </button>
+      )}
     </div>
   );
 }

--- a/src/features/calendar/components/__tests__/CalendarSyncToast.test.tsx
+++ b/src/features/calendar/components/__tests__/CalendarSyncToast.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CalendarSyncToast from "../CalendarSyncToast";
+
+describe("CalendarSyncToast", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders nothing when not visible", () => {
+    const { container } = render(
+      <CalendarSyncToast
+        visible={false}
+        newEventCount={3}
+        onDismiss={vi.fn()}
+        onReview={vi.fn()}
+      />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the headline with the correct count", () => {
+    render(
+      <CalendarSyncToast
+        visible={true}
+        newEventCount={3}
+        onDismiss={vi.fn()}
+        onReview={vi.fn()}
+      />
+    );
+    expect(screen.getByText("3 new events from your calendar")).toBeInTheDocument();
+  });
+
+  it("uses the singular form for exactly one event", () => {
+    render(
+      <CalendarSyncToast
+        visible={true}
+        newEventCount={1}
+        onDismiss={vi.fn()}
+        onReview={vi.fn()}
+      />
+    );
+    expect(screen.getByText("1 new event from your calendar")).toBeInTheDocument();
+  });
+
+  it("auto-dismisses after 6 seconds", () => {
+    const onDismiss = vi.fn();
+    render(
+      <CalendarSyncToast
+        visible={true}
+        newEventCount={2}
+        onDismiss={onDismiss}
+        onReview={vi.fn()}
+      />
+    );
+    expect(onDismiss).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(6000);
+    });
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("Review button calls onReview", async () => {
+    vi.useRealTimers();
+    const user = userEvent.setup();
+    const onReview = vi.fn();
+    render(
+      <CalendarSyncToast
+        visible={true}
+        newEventCount={1}
+        onDismiss={vi.fn()}
+        onReview={onReview}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: /review in inbox/i }));
+    expect(onReview).toHaveBeenCalledTimes(1);
+  });
+
+  it("X button calls onDismiss", async () => {
+    vi.useRealTimers();
+    const user = userEvent.setup();
+    const onDismiss = vi.fn();
+    render(
+      <CalendarSyncToast
+        visible={true}
+        newEventCount={1}
+        onDismiss={onDismiss}
+        onReview={vi.fn()}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: /dismiss notification/i }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/calendar/components/backfill/BackfillCompletionScreen.tsx
+++ b/src/features/calendar/components/backfill/BackfillCompletionScreen.tsx
@@ -1,0 +1,59 @@
+// BackfillCompletionScreen — the "you're all caught up" finale for the
+// backfill wizard. Shows a big celebration emoji, summary counts, and a
+// CTA button. Auto-closes after 3 seconds via onClose.
+
+"use client";
+
+import { useEffect } from "react";
+
+interface BackfillCompletionScreenProps {
+  confirmed: number;
+  dismissed: number;
+  skipped: number;
+  onClose: () => void;
+}
+
+export default function BackfillCompletionScreen({
+  confirmed,
+  dismissed,
+  skipped,
+  onClose,
+}: BackfillCompletionScreenProps) {
+  // Auto-close after 3s so the user doesn't have to click anything on the
+  // happy path. Clicking the CTA closes immediately.
+  useEffect(() => {
+    const timer = setTimeout(onClose, 3000);
+    return () => clearTimeout(timer);
+  }, [onClose]);
+
+  const totalReviewed = confirmed + dismissed + skipped;
+
+  return (
+    <div
+      className="flex flex-col items-center justify-center px-8 py-12 text-center"
+      data-testid="backfill-completion-screen"
+    >
+      <div className="text-6xl mb-4" aria-hidden="true">
+        🎉
+      </div>
+      <h2 className="text-2xl font-semibold text-[#403770]">You&apos;re all caught up</h2>
+      <p className="mt-3 text-sm text-[#6E6390]">
+        {confirmed} {confirmed === 1 ? "activity" : "activities"} logged from{" "}
+        {totalReviewed} {totalReviewed === 1 ? "event" : "events"}
+      </p>
+      {(dismissed > 0 || skipped > 0) && (
+        <p className="mt-1 text-xs text-[#8A80A8]">
+          {dismissed} dismissed · {skipped} skipped for later
+        </p>
+      )}
+      <button
+        type="button"
+        onClick={onClose}
+        className="mt-8 inline-flex items-center gap-2 px-5 py-2 text-sm font-semibold text-white bg-[#F37167] rounded-lg hover:bg-[#e0564c] transition-colors"
+      >
+        Go to Activities
+        <span aria-hidden="true">→</span>
+      </button>
+    </div>
+  );
+}

--- a/src/features/calendar/components/backfill/BackfillCompletionScreen.tsx
+++ b/src/features/calendar/components/backfill/BackfillCompletionScreen.tsx
@@ -1,6 +1,7 @@
 // BackfillCompletionScreen — the "you're all caught up" finale for the
 // backfill wizard. Shows a big celebration emoji, summary counts, and a
-// CTA button. Auto-closes after 3 seconds via onClose.
+// CTA button that navigates the user to the Activities tab. Auto-forwards
+// to Activities after 3 seconds via onGoToActivities.
 
 "use client";
 
@@ -10,21 +11,26 @@ interface BackfillCompletionScreenProps {
   confirmed: number;
   dismissed: number;
   skipped: number;
-  onClose: () => void;
+  // Called when the user clicks the CTA or the auto-forward timer fires.
+  // Typically closes the modal and routes to ?tab=activities.
+  onGoToActivities: () => void;
+  // Still accepted for back-compat — not used directly by this component but
+  // the parent modal may want it for stray close paths.
+  onClose?: () => void;
 }
 
 export default function BackfillCompletionScreen({
   confirmed,
   dismissed,
   skipped,
-  onClose,
+  onGoToActivities,
 }: BackfillCompletionScreenProps) {
-  // Auto-close after 3s so the user doesn't have to click anything on the
-  // happy path. Clicking the CTA closes immediately.
+  // Auto-forward to Activities after 3s so the user doesn't have to click
+  // anything on the happy path. Clicking the CTA forwards immediately.
   useEffect(() => {
-    const timer = setTimeout(onClose, 3000);
+    const timer = setTimeout(onGoToActivities, 3000);
     return () => clearTimeout(timer);
-  }, [onClose]);
+  }, [onGoToActivities]);
 
   const totalReviewed = confirmed + dismissed + skipped;
 
@@ -48,7 +54,7 @@ export default function BackfillCompletionScreen({
       )}
       <button
         type="button"
-        onClick={onClose}
+        onClick={onGoToActivities}
         className="mt-8 inline-flex items-center gap-2 px-5 py-2 text-sm font-semibold text-white bg-[#F37167] rounded-lg hover:bg-[#e0564c] transition-colors"
       >
         Go to Activities

--- a/src/features/calendar/components/backfill/BackfillEventCard.tsx
+++ b/src/features/calendar/components/backfill/BackfillEventCard.tsx
@@ -1,11 +1,13 @@
 // BackfillEventCard — The rich inline-edit card used inside the backfill wizard.
-// Shows the event with a confidence banner, then editable Type / Plan / District /
-// Notes fields, and a read-only attendees list. Local state resets when a new
-// event id arrives from props.
+// Controlled component: the parent BackfillWizard owns the edit state so that
+// keyboard shortcuts (Y/Enter) can send the user's latest edits, not the raw
+// event suggestions. Shows the event with a confidence banner, editable Type /
+// Plan / District / Notes fields, a read-only attendees list, and an optional
+// inline error banner when a save attempt fails mid-wizard.
 
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { format } from "date-fns";
 import type { CalendarEvent } from "@/features/shared/types/api-types";
 import {
@@ -17,20 +19,41 @@ import {
 import { MultiSelect } from "@/features/shared/components/MultiSelect";
 import { useTerritoryPlans } from "@/features/plans/lib/queries";
 
-export interface BackfillConfirmOverrides {
-  activityType: ActivityType;
+// Edited, in-flight values for a single event card. The wizard holds this
+// state so keyboard shortcuts can read the user's latest edits.
+export interface BackfillCardValues {
   title: string;
+  activityType: ActivityType;
   planIds: string[];
   districtLeaids: string[];
-  notes: string | null;
+  notes: string;
+}
+
+// Back-compat alias for the old props name. Keep for external callers that
+// may still reference BackfillConfirmOverrides.
+export type BackfillConfirmOverrides = BackfillCardValues;
+
+// Derive the initial card values from a CalendarEvent's suggestions.
+export function initialValuesFromEvent(event: CalendarEvent): BackfillCardValues {
+  return {
+    title: event.title,
+    activityType:
+      (event.suggestedActivityType as ActivityType | null) ?? "program_check_in",
+    planIds: event.suggestedPlanId ? [event.suggestedPlanId] : [],
+    districtLeaids: event.suggestedDistrictId ? [event.suggestedDistrictId] : [],
+    notes: event.description ?? "",
+  };
 }
 
 interface BackfillEventCardProps {
   event: CalendarEvent;
-  onConfirm: (overrides: BackfillConfirmOverrides) => void;
+  values: BackfillCardValues;
+  onValuesChange: (next: BackfillCardValues) => void;
+  onConfirm: (overrides: BackfillCardValues) => void;
   onSkip: () => void;
   onDismiss: () => void;
   isSaving: boolean;
+  errorMessage?: string | null;
 }
 
 type ConfidenceVariant = "high" | "medium" | "low" | "none";
@@ -53,9 +76,11 @@ const CONFIDENCE_STYLES: Record<ConfidenceVariant, ConfidenceStyle> = {
     className: "bg-[#E8F1F5] text-[#4E7C94] border-[#8bb5cb]/30",
   },
   low: {
+    // Warning tokens from Documentation/UI Framework/tokens.md §Semantic Colors:
+    // bg #fffaf1, border #ffd98d, accent #FFCF70 (golden).
     label: "No match found",
     icon: "❔",
-    className: "bg-[#FFF8EC] text-[#8A6A00] border-[#E8C77A]/40",
+    className: "bg-[#fffaf1] text-[#8A6A00] border-[#ffd98d]",
   },
   none: { label: "", icon: "", className: "" },
 };
@@ -73,43 +98,21 @@ function formatTimeRange(event: CalendarEvent): { date: string; time: string; du
 
 export default function BackfillEventCard({
   event,
+  values,
+  onValuesChange,
   onConfirm,
   onSkip,
   onDismiss,
   isSaving,
+  errorMessage,
 }: BackfillEventCardProps) {
   const { data: plans } = useTerritoryPlans();
 
-  const initialType: ActivityType =
-    (event.suggestedActivityType as ActivityType | null) ?? "program_check_in";
-  const initialPlanIds = useMemo(
-    () => (event.suggestedPlanId ? [event.suggestedPlanId] : []),
-    [event.suggestedPlanId]
-  );
-  const initialDistrictLeaids = useMemo(
-    () => (event.suggestedDistrictId ? [event.suggestedDistrictId] : []),
-    [event.suggestedDistrictId]
-  );
-  const initialNotes = event.description ?? "";
+  const { title, activityType, planIds, districtLeaids, notes } = values;
 
-  // Local state — resets whenever a new event.id is passed in
-  const [title, setTitle] = useState(event.title);
-  const [activityType, setActivityType] = useState<ActivityType>(initialType);
-  const [planIds, setPlanIds] = useState<string[]>(initialPlanIds);
-  const [districtLeaids, setDistrictLeaids] = useState<string[]>(initialDistrictLeaids);
-  const [notes, setNotes] = useState<string>(initialNotes);
-
-  useEffect(() => {
-    setTitle(event.title);
-    setActivityType(
-      (event.suggestedActivityType as ActivityType | null) ?? "program_check_in"
-    );
-    setPlanIds(event.suggestedPlanId ? [event.suggestedPlanId] : []);
-    setDistrictLeaids(event.suggestedDistrictId ? [event.suggestedDistrictId] : []);
-    setNotes(event.description ?? "");
-    // We intentionally only reset when event.id changes, not on every render
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [event.id]);
+  const setField = <K extends keyof BackfillCardValues>(key: K, value: BackfillCardValues[K]) => {
+    onValuesChange({ ...values, [key]: value });
+  };
 
   // Build plan options from all active plans + guarantee the suggested plan is present
   const planOptions = useMemo(() => {
@@ -155,13 +158,7 @@ export default function BackfillEventCard({
 
   const handleSave = () => {
     if (isSaving) return;
-    onConfirm({
-      activityType,
-      title: title.trim() || event.title,
-      planIds,
-      districtLeaids,
-      notes: notes.trim() ? notes.trim() : null,
-    });
+    onConfirm(values);
   };
 
   const cardClasses = `
@@ -188,6 +185,17 @@ export default function BackfillEventCard({
       )}
 
       <div className="p-6 space-y-5">
+        {/* Inline error banner — shown when a save or dismiss attempt fails */}
+        {errorMessage && (
+          <div
+            role="alert"
+            data-testid="backfill-event-error"
+            className="px-3 py-2 rounded-lg bg-[#fef1f0] border border-[#f58d85] text-xs text-[#F37167]"
+          >
+            {errorMessage}
+          </div>
+        )}
+
         {/* Title */}
         <div>
           <label className="sr-only" htmlFor="backfill-title">
@@ -197,7 +205,7 @@ export default function BackfillEventCard({
             id="backfill-title"
             type="text"
             value={title}
-            onChange={(e) => setTitle(e.target.value)}
+            onChange={(e) => setField("title", e.target.value)}
             className="w-full text-xl font-semibold text-[#403770] bg-transparent focus:outline-none focus:ring-2 focus:ring-[#F37167] rounded px-1 -mx-1"
           />
           <div className="mt-1 flex items-center gap-2 text-xs text-[#8A80A8]">
@@ -222,7 +230,7 @@ export default function BackfillEventCard({
             <select
               id="backfill-type"
               value={activityType}
-              onChange={(e) => setActivityType(e.target.value as ActivityType)}
+              onChange={(e) => setField("activityType", e.target.value as ActivityType)}
               className="w-full bg-white border border-[#C2BBD4] rounded-lg px-3 py-2 text-sm text-[#403770] focus:ring-2 focus:ring-[#F37167] focus:border-[#F37167] focus:outline-none"
             >
               {typeOptions.map((opt) => (
@@ -242,7 +250,7 @@ export default function BackfillEventCard({
               label="Territory plan"
               options={planOptions}
               selected={planIds}
-              onChange={setPlanIds}
+              onChange={(next) => setField("planIds", next)}
               placeholder="Select plan..."
               countLabel="plans"
             />
@@ -262,7 +270,7 @@ export default function BackfillEventCard({
                 label="District"
                 options={districtOptions}
                 selected={districtLeaids}
-                onChange={setDistrictLeaids}
+                onChange={(next) => setField("districtLeaids", next)}
                 placeholder="Select district..."
                 countLabel="districts"
               />
@@ -316,7 +324,7 @@ export default function BackfillEventCard({
           <textarea
             id="backfill-notes"
             value={notes}
-            onChange={(e) => setNotes(e.target.value)}
+            onChange={(e) => setField("notes", e.target.value)}
             rows={3}
             placeholder="Anything to remember from this meeting?"
             className="w-full bg-white border border-[#C2BBD4] rounded-lg px-3 py-2 text-sm text-[#403770] focus:ring-2 focus:ring-[#F37167] focus:border-[#F37167] focus:outline-none resize-none"

--- a/src/features/calendar/components/backfill/BackfillEventCard.tsx
+++ b/src/features/calendar/components/backfill/BackfillEventCard.tsx
@@ -1,0 +1,388 @@
+// BackfillEventCard — The rich inline-edit card used inside the backfill wizard.
+// Shows the event with a confidence banner, then editable Type / Plan / District /
+// Notes fields, and a read-only attendees list. Local state resets when a new
+// event id arrives from props.
+
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { format } from "date-fns";
+import type { CalendarEvent } from "@/features/shared/types/api-types";
+import {
+  ACTIVITY_TYPE_LABELS,
+  ACTIVITY_TYPE_ICONS,
+  ALL_ACTIVITY_TYPES,
+  type ActivityType,
+} from "@/features/activities/types";
+import { MultiSelect } from "@/features/shared/components/MultiSelect";
+import { useTerritoryPlans } from "@/features/plans/lib/queries";
+
+export interface BackfillConfirmOverrides {
+  activityType: ActivityType;
+  title: string;
+  planIds: string[];
+  districtLeaids: string[];
+  notes: string | null;
+}
+
+interface BackfillEventCardProps {
+  event: CalendarEvent;
+  onConfirm: (overrides: BackfillConfirmOverrides) => void;
+  onSkip: () => void;
+  onDismiss: () => void;
+  isSaving: boolean;
+}
+
+type ConfidenceVariant = "high" | "medium" | "low" | "none";
+
+interface ConfidenceStyle {
+  label: string;
+  icon: string;
+  className: string;
+}
+
+const CONFIDENCE_STYLES: Record<ConfidenceVariant, ConfidenceStyle> = {
+  high: {
+    label: "Strong match",
+    icon: "✨",
+    className: "bg-[#EDFFE3] text-[#5C8A3F] border-[#8AA891]/30",
+  },
+  medium: {
+    label: "Possible match",
+    icon: "💡",
+    className: "bg-[#E8F1F5] text-[#4E7C94] border-[#8bb5cb]/30",
+  },
+  low: {
+    label: "No match found",
+    icon: "❔",
+    className: "bg-[#FFF8EC] text-[#8A6A00] border-[#E8C77A]/40",
+  },
+  none: { label: "", icon: "", className: "" },
+};
+
+function formatTimeRange(event: CalendarEvent): { date: string; time: string; duration: string } {
+  const start = new Date(event.startTime);
+  const end = new Date(event.endTime);
+  const date = format(start, "EEE, MMM d, yyyy");
+  const time = `${format(start, "h:mm a")} – ${format(end, "h:mm a")}`;
+  const minutes = Math.max(0, Math.round((end.getTime() - start.getTime()) / 60000));
+  const duration =
+    minutes >= 60 ? `${Math.round((minutes / 60) * 10) / 10}h` : `${minutes}m`;
+  return { date, time, duration };
+}
+
+export default function BackfillEventCard({
+  event,
+  onConfirm,
+  onSkip,
+  onDismiss,
+  isSaving,
+}: BackfillEventCardProps) {
+  const { data: plans } = useTerritoryPlans();
+
+  const initialType: ActivityType =
+    (event.suggestedActivityType as ActivityType | null) ?? "program_check_in";
+  const initialPlanIds = useMemo(
+    () => (event.suggestedPlanId ? [event.suggestedPlanId] : []),
+    [event.suggestedPlanId]
+  );
+  const initialDistrictLeaids = useMemo(
+    () => (event.suggestedDistrictId ? [event.suggestedDistrictId] : []),
+    [event.suggestedDistrictId]
+  );
+  const initialNotes = event.description ?? "";
+
+  // Local state — resets whenever a new event.id is passed in
+  const [title, setTitle] = useState(event.title);
+  const [activityType, setActivityType] = useState<ActivityType>(initialType);
+  const [planIds, setPlanIds] = useState<string[]>(initialPlanIds);
+  const [districtLeaids, setDistrictLeaids] = useState<string[]>(initialDistrictLeaids);
+  const [notes, setNotes] = useState<string>(initialNotes);
+
+  useEffect(() => {
+    setTitle(event.title);
+    setActivityType(
+      (event.suggestedActivityType as ActivityType | null) ?? "program_check_in"
+    );
+    setPlanIds(event.suggestedPlanId ? [event.suggestedPlanId] : []);
+    setDistrictLeaids(event.suggestedDistrictId ? [event.suggestedDistrictId] : []);
+    setNotes(event.description ?? "");
+    // We intentionally only reset when event.id changes, not on every render
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [event.id]);
+
+  // Build plan options from all active plans + guarantee the suggested plan is present
+  const planOptions = useMemo(() => {
+    const list = (plans ?? [])
+      .filter((p) => p.status === "planning" || p.status === "working")
+      .map((p) => ({ value: p.id, label: p.name }));
+    // If the suggested plan isn't in the list (e.g. archived), make sure it's still selectable
+    if (
+      event.suggestedPlanId &&
+      !list.some((opt) => opt.value === event.suggestedPlanId)
+    ) {
+      list.unshift({
+        value: event.suggestedPlanId,
+        label: event.suggestedPlanName ?? "Suggested plan",
+      });
+    }
+    return list;
+  }, [plans, event.suggestedPlanId, event.suggestedPlanName]);
+
+  // District options — just the suggested district when present. Users can clear
+  // the selection; editing to a different district happens via the full Edit &
+  // Confirm flow in the main inbox. This keeps the wizard focused on triage.
+  const districtOptions = useMemo(() => {
+    if (!event.suggestedDistrictId) return [];
+    const label = event.suggestedDistrictName
+      ? event.suggestedDistrictState
+        ? `${event.suggestedDistrictName} (${event.suggestedDistrictState})`
+        : event.suggestedDistrictName
+      : event.suggestedDistrictId;
+    return [{ value: event.suggestedDistrictId, label }];
+  }, [event.suggestedDistrictId, event.suggestedDistrictName, event.suggestedDistrictState]);
+
+  const typeOptions = useMemo(
+    () => ALL_ACTIVITY_TYPES.map((t) => ({ value: t, label: ACTIVITY_TYPE_LABELS[t] })),
+    []
+  );
+
+  const { date: dateText, time: timeText, duration } = formatTimeRange(event);
+
+  const confidence: ConfidenceVariant = event.matchConfidence as ConfidenceVariant;
+  const confidenceStyle = CONFIDENCE_STYLES[confidence] ?? CONFIDENCE_STYLES.none;
+  const showConfidence = confidence !== "none" && confidence !== undefined;
+
+  const handleSave = () => {
+    if (isSaving) return;
+    onConfirm({
+      activityType,
+      title: title.trim() || event.title,
+      planIds,
+      districtLeaids,
+      notes: notes.trim() ? notes.trim() : null,
+    });
+  };
+
+  const cardClasses = `
+    bg-white rounded-2xl border border-[#D4CFE2] overflow-hidden
+    ${isSaving ? "pointer-events-none opacity-70" : ""}
+  `;
+
+  return (
+    <div className={cardClasses} data-testid="backfill-event-card">
+      {/* Confidence banner */}
+      {showConfidence && (
+        <div
+          className={`flex items-center gap-2 px-5 py-2.5 text-xs font-medium border-b ${confidenceStyle.className}`}
+        >
+          <span aria-hidden="true">{confidenceStyle.icon}</span>
+          <span>{confidenceStyle.label}</span>
+          {event.suggestedDistrictName && (
+            <span className="text-[#6E6390]">
+              · {event.suggestedDistrictName}
+              {event.suggestedDistrictState && ` (${event.suggestedDistrictState})`}
+            </span>
+          )}
+        </div>
+      )}
+
+      <div className="p-6 space-y-5">
+        {/* Title */}
+        <div>
+          <label className="sr-only" htmlFor="backfill-title">
+            Meeting title
+          </label>
+          <input
+            id="backfill-title"
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            className="w-full text-xl font-semibold text-[#403770] bg-transparent focus:outline-none focus:ring-2 focus:ring-[#F37167] rounded px-1 -mx-1"
+          />
+          <div className="mt-1 flex items-center gap-2 text-xs text-[#8A80A8]">
+            <span aria-hidden="true">🗓</span>
+            <span>{dateText}</span>
+            <span aria-hidden="true">·</span>
+            <span>{timeText}</span>
+            <span aria-hidden="true">·</span>
+            <span>{duration}</span>
+          </div>
+        </div>
+
+        {/* Editable fields */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <label
+              htmlFor="backfill-type"
+              className="block text-xs font-medium text-[#544A78] uppercase tracking-wider mb-1"
+            >
+              Activity type
+            </label>
+            <select
+              id="backfill-type"
+              value={activityType}
+              onChange={(e) => setActivityType(e.target.value as ActivityType)}
+              className="w-full bg-white border border-[#C2BBD4] rounded-lg px-3 py-2 text-sm text-[#403770] focus:ring-2 focus:ring-[#F37167] focus:border-[#F37167] focus:outline-none"
+            >
+              {typeOptions.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {ACTIVITY_TYPE_ICONS[opt.value as ActivityType]} {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-[#544A78] uppercase tracking-wider mb-1">
+              Plan
+            </label>
+            <MultiSelect
+              id="backfill-plan"
+              label="Territory plan"
+              options={planOptions}
+              selected={planIds}
+              onChange={setPlanIds}
+              placeholder="Select plan..."
+              countLabel="plans"
+            />
+          </div>
+
+          <div className="sm:col-span-2">
+            <label className="block text-xs font-medium text-[#544A78] uppercase tracking-wider mb-1">
+              District
+            </label>
+            {districtOptions.length === 0 ? (
+              <div className="text-xs italic text-[#A69DC0] py-2">
+                No district match found — log this and edit from Activities if needed.
+              </div>
+            ) : (
+              <MultiSelect
+                id="backfill-district"
+                label="District"
+                options={districtOptions}
+                selected={districtLeaids}
+                onChange={setDistrictLeaids}
+                placeholder="Select district..."
+                countLabel="districts"
+              />
+            )}
+          </div>
+        </div>
+
+        {/* Attendees — read only */}
+        {event.attendees.length > 0 && (
+          <div>
+            <div className="text-xs font-medium text-[#544A78] uppercase tracking-wider mb-2">
+              Attendees ({event.attendees.length})
+            </div>
+            <ul className="space-y-1">
+              {event.attendees.map((attendee) => {
+                const matched = event.suggestedContacts.find(
+                  (c) => c.email?.toLowerCase() === attendee.email.toLowerCase()
+                );
+                const displayName = matched?.name ?? attendee.name ?? attendee.email;
+                const subtitle = matched?.title ?? attendee.email;
+                return (
+                  <li
+                    key={attendee.email}
+                    className="flex items-center gap-2 text-sm text-[#403770]"
+                  >
+                    <span
+                      className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${
+                        matched ? "bg-[#F37167]" : "bg-[#C2BBD4]"
+                      }`}
+                      aria-hidden="true"
+                    />
+                    <span className="font-medium">{displayName}</span>
+                    {subtitle && subtitle !== displayName && (
+                      <span className="text-xs text-[#8A80A8]">· {subtitle}</span>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        )}
+
+        {/* Notes */}
+        <div>
+          <label
+            htmlFor="backfill-notes"
+            className="block text-xs font-medium text-[#544A78] uppercase tracking-wider mb-1"
+          >
+            Notes
+          </label>
+          <textarea
+            id="backfill-notes"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            rows={3}
+            placeholder="Anything to remember from this meeting?"
+            className="w-full bg-white border border-[#C2BBD4] rounded-lg px-3 py-2 text-sm text-[#403770] focus:ring-2 focus:ring-[#F37167] focus:border-[#F37167] focus:outline-none resize-none"
+          />
+        </div>
+
+        {/* Action row */}
+        <div className="flex items-center gap-2 pt-2 border-t border-[#E2DEEC]">
+          <button
+            type="button"
+            onClick={onDismiss}
+            disabled={isSaving}
+            className="px-3 py-2 text-xs font-medium text-[#8A80A8] hover:text-[#403770] transition-colors disabled:opacity-50"
+          >
+            Dismiss
+          </button>
+          <button
+            type="button"
+            onClick={onSkip}
+            disabled={isSaving}
+            className="px-3 py-2 text-xs font-medium text-[#6E6390] hover:text-[#403770] transition-colors disabled:opacity-50"
+          >
+            Skip
+          </button>
+          <div className="flex-1" />
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={isSaving}
+            className="inline-flex items-center gap-2 px-4 py-2 text-sm font-semibold text-white bg-[#F37167] rounded-lg hover:bg-[#e0564c] transition-colors disabled:opacity-50"
+          >
+            {isSaving ? (
+              <>
+                <svg
+                  className="w-4 h-4 animate-spin"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                  data-testid="save-spinner"
+                >
+                  <circle
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    opacity="0.25"
+                  />
+                  <path
+                    d="M4 12a8 8 0 018-8"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                  />
+                </svg>
+                Saving...
+              </>
+            ) : (
+              <>
+                <span aria-hidden="true">★</span>
+                Save &amp; Next
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/calendar/components/backfill/BackfillSetupModal.tsx
+++ b/src/features/calendar/components/backfill/BackfillSetupModal.tsx
@@ -23,6 +23,10 @@ interface BackfillSetupModalProps {
   isOpen: boolean;
   onClose: () => void;
   initialStep?: "picker" | "wizard";
+  // Optional CTA from the completion screen. When provided, the "Go to
+  // Activities" button navigates the user to the Activities tab instead of
+  // merely closing the modal. Falls back to onClose when not supplied.
+  onGoToActivities?: () => void;
 }
 
 interface WizardCounts {
@@ -35,6 +39,7 @@ export default function BackfillSetupModal({
   isOpen,
   onClose,
   initialStep = "picker",
+  onGoToActivities,
 }: BackfillSetupModalProps) {
   const [step, setStep] = useState<Step>(initialStep === "wizard" ? "wizard" : "picker");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -250,6 +255,7 @@ export default function BackfillSetupModal({
             dismissed={counts.dismissed}
             skipped={counts.skipped}
             onClose={onClose}
+            onGoToActivities={onGoToActivities ?? onClose}
           />
         )}
 

--- a/src/features/calendar/components/backfill/BackfillSetupModal.tsx
+++ b/src/features/calendar/components/backfill/BackfillSetupModal.tsx
@@ -1,0 +1,322 @@
+// BackfillSetupModal — The full-screen modal that orchestrates the backfill
+// wizard. Owns step state (picker → loading → wizard → complete/empty/error)
+// and delegates to the sub-components. Mirrors the ActivityFormModal portal
+// pattern (fixed overlay, rounded-2xl body on md+, rounded-none full-screen
+// on mobile).
+
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCalendarInbox,
+  useCompleteBackfill,
+  useStartBackfill,
+  type BackfillDays,
+} from "@/features/calendar/lib/queries";
+import BackfillWindowPicker from "./BackfillWindowPicker";
+import BackfillWizard from "./BackfillWizard";
+import BackfillCompletionScreen from "./BackfillCompletionScreen";
+
+type Step = "picker" | "loading" | "wizard" | "empty" | "complete" | "error";
+
+interface BackfillSetupModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  initialStep?: "picker" | "wizard";
+}
+
+interface WizardCounts {
+  confirmed: number;
+  dismissed: number;
+  skipped: number;
+}
+
+export default function BackfillSetupModal({
+  isOpen,
+  onClose,
+  initialStep = "picker",
+}: BackfillSetupModalProps) {
+  const [step, setStep] = useState<Step>(initialStep === "wizard" ? "wizard" : "picker");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [counts, setCounts] = useState<WizardCounts>({
+    confirmed: 0,
+    dismissed: 0,
+    skipped: 0,
+  });
+
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  const startMutation = useStartBackfill();
+  const completeMutation = useCompleteBackfill();
+
+  // Only fetch the inbox when we're actively in the wizard step — avoids a
+  // wasted fetch during the picker step.
+  const { data: inboxData, isLoading: inboxLoading } = useCalendarInbox(
+    step === "wizard" ? "pending" : undefined
+  );
+
+  // Reset step and errors whenever the modal re-opens
+  useEffect(() => {
+    if (isOpen) {
+      setStep(initialStep === "wizard" ? "wizard" : "picker");
+      setErrorMessage(null);
+      setCounts({ confirmed: 0, dismissed: 0, skipped: 0 });
+    }
+  }, [isOpen, initialStep]);
+
+  // Body scroll lock while the modal is visible
+  useEffect(() => {
+    if (!isOpen) return;
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, [isOpen]);
+
+  // Escape key closes
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [isOpen, onClose]);
+
+  const handleStart = useCallback(
+    (days: BackfillDays) => {
+      setStep("loading");
+      setErrorMessage(null);
+      startMutation.mutate(days, {
+        onSuccess: (result) => {
+          if (!result || result.pendingCount === 0) {
+            setStep("empty");
+          } else {
+            setStep("wizard");
+          }
+        },
+        onError: (err) => {
+          setErrorMessage(err instanceof Error ? err.message : "Couldn't reach Google.");
+          setStep("error");
+        },
+      });
+    },
+    [startMutation]
+  );
+
+  const handleWizardComplete = useCallback(
+    (finalCounts: WizardCounts) => {
+      setCounts(finalCounts);
+      completeMutation.mutate(undefined, {
+        onSuccess: () => setStep("complete"),
+        onError: () => {
+          // Even if the API call fails, still show the completion screen so
+          // the user doesn't get stuck. The connection will eventually re-sync.
+          setStep("complete");
+        },
+      });
+    },
+    [completeMutation]
+  );
+
+  const handleRetry = useCallback(() => {
+    setStep("picker");
+    setErrorMessage(null);
+  }, []);
+
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) onClose();
+  };
+
+  if (!isOpen) return null;
+
+  const inboxEvents = inboxData?.events ?? [];
+  const isStarting = startMutation.isPending || step === "loading";
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-[#403770]/40 backdrop-blur-sm p-0 md:p-4"
+      onClick={handleBackdropClick}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="backfill-modal-title"
+      data-testid="backfill-setup-modal"
+    >
+      <div
+        ref={modalRef}
+        className="relative bg-white shadow-xl max-w-2xl w-full max-h-full md:max-h-[90vh] md:rounded-2xl rounded-none overflow-hidden flex flex-col"
+      >
+        {/* Close button — always available */}
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close"
+          className="absolute top-4 right-4 z-20 w-8 h-8 flex items-center justify-center rounded-lg text-[#8A80A8] hover:text-[#403770] hover:bg-[#F7F5FA] transition-colors"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+
+        <h2 id="backfill-modal-title" className="sr-only">
+          Google Calendar backfill
+        </h2>
+
+        {step === "picker" && (
+          <BackfillWindowPicker
+            onStart={handleStart}
+            onCancel={onClose}
+            isLoading={isStarting}
+          />
+        )}
+
+        {step === "loading" && (
+          <div className="flex flex-col items-center justify-center px-8 py-16 text-center">
+            <svg
+              className="w-10 h-10 animate-spin text-[#F37167]"
+              fill="none"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <circle
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="3"
+                opacity="0.25"
+              />
+              <path
+                d="M4 12a8 8 0 018-8"
+                stroke="currentColor"
+                strokeWidth="3"
+                strokeLinecap="round"
+              />
+            </svg>
+            <p className="mt-5 text-base font-medium text-[#403770]">
+              Pulling your calendar from Google...
+            </p>
+            <p className="mt-1 text-sm text-[#8A80A8]">This usually takes a few seconds.</p>
+          </div>
+        )}
+
+        {step === "wizard" && (
+          <>
+            {inboxLoading && inboxEvents.length === 0 ? (
+              <div className="flex flex-col items-center justify-center px-8 py-16 text-center">
+                <svg
+                  className="w-8 h-8 animate-spin text-[#F37167]"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <circle
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="3"
+                    opacity="0.25"
+                  />
+                  <path
+                    d="M4 12a8 8 0 018-8"
+                    stroke="currentColor"
+                    strokeWidth="3"
+                    strokeLinecap="round"
+                  />
+                </svg>
+                <p className="mt-4 text-sm text-[#6E6390]">Loading events...</p>
+              </div>
+            ) : inboxEvents.length === 0 ? (
+              <EmptyState onClose={onClose} />
+            ) : (
+              <BackfillWizard
+                events={inboxEvents}
+                onComplete={handleWizardComplete}
+                onClose={onClose}
+              />
+            )}
+          </>
+        )}
+
+        {step === "empty" && <EmptyState onClose={onClose} />}
+
+        {step === "complete" && (
+          <BackfillCompletionScreen
+            confirmed={counts.confirmed}
+            dismissed={counts.dismissed}
+            skipped={counts.skipped}
+            onClose={onClose}
+          />
+        )}
+
+        {step === "error" && (
+          <div className="flex flex-col items-center justify-center px-8 py-16 text-center">
+            <div className="w-12 h-12 rounded-full bg-[#F37167]/10 flex items-center justify-center mb-4">
+              <svg
+                className="w-6 h-6 text-[#F37167]"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 9v2m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+            </div>
+            <h3 className="text-lg font-semibold text-[#403770]">
+              Couldn&apos;t reach Google
+            </h3>
+            <p className="mt-2 text-sm text-[#6E6390] max-w-sm">
+              {errorMessage ?? "Something went wrong while syncing. Let's try that again."}
+            </p>
+            <div className="mt-6 flex items-center gap-3">
+              <button
+                type="button"
+                onClick={onClose}
+                className="px-4 py-2 text-sm font-medium text-[#6E6390] hover:text-[#403770] transition-colors"
+              >
+                Close
+              </button>
+              <button
+                type="button"
+                onClick={handleRetry}
+                className="inline-flex items-center gap-2 px-4 py-2 text-sm font-semibold text-white bg-[#F37167] rounded-lg hover:bg-[#e0564c] transition-colors"
+              >
+                Try again
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function EmptyState({ onClose }: { onClose: () => void }) {
+  return (
+    <div className="flex flex-col items-center justify-center px-8 py-16 text-center">
+      <div className="text-5xl mb-4" aria-hidden="true">
+        📅
+      </div>
+      <h3 className="text-lg font-semibold text-[#403770]">All caught up</h3>
+      <p className="mt-2 text-sm text-[#6E6390] max-w-sm">
+        We couldn&apos;t find any external meetings in that window. Come back
+        anytime from settings to sync more history.
+      </p>
+      <button
+        type="button"
+        onClick={onClose}
+        className="mt-6 inline-flex items-center gap-2 px-5 py-2 text-sm font-semibold text-white bg-[#F37167] rounded-lg hover:bg-[#e0564c] transition-colors"
+      >
+        Close
+      </button>
+    </div>
+  );
+}

--- a/src/features/calendar/components/backfill/BackfillSetupModal.tsx
+++ b/src/features/calendar/components/backfill/BackfillSetupModal.tsx
@@ -13,6 +13,7 @@ import {
   useStartBackfill,
   type BackfillDays,
 } from "@/features/calendar/lib/queries";
+import type { CalendarEvent } from "@/features/shared/types/api-types";
 import BackfillWindowPicker from "./BackfillWindowPicker";
 import BackfillWizard from "./BackfillWizard";
 import BackfillCompletionScreen from "./BackfillCompletionScreen";
@@ -60,12 +61,32 @@ export default function BackfillSetupModal({
     step === "wizard" ? "pending" : undefined
   );
 
+  // Snapshot the inbox events the first time they arrive in the wizard step.
+  // After that, we render the wizard against this stable list — mid-wizard
+  // query invalidations (from confirm/dismiss mutations) won't swap the view
+  // out from under the user. Cleared when the modal leaves the wizard step.
+  //
+  // Implemented as a setState-during-render latch so the capture happens on
+  // the same render that first sees non-empty inbox data (synchronous for
+  // tests and for the resume flow where inbox is already cached).
+  const [wizardEvents, setWizardEvents] = useState<CalendarEvent[]>([]);
+
+  const inboxEvents = inboxData?.events ?? [];
+
+  if (step === "wizard" && wizardEvents.length === 0 && inboxEvents.length > 0) {
+    setWizardEvents(inboxEvents);
+  }
+  if (step !== "wizard" && wizardEvents.length > 0) {
+    setWizardEvents([]);
+  }
+
   // Reset step and errors whenever the modal re-opens
   useEffect(() => {
     if (isOpen) {
       setStep(initialStep === "wizard" ? "wizard" : "picker");
       setErrorMessage(null);
       setCounts({ confirmed: 0, dismissed: 0, skipped: 0 });
+      setWizardEvents([]);
     }
   }, [isOpen, initialStep]);
 
@@ -138,7 +159,6 @@ export default function BackfillSetupModal({
 
   if (!isOpen) return null;
 
-  const inboxEvents = inboxData?.events ?? [];
   const isStarting = startMutation.isPending || step === "loading";
 
   return (
@@ -210,7 +230,16 @@ export default function BackfillSetupModal({
 
         {step === "wizard" && (
           <>
-            {inboxLoading && inboxEvents.length === 0 ? (
+            {wizardEvents.length > 0 ? (
+              // Once the wizard has events, it owns the view until step changes.
+              // Mid-wizard inbox refetches won't unmount this branch, so the
+              // wizard's internal state stays intact through the whole flow.
+              <BackfillWizard
+                events={wizardEvents}
+                onComplete={handleWizardComplete}
+                onClose={onClose}
+              />
+            ) : inboxLoading ? (
               <div className="flex flex-col items-center justify-center px-8 py-16 text-center">
                 <svg
                   className="w-8 h-8 animate-spin text-[#F37167]"
@@ -235,14 +264,8 @@ export default function BackfillSetupModal({
                 </svg>
                 <p className="mt-4 text-sm text-[#6E6390]">Loading events...</p>
               </div>
-            ) : inboxEvents.length === 0 ? (
-              <EmptyState onClose={onClose} />
             ) : (
-              <BackfillWizard
-                events={inboxEvents}
-                onComplete={handleWizardComplete}
-                onClose={onClose}
-              />
+              <EmptyState onClose={onClose} />
             )}
           </>
         )}

--- a/src/features/calendar/components/backfill/BackfillWindowPicker.tsx
+++ b/src/features/calendar/components/backfill/BackfillWindowPicker.tsx
@@ -1,0 +1,173 @@
+// BackfillWindowPicker — Step 1 of the backfill setup wizard.
+// Four preset cards (7 / 30 / 60 / 90 days) in a 2x2 grid. 30 is pre-selected
+// with a star badge. "Maybe later" cancels, "Start sync →" kicks off the
+// backfill mutation in the parent.
+
+"use client";
+
+import { useState, useRef, useEffect, KeyboardEvent } from "react";
+import type { BackfillDays } from "@/features/calendar/lib/queries";
+
+interface BackfillWindowPickerProps {
+  onStart: (days: BackfillDays) => void;
+  onCancel: () => void;
+  isLoading: boolean;
+}
+
+interface PresetCard {
+  days: BackfillDays;
+  label: string;
+  range: string;
+  subtitle: string;
+  isDefault: boolean;
+}
+
+const PRESETS: PresetCard[] = [
+  { days: 7,  label: "Last 7 days",  range: "~5-15 events",   subtitle: "Just this week",      isDefault: false },
+  { days: 30, label: "Last 30 days", range: "~20-40 events",  subtitle: "Monthly review",      isDefault: true  },
+  { days: 60, label: "Last 60 days", range: "~40-80 events",  subtitle: "Quarterly check-in",  isDefault: false },
+  { days: 90, label: "Last 90 days", range: "~60-120 events", subtitle: "Full fiscal quarter", isDefault: false },
+];
+
+export default function BackfillWindowPicker({
+  onStart,
+  onCancel,
+  isLoading,
+}: BackfillWindowPickerProps) {
+  const [selected, setSelected] = useState<BackfillDays | null>(30);
+  const buttonRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  // Focus the default card on mount
+  useEffect(() => {
+    const defaultIndex = PRESETS.findIndex((p) => p.isDefault);
+    if (defaultIndex >= 0) {
+      buttonRefs.current[defaultIndex]?.focus();
+    }
+  }, []);
+
+  const handleCardKeyDown = (e: KeyboardEvent<HTMLButtonElement>, index: number) => {
+    // 2x2 grid movement
+    let nextIndex = index;
+    if (e.key === "ArrowRight") nextIndex = index + 1;
+    else if (e.key === "ArrowLeft") nextIndex = index - 1;
+    else if (e.key === "ArrowDown") nextIndex = index + 2;
+    else if (e.key === "ArrowUp") nextIndex = index - 2;
+    else return;
+
+    if (nextIndex >= 0 && nextIndex < PRESETS.length) {
+      e.preventDefault();
+      buttonRefs.current[nextIndex]?.focus();
+    }
+  };
+
+  return (
+    <div className="p-8">
+      <div className="mb-6">
+        <h2 className="text-2xl font-semibold text-[#403770]">
+          Get your calendar caught up
+        </h2>
+        <p className="mt-2 text-sm text-[#6E6390]">
+          Choose how far back you want to sync events. We&apos;ll walk you
+          through each meeting so you can log it as an activity.
+        </p>
+      </div>
+
+      <div
+        role="radiogroup"
+        aria-label="Backfill window preset"
+        className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-8"
+      >
+        {PRESETS.map((preset, index) => {
+          const isSelected = selected === preset.days;
+          return (
+            <button
+              key={preset.days}
+              ref={(el) => {
+                buttonRefs.current[index] = el;
+              }}
+              type="button"
+              role="radio"
+              aria-checked={isSelected}
+              aria-label={`${preset.label} — ${preset.subtitle}`}
+              onClick={() => setSelected(preset.days)}
+              onKeyDown={(e) => handleCardKeyDown(e, index)}
+              className={`
+                relative text-left p-5 rounded-lg transition-colors
+                focus:outline-none focus:ring-2 focus:ring-[#F37167] focus:ring-offset-2
+                ${
+                  isSelected
+                    ? "bg-[#F7F5FA] border-2 border-[#403770] ring-2 ring-[#403770]/10"
+                    : "bg-white border border-[#D4CFE2] hover:border-[#403770]"
+                }
+              `}
+            >
+              {preset.isDefault && (
+                <span
+                  className="absolute top-2 right-2 inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full bg-[#F37167] text-white text-[10px] font-semibold"
+                  aria-label="Recommended"
+                >
+                  <span aria-hidden="true">★</span>
+                  <span>Recommended</span>
+                </span>
+              )}
+              <div className="text-base font-semibold text-[#403770]">
+                {preset.label}
+              </div>
+              <div className="mt-1 text-xs text-[#8A80A8]">{preset.range}</div>
+              <div className="mt-2 text-xs text-[#6E6390]">{preset.subtitle}</div>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex items-center gap-3 justify-end">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={isLoading}
+          className="px-4 py-2 text-sm font-medium text-[#6E6390] hover:text-[#403770] transition-colors disabled:opacity-50"
+        >
+          Maybe later
+        </button>
+        <button
+          type="button"
+          onClick={() => selected && onStart(selected)}
+          disabled={!selected || isLoading}
+          className="inline-flex items-center gap-2 px-5 py-2 text-sm font-semibold text-white bg-[#F37167] rounded-lg hover:bg-[#e0564c] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {isLoading ? (
+            <>
+              <svg
+                className="w-4 h-4 animate-spin"
+                fill="none"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <circle
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  opacity="0.25"
+                />
+                <path
+                  d="M4 12a8 8 0 018-8"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                />
+              </svg>
+              Starting sync...
+            </>
+          ) : (
+            <>
+              Start sync
+              <span aria-hidden="true">→</span>
+            </>
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/calendar/components/backfill/BackfillWindowPicker.tsx
+++ b/src/features/calendar/components/backfill/BackfillWindowPicker.tsx
@@ -17,16 +17,20 @@ interface BackfillWindowPickerProps {
 interface PresetCard {
   days: BackfillDays;
   label: string;
+  split: string;
   range: string;
   subtitle: string;
   isDefault: boolean;
 }
 
+// Each preset is SYMMETRIC around today: the wizard pulls the same number of
+// days before and after "now", so picking 30 means "past 30 days + next 30 days".
+// Event-count ranges are doubled from the historic past-only estimates.
 const PRESETS: PresetCard[] = [
-  { days: 7,  label: "Last 7 days",  range: "~5-15 events",   subtitle: "Just this week",      isDefault: false },
-  { days: 30, label: "Last 30 days", range: "~20-40 events",  subtitle: "Monthly review",      isDefault: true  },
-  { days: 60, label: "Last 60 days", range: "~40-80 events",  subtitle: "Quarterly check-in",  isDefault: false },
-  { days: 90, label: "Last 90 days", range: "~60-120 events", subtitle: "Full fiscal quarter", isDefault: false },
+  { days: 7,  label: "± 7 days",  split: "7 days back + 7 days forward",   range: "~10-30 events",   subtitle: "This week and next",    isDefault: false },
+  { days: 30, label: "± 30 days", split: "30 days back + 30 days forward", range: "~40-80 events",   subtitle: "Monthly view",          isDefault: true  },
+  { days: 60, label: "± 60 days", split: "60 days back + 60 days forward", range: "~80-160 events",  subtitle: "Two-month horizon",     isDefault: false },
+  { days: 90, label: "± 90 days", split: "90 days back + 90 days forward", range: "~120-240 events", subtitle: "Full fiscal quarter",   isDefault: false },
 ];
 
 export default function BackfillWindowPicker({
@@ -64,11 +68,13 @@ export default function BackfillWindowPicker({
     <div className="p-8">
       <div className="mb-6">
         <h2 className="text-2xl font-semibold text-[#403770]">
-          Get your calendar caught up
+          Sync your calendar
         </h2>
         <p className="mt-2 text-sm text-[#6E6390]">
-          Choose how far back you want to sync events. We&apos;ll walk you
-          through each meeting so you can log it as an activity.
+          Pick how much of your calendar to bring in. We&apos;ll pull the same
+          number of days{" "}
+          <span className="font-semibold text-[#403770]">before and after today</span>{" "}
+          so you can log past meetings and plan for upcoming ones in one pass.
         </p>
       </div>
 
@@ -88,7 +94,7 @@ export default function BackfillWindowPicker({
               type="button"
               role="radio"
               aria-checked={isSelected}
-              aria-label={`${preset.label} — ${preset.subtitle}`}
+              aria-label={`${preset.label} — ${preset.split}`}
               onClick={() => setSelected(preset.days)}
               onKeyDown={(e) => handleCardKeyDown(e, index)}
               className={`
@@ -113,8 +119,11 @@ export default function BackfillWindowPicker({
               <div className="text-base font-semibold text-[#403770]">
                 {preset.label}
               </div>
-              <div className="mt-1 text-xs text-[#8A80A8]">{preset.range}</div>
-              <div className="mt-2 text-xs text-[#6E6390]">{preset.subtitle}</div>
+              <div className="mt-1 text-xs font-medium text-[#544A78]">
+                {preset.split}
+              </div>
+              <div className="mt-2 text-xs text-[#8A80A8]">{preset.range}</div>
+              <div className="mt-1 text-xs text-[#6E6390]">{preset.subtitle}</div>
             </button>
           );
         })}

--- a/src/features/calendar/components/backfill/BackfillWizard.tsx
+++ b/src/features/calendar/components/backfill/BackfillWizard.tsx
@@ -1,0 +1,252 @@
+// BackfillWizard — Step 2 of the backfill setup. Cycles through pending
+// calendar events one at a time, calling the existing confirm/dismiss
+// mutations for each decision. Owns its own progress counters and
+// keyboard shortcuts (Y/Enter/S/X/Arrows/Esc). When the user blows past
+// the last event, calls onComplete.
+
+"use client";
+
+import { useEffect, useMemo, useState, useCallback } from "react";
+import type { CalendarEvent } from "@/features/shared/types/api-types";
+import {
+  useConfirmCalendarEvent,
+  useDismissCalendarEvent,
+} from "@/features/calendar/lib/queries";
+import BackfillEventCard, {
+  type BackfillConfirmOverrides,
+} from "./BackfillEventCard";
+
+interface BackfillWizardProps {
+  events: CalendarEvent[];
+  onComplete: (counts: { confirmed: number; skipped: number; dismissed: number }) => void;
+  onClose: () => void;
+}
+
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+  if (target.isContentEditable) return true;
+  return false;
+}
+
+export default function BackfillWizard({ events, onComplete, onClose }: BackfillWizardProps) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [confirmedIds, setConfirmedIds] = useState<Set<string>>(() => new Set());
+  const [skippedIds, setSkippedIds] = useState<Set<string>>(() => new Set());
+  const [dismissedIds, setDismissedIds] = useState<Set<string>>(() => new Set());
+
+  const confirmMutation = useConfirmCalendarEvent();
+  const dismissMutation = useDismissCalendarEvent();
+
+  const currentEvent: CalendarEvent | undefined = events[currentIndex];
+  const total = events.length;
+  const progressPct = total === 0 ? 0 : Math.min(100, Math.round((currentIndex / total) * 100));
+
+  const counts = useMemo(
+    () => ({
+      confirmed: confirmedIds.size,
+      skipped: skippedIds.size,
+      dismissed: dismissedIds.size,
+    }),
+    [confirmedIds, skippedIds, dismissedIds]
+  );
+
+  const advance = useCallback(() => {
+    setCurrentIndex((idx) => {
+      const next = idx + 1;
+      if (next >= total) {
+        // Defer onComplete until after the state update settles
+        queueMicrotask(() => onComplete(counts));
+        return idx;
+      }
+      return next;
+    });
+  }, [total, onComplete, counts]);
+
+  const handleConfirm = useCallback(
+    (overrides: BackfillConfirmOverrides) => {
+      if (!currentEvent) return;
+      const eventId = currentEvent.id;
+      confirmMutation.mutate(
+        {
+          eventId,
+          activityType: overrides.activityType,
+          title: overrides.title,
+          planIds: overrides.planIds,
+          districtLeaids: overrides.districtLeaids,
+          notes: overrides.notes ?? undefined,
+        },
+        {
+          onSuccess: () => {
+            setConfirmedIds((prev) => new Set(prev).add(eventId));
+            advance();
+          },
+        }
+      );
+    },
+    [currentEvent, confirmMutation, advance]
+  );
+
+  const handleDismiss = useCallback(() => {
+    if (!currentEvent) return;
+    const eventId = currentEvent.id;
+    dismissMutation.mutate(eventId, {
+      onSuccess: () => {
+        setDismissedIds((prev) => new Set(prev).add(eventId));
+        advance();
+      },
+    });
+  }, [currentEvent, dismissMutation, advance]);
+
+  const handleSkip = useCallback(() => {
+    if (!currentEvent) return;
+    setSkippedIds((prev) => new Set(prev).add(currentEvent.id));
+    advance();
+  }, [currentEvent, advance]);
+
+  const handlePrev = useCallback(() => {
+    setCurrentIndex((idx) => Math.max(0, idx - 1));
+  }, []);
+
+  const isSaving = confirmMutation.isPending || dismissMutation.isPending;
+
+  // Keyboard shortcuts — skipped when focus is inside a form input/textarea/select.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (isTypingTarget(e.target)) return;
+      // Don't swallow modifier-key combinations
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+      switch (e.key) {
+        case "Escape":
+          e.preventDefault();
+          onClose();
+          break;
+        case "ArrowLeft":
+          e.preventDefault();
+          handlePrev();
+          break;
+        case "ArrowRight":
+          e.preventDefault();
+          handleSkip();
+          break;
+        case "y":
+        case "Y":
+        case "Enter":
+          e.preventDefault();
+          // Fire confirm with the *current* card state. Since the card owns
+          // its edit state we can't reach into it, so keyboard confirm uses
+          // the suggestions directly. The user can still click Save & Next
+          // after editing to send edited values.
+          if (currentEvent) {
+            handleConfirm({
+              activityType:
+                (currentEvent.suggestedActivityType as BackfillConfirmOverrides["activityType"]) ??
+                "program_check_in",
+              title: currentEvent.title,
+              planIds: currentEvent.suggestedPlanId ? [currentEvent.suggestedPlanId] : [],
+              districtLeaids: currentEvent.suggestedDistrictId
+                ? [currentEvent.suggestedDistrictId]
+                : [],
+              notes: currentEvent.description ?? null,
+            });
+          }
+          break;
+        case "s":
+        case "S":
+          e.preventDefault();
+          handleSkip();
+          break;
+        case "x":
+        case "X":
+          e.preventDefault();
+          handleDismiss();
+          break;
+        default:
+          break;
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [currentEvent, handleConfirm, handleDismiss, handleSkip, handlePrev, onClose]);
+
+  if (total === 0 || !currentEvent) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col h-full" data-testid="backfill-wizard">
+      {/* Sticky header strip */}
+      <div className="sticky top-0 z-10 bg-white border-b border-[#E2DEEC] px-6 py-4">
+        <div className="flex items-center gap-3 mb-2">
+          <div className="flex-1">
+            <div className="text-sm font-semibold text-[#403770]">
+              Event {Math.min(currentIndex + 1, total)} of {total}
+              <span className="ml-2 text-[#8A80A8] font-normal">· {progressPct}%</span>
+            </div>
+            <div className="mt-0.5 text-xs text-[#6E6390]">
+              {counts.confirmed} confirmed · {counts.skipped} skipped · {counts.dismissed}{" "}
+              dismissed
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="w-8 h-8 flex items-center justify-center rounded-lg text-[#8A80A8] hover:text-[#403770] hover:bg-[#F7F5FA] transition-colors"
+            aria-label="Close wizard"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        <div className="h-1.5 rounded-full bg-[#EFEDF5] overflow-hidden">
+          <div
+            className="h-full bg-[#F37167] transition-all duration-300"
+            style={{ width: `${progressPct}%` }}
+            role="progressbar"
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={progressPct}
+            aria-label="Backfill progress"
+          />
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className="flex-1 overflow-y-auto px-6 py-5">
+        <BackfillEventCard
+          key={currentEvent.id}
+          event={currentEvent}
+          onConfirm={handleConfirm}
+          onSkip={handleSkip}
+          onDismiss={handleDismiss}
+          isSaving={isSaving}
+        />
+      </div>
+
+      {/* Footer actions */}
+      <div className="sticky bottom-0 bg-white border-t border-[#E2DEEC] px-6 py-3 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={handlePrev}
+          disabled={currentIndex === 0 || isSaving}
+          className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-[#6E6390] hover:text-[#403770] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          <span aria-hidden="true">‹</span> Prev
+        </button>
+        <div className="flex-1 text-center text-[11px] text-[#A69DC0]">
+          Y / Enter = confirm · S = skip · X = dismiss · ← → prev/next · Esc = close
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-xs font-medium text-[#6E6390] hover:text-[#403770] transition-colors"
+        >
+          Save &amp; finish later
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/calendar/components/backfill/BackfillWizard.tsx
+++ b/src/features/calendar/components/backfill/BackfillWizard.tsx
@@ -33,6 +33,13 @@ function isTypingTarget(target: EventTarget | null): boolean {
 }
 
 export default function BackfillWizard({ events, onComplete, onClose }: BackfillWizardProps) {
+  // Freeze the events array at mount time. The inbox query gets invalidated
+  // on every confirm/dismiss mutation, which shrinks the live `events` prop
+  // mid-wizard and causes currentIndex to go out of bounds (skipping events
+  // or rendering null). Work against a stable snapshot so the user can walk
+  // their whole list exactly once.
+  const [frozenEvents] = useState<CalendarEvent[]>(() => events);
+
   const [currentIndex, setCurrentIndex] = useState(0);
   const [confirmedIds, setConfirmedIds] = useState<Set<string>>(() => new Set());
   const [skippedIds, setSkippedIds] = useState<Set<string>>(() => new Set());
@@ -42,14 +49,14 @@ export default function BackfillWizard({ events, onComplete, onClose }: Backfill
   const confirmMutation = useConfirmCalendarEvent();
   const dismissMutation = useDismissCalendarEvent();
 
-  const currentEvent: CalendarEvent | undefined = events[currentIndex];
-  const total = events.length;
+  const currentEvent: CalendarEvent | undefined = frozenEvents[currentIndex];
+  const total = frozenEvents.length;
   const progressPct = total === 0 ? 0 : Math.min(100, Math.round((currentIndex / total) * 100));
 
   // Card edit state lives here so keyboard shortcuts (Y/Enter) can access the
   // user's latest edits before submitting. Controlled BackfillEventCard below.
   const [cardValues, setCardValues] = useState<BackfillCardValues>(() =>
-    events[0] ? initialValuesFromEvent(events[0]) : {
+    frozenEvents[0] ? initialValuesFromEvent(frozenEvents[0]) : {
       title: "",
       activityType: "program_check_in" as ActivityType,
       planIds: [],

--- a/src/features/calendar/components/backfill/BackfillWizard.tsx
+++ b/src/features/calendar/components/backfill/BackfillWizard.tsx
@@ -6,14 +6,16 @@
 
 "use client";
 
-import { useEffect, useMemo, useState, useCallback } from "react";
+import { useEffect, useState, useCallback } from "react";
 import type { CalendarEvent } from "@/features/shared/types/api-types";
+import type { ActivityType } from "@/features/activities/types";
 import {
   useConfirmCalendarEvent,
   useDismissCalendarEvent,
 } from "@/features/calendar/lib/queries";
 import BackfillEventCard, {
-  type BackfillConfirmOverrides,
+  type BackfillCardValues,
+  initialValuesFromEvent,
 } from "./BackfillEventCard";
 
 interface BackfillWizardProps {
@@ -35,6 +37,7 @@ export default function BackfillWizard({ events, onComplete, onClose }: Backfill
   const [confirmedIds, setConfirmedIds] = useState<Set<string>>(() => new Set());
   const [skippedIds, setSkippedIds] = useState<Set<string>>(() => new Set());
   const [dismissedIds, setDismissedIds] = useState<Set<string>>(() => new Set());
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const confirmMutation = useConfirmCalendarEvent();
   const dismissMutation = useDismissCalendarEvent();
@@ -43,67 +46,152 @@ export default function BackfillWizard({ events, onComplete, onClose }: Backfill
   const total = events.length;
   const progressPct = total === 0 ? 0 : Math.min(100, Math.round((currentIndex / total) * 100));
 
-  const counts = useMemo(
-    () => ({
-      confirmed: confirmedIds.size,
-      skipped: skippedIds.size,
-      dismissed: dismissedIds.size,
-    }),
-    [confirmedIds, skippedIds, dismissedIds]
+  // Card edit state lives here so keyboard shortcuts (Y/Enter) can access the
+  // user's latest edits before submitting. Controlled BackfillEventCard below.
+  const [cardValues, setCardValues] = useState<BackfillCardValues>(() =>
+    events[0] ? initialValuesFromEvent(events[0]) : {
+      title: "",
+      activityType: "program_check_in" as ActivityType,
+      planIds: [],
+      districtLeaids: [],
+      notes: "",
+    }
   );
 
+  // Reset card state (and clear inline errors) whenever the current event changes
+  useEffect(() => {
+    if (currentEvent) {
+      setCardValues(initialValuesFromEvent(currentEvent));
+    }
+    setErrorMessage(null);
+  }, [currentIndex, currentEvent]);
+
+  // Advance to the next event. Only call this when NOT on the last event —
+  // completion is handled by the individual setters below so the final counts
+  // reflect the *just-applied* state, not a stale memo.
   const advance = useCallback(() => {
-    setCurrentIndex((idx) => {
-      const next = idx + 1;
-      if (next >= total) {
-        // Defer onComplete until after the state update settles
-        queueMicrotask(() => onComplete(counts));
-        return idx;
-      }
-      return next;
-    });
-  }, [total, onComplete, counts]);
+    setCurrentIndex((idx) => Math.min(idx + 1, total - 1));
+  }, [total]);
+
+  const isLastEvent = currentIndex + 1 >= total;
 
   const handleConfirm = useCallback(
-    (overrides: BackfillConfirmOverrides) => {
+    (overrides: BackfillCardValues) => {
       if (!currentEvent) return;
       const eventId = currentEvent.id;
+      setErrorMessage(null);
       confirmMutation.mutate(
         {
           eventId,
           activityType: overrides.activityType,
-          title: overrides.title,
+          title: overrides.title.trim() || currentEvent.title,
           planIds: overrides.planIds,
           districtLeaids: overrides.districtLeaids,
-          notes: overrides.notes ?? undefined,
+          notes: overrides.notes.trim() ? overrides.notes.trim() : undefined,
         },
         {
           onSuccess: () => {
-            setConfirmedIds((prev) => new Set(prev).add(eventId));
-            advance();
+            setConfirmedIds((prev) => {
+              const next = new Set(prev).add(eventId);
+              if (isLastEvent) {
+                queueMicrotask(() =>
+                  onComplete({
+                    confirmed: next.size,
+                    skipped: skippedIds.size,
+                    dismissed: dismissedIds.size,
+                  })
+                );
+              }
+              return next;
+            });
+            if (!isLastEvent) advance();
+          },
+          onError: (err) => {
+            setErrorMessage(
+              err instanceof Error
+                ? err.message
+                : "We couldn't save this one. Try again?"
+            );
           },
         }
       );
     },
-    [currentEvent, confirmMutation, advance]
+    [
+      currentEvent,
+      confirmMutation,
+      advance,
+      isLastEvent,
+      onComplete,
+      skippedIds,
+      dismissedIds,
+    ]
   );
 
   const handleDismiss = useCallback(() => {
     if (!currentEvent) return;
     const eventId = currentEvent.id;
+    setErrorMessage(null);
     dismissMutation.mutate(eventId, {
       onSuccess: () => {
-        setDismissedIds((prev) => new Set(prev).add(eventId));
-        advance();
+        setDismissedIds((prev) => {
+          const next = new Set(prev).add(eventId);
+          if (isLastEvent) {
+            queueMicrotask(() =>
+              onComplete({
+                confirmed: confirmedIds.size,
+                skipped: skippedIds.size,
+                dismissed: next.size,
+              })
+            );
+          }
+          return next;
+        });
+        if (!isLastEvent) advance();
+      },
+      onError: (err) => {
+        setErrorMessage(
+          err instanceof Error
+            ? err.message
+            : "We couldn't dismiss this one. Try again?"
+        );
       },
     });
-  }, [currentEvent, dismissMutation, advance]);
+  }, [
+    currentEvent,
+    dismissMutation,
+    advance,
+    isLastEvent,
+    onComplete,
+    confirmedIds,
+    skippedIds,
+  ]);
 
   const handleSkip = useCallback(() => {
     if (!currentEvent) return;
-    setSkippedIds((prev) => new Set(prev).add(currentEvent.id));
-    advance();
-  }, [currentEvent, advance]);
+    const eventId = currentEvent.id;
+    setErrorMessage(null);
+    setSkippedIds((prev) => {
+      const next = new Set(prev).add(eventId);
+      if (isLastEvent) {
+        queueMicrotask(() =>
+          onComplete({
+            confirmed: confirmedIds.size,
+            skipped: next.size,
+            dismissed: dismissedIds.size,
+          })
+        );
+      }
+      return next;
+    });
+    if (!isLastEvent) advance();
+  }, [
+    currentEvent,
+    advance,
+    isLastEvent,
+    onComplete,
+    confirmedIds,
+    dismissedIds,
+  ]);
 
   const handlePrev = useCallback(() => {
     setCurrentIndex((idx) => Math.max(0, idx - 1));
@@ -135,22 +223,10 @@ export default function BackfillWizard({ events, onComplete, onClose }: Backfill
         case "Y":
         case "Enter":
           e.preventDefault();
-          // Fire confirm with the *current* card state. Since the card owns
-          // its edit state we can't reach into it, so keyboard confirm uses
-          // the suggestions directly. The user can still click Save & Next
-          // after editing to send edited values.
+          // Confirm with the *current* edited card values (not the raw
+          // suggestions) so keyboard confirm respects user edits.
           if (currentEvent) {
-            handleConfirm({
-              activityType:
-                (currentEvent.suggestedActivityType as BackfillConfirmOverrides["activityType"]) ??
-                "program_check_in",
-              title: currentEvent.title,
-              planIds: currentEvent.suggestedPlanId ? [currentEvent.suggestedPlanId] : [],
-              districtLeaids: currentEvent.suggestedDistrictId
-                ? [currentEvent.suggestedDistrictId]
-                : [],
-              notes: currentEvent.description ?? null,
-            });
+            handleConfirm(cardValues);
           }
           break;
         case "s":
@@ -169,11 +245,17 @@ export default function BackfillWizard({ events, onComplete, onClose }: Backfill
     };
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
-  }, [currentEvent, handleConfirm, handleDismiss, handleSkip, handlePrev, onClose]);
+  }, [currentEvent, cardValues, handleConfirm, handleDismiss, handleSkip, handlePrev, onClose]);
 
   if (total === 0 || !currentEvent) {
     return null;
   }
+
+  const displayCounts = {
+    confirmed: confirmedIds.size,
+    skipped: skippedIds.size,
+    dismissed: dismissedIds.size,
+  };
 
   return (
     <div className="flex flex-col h-full" data-testid="backfill-wizard">
@@ -186,8 +268,8 @@ export default function BackfillWizard({ events, onComplete, onClose }: Backfill
               <span className="ml-2 text-[#8A80A8] font-normal">· {progressPct}%</span>
             </div>
             <div className="mt-0.5 text-xs text-[#6E6390]">
-              {counts.confirmed} confirmed · {counts.skipped} skipped · {counts.dismissed}{" "}
-              dismissed
+              {displayCounts.confirmed} confirmed · {displayCounts.skipped} skipped ·{" "}
+              {displayCounts.dismissed} dismissed
             </div>
           </div>
           <button
@@ -219,10 +301,13 @@ export default function BackfillWizard({ events, onComplete, onClose }: Backfill
         <BackfillEventCard
           key={currentEvent.id}
           event={currentEvent}
+          values={cardValues}
+          onValuesChange={setCardValues}
           onConfirm={handleConfirm}
           onSkip={handleSkip}
           onDismiss={handleDismiss}
           isSaving={isSaving}
+          errorMessage={errorMessage}
         />
       </div>
 

--- a/src/features/calendar/components/backfill/BackfillWizard.tsx
+++ b/src/features/calendar/components/backfill/BackfillWizard.tsx
@@ -279,16 +279,7 @@ export default function BackfillWizard({ events, onComplete, onClose }: Backfill
               {displayCounts.dismissed} dismissed
             </div>
           </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="w-8 h-8 flex items-center justify-center rounded-lg text-[#8A80A8] hover:text-[#403770] hover:bg-[#F7F5FA] transition-colors"
-            aria-label="Close wizard"
-          >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
+          {/* Close button lives in the parent BackfillSetupModal (absolute top-right). */}
         </div>
         <div className="h-1.5 rounded-full bg-[#EFEDF5] overflow-hidden">
           <div
@@ -328,8 +319,8 @@ export default function BackfillWizard({ events, onComplete, onClose }: Backfill
         >
           <span aria-hidden="true">‹</span> Prev
         </button>
-        <div className="flex-1 text-center text-[11px] text-[#A69DC0]">
-          Y / Enter = confirm · S = skip · X = dismiss · ← → prev/next · Esc = close
+        <div className="flex-1 text-center text-[10px] text-[#A69DC0] whitespace-nowrap">
+          Y confirm · S skip · X dismiss · ← → nav · Esc close
         </div>
         <button
           type="button"

--- a/src/features/calendar/components/backfill/__tests__/BackfillCompletionScreen.test.tsx
+++ b/src/features/calendar/components/backfill/__tests__/BackfillCompletionScreen.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import BackfillCompletionScreen from "../BackfillCompletionScreen";
+
+describe("BackfillCompletionScreen", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders the correct counts", () => {
+    render(
+      <BackfillCompletionScreen
+        confirmed={5}
+        dismissed={2}
+        skipped={1}
+        onClose={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/5 activities logged from 8 events/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 dismissed · 1 skipped/)).toBeInTheDocument();
+  });
+
+  it("pluralizes correctly for single activity + single event", () => {
+    render(
+      <BackfillCompletionScreen
+        confirmed={1}
+        dismissed={0}
+        skipped={0}
+        onClose={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/1 activity logged from 1 event/i)).toBeInTheDocument();
+  });
+
+  it("calls onClose when the CTA is clicked", async () => {
+    // Use real timers inside this test so userEvent works
+    vi.useRealTimers();
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(
+      <BackfillCompletionScreen confirmed={1} dismissed={0} skipped={0} onClose={onClose} />
+    );
+    await user.click(screen.getByRole("button", { name: /go to activities/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("auto-closes after 3 seconds", () => {
+    const onClose = vi.fn();
+    render(
+      <BackfillCompletionScreen confirmed={1} dismissed={0} skipped={0} onClose={onClose} />
+    );
+    expect(onClose).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the dismissed/skipped subtext when both are zero", () => {
+    render(
+      <BackfillCompletionScreen confirmed={3} dismissed={0} skipped={0} onClose={vi.fn()} />
+    );
+    expect(screen.queryByText(/dismissed/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/skipped/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/features/calendar/components/backfill/__tests__/BackfillCompletionScreen.test.tsx
+++ b/src/features/calendar/components/backfill/__tests__/BackfillCompletionScreen.test.tsx
@@ -18,7 +18,7 @@ describe("BackfillCompletionScreen", () => {
         confirmed={5}
         dismissed={2}
         skipped={1}
-        onClose={vi.fn()}
+        onGoToActivities={vi.fn()}
       />
     );
     expect(screen.getByText(/5 activities logged from 8 events/i)).toBeInTheDocument();
@@ -31,39 +31,54 @@ describe("BackfillCompletionScreen", () => {
         confirmed={1}
         dismissed={0}
         skipped={0}
-        onClose={vi.fn()}
+        onGoToActivities={vi.fn()}
       />
     );
     expect(screen.getByText(/1 activity logged from 1 event/i)).toBeInTheDocument();
   });
 
-  it("calls onClose when the CTA is clicked", async () => {
+  it("calls onGoToActivities when the CTA is clicked", async () => {
     // Use real timers inside this test so userEvent works
     vi.useRealTimers();
     const user = userEvent.setup();
-    const onClose = vi.fn();
+    const onGoToActivities = vi.fn();
     render(
-      <BackfillCompletionScreen confirmed={1} dismissed={0} skipped={0} onClose={onClose} />
+      <BackfillCompletionScreen
+        confirmed={1}
+        dismissed={0}
+        skipped={0}
+        onGoToActivities={onGoToActivities}
+      />
     );
     await user.click(screen.getByRole("button", { name: /go to activities/i }));
-    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onGoToActivities).toHaveBeenCalledTimes(1);
   });
 
-  it("auto-closes after 3 seconds", () => {
-    const onClose = vi.fn();
+  it("auto-forwards to Activities after 3 seconds", () => {
+    const onGoToActivities = vi.fn();
     render(
-      <BackfillCompletionScreen confirmed={1} dismissed={0} skipped={0} onClose={onClose} />
+      <BackfillCompletionScreen
+        confirmed={1}
+        dismissed={0}
+        skipped={0}
+        onGoToActivities={onGoToActivities}
+      />
     );
-    expect(onClose).not.toHaveBeenCalled();
+    expect(onGoToActivities).not.toHaveBeenCalled();
     act(() => {
       vi.advanceTimersByTime(3000);
     });
-    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onGoToActivities).toHaveBeenCalledTimes(1);
   });
 
   it("hides the dismissed/skipped subtext when both are zero", () => {
     render(
-      <BackfillCompletionScreen confirmed={3} dismissed={0} skipped={0} onClose={vi.fn()} />
+      <BackfillCompletionScreen
+        confirmed={3}
+        dismissed={0}
+        skipped={0}
+        onGoToActivities={vi.fn()}
+      />
     );
     expect(screen.queryByText(/dismissed/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/skipped/i)).not.toBeInTheDocument();

--- a/src/features/calendar/components/backfill/__tests__/BackfillEventCard.test.tsx
+++ b/src/features/calendar/components/backfill/__tests__/BackfillEventCard.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useState } from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { CalendarEvent } from "@/features/shared/types/api-types";
@@ -14,7 +15,10 @@ vi.mock("@/features/plans/lib/queries", () => ({
   }),
 }));
 
-import BackfillEventCard from "../BackfillEventCard";
+import BackfillEventCard, {
+  initialValuesFromEvent,
+  type BackfillCardValues,
+} from "../BackfillEventCard";
 
 function makeEvent(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
   return {
@@ -48,6 +52,44 @@ function makeEvent(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
   };
 }
 
+// Tiny controlled wrapper — mimics how BackfillWizard owns card state so the
+// card can stay focused on rendering + edit dispatch.
+interface HarnessProps {
+  event: CalendarEvent;
+  onConfirm?: (values: BackfillCardValues) => void;
+  onSkip?: () => void;
+  onDismiss?: () => void;
+  isSaving?: boolean;
+  errorMessage?: string | null;
+  initialValues?: BackfillCardValues;
+}
+
+function Harness({
+  event,
+  onConfirm = vi.fn(),
+  onSkip = vi.fn(),
+  onDismiss = vi.fn(),
+  isSaving = false,
+  errorMessage = null,
+  initialValues,
+}: HarnessProps) {
+  const [values, setValues] = useState<BackfillCardValues>(
+    initialValues ?? initialValuesFromEvent(event)
+  );
+  return (
+    <BackfillEventCard
+      event={event}
+      values={values}
+      onValuesChange={setValues}
+      onConfirm={onConfirm}
+      onSkip={onSkip}
+      onDismiss={onDismiss}
+      isSaving={isSaving}
+      errorMessage={errorMessage}
+    />
+  );
+}
+
 describe("BackfillEventCard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -55,15 +97,7 @@ describe("BackfillEventCard", () => {
 
   it("pre-fills title, type and notes from event suggestions", () => {
     const event = makeEvent();
-    render(
-      <BackfillEventCard
-        event={event}
-        onConfirm={vi.fn()}
-        onSkip={vi.fn()}
-        onDismiss={vi.fn()}
-        isSaving={false}
-      />
-    );
+    render(<Harness event={event} />);
 
     const titleInput = screen.getByLabelText<HTMLInputElement>(/meeting title/i);
     expect(titleInput.value).toBe("Quarterly review with Ada County");
@@ -76,28 +110,12 @@ describe("BackfillEventCard", () => {
   });
 
   it("shows the high-confidence banner", () => {
-    render(
-      <BackfillEventCard
-        event={makeEvent()}
-        onConfirm={vi.fn()}
-        onSkip={vi.fn()}
-        onDismiss={vi.fn()}
-        isSaving={false}
-      />
-    );
+    render(<Harness event={makeEvent()} />);
     expect(screen.getByText("Strong match")).toBeInTheDocument();
   });
 
   it("does not render a banner for confidence=none", () => {
-    render(
-      <BackfillEventCard
-        event={makeEvent({ matchConfidence: "none" })}
-        onConfirm={vi.fn()}
-        onSkip={vi.fn()}
-        onDismiss={vi.fn()}
-        isSaving={false}
-      />
-    );
+    render(<Harness event={makeEvent({ matchConfidence: "none" })} />);
     expect(screen.queryByText("Strong match")).not.toBeInTheDocument();
     expect(screen.queryByText("Possible match")).not.toBeInTheDocument();
   });
@@ -105,15 +123,7 @@ describe("BackfillEventCard", () => {
   it("updates local state without calling onConfirm while editing", async () => {
     const user = userEvent.setup();
     const onConfirm = vi.fn();
-    render(
-      <BackfillEventCard
-        event={makeEvent()}
-        onConfirm={onConfirm}
-        onSkip={vi.fn()}
-        onDismiss={vi.fn()}
-        isSaving={false}
-      />
-    );
+    render(<Harness event={makeEvent()} onConfirm={onConfirm} />);
 
     const notesInput = screen.getByLabelText(/notes/i);
     await user.clear(notesInput);
@@ -124,15 +134,7 @@ describe("BackfillEventCard", () => {
   it("calls onConfirm with edited values when Save & Next is clicked", async () => {
     const user = userEvent.setup();
     const onConfirm = vi.fn();
-    render(
-      <BackfillEventCard
-        event={makeEvent()}
-        onConfirm={onConfirm}
-        onSkip={vi.fn()}
-        onDismiss={vi.fn()}
-        isSaving={false}
-      />
-    );
+    render(<Harness event={makeEvent()} onConfirm={onConfirm} />);
 
     const notesInput = screen.getByLabelText(/notes/i);
     await user.clear(notesInput);
@@ -152,38 +154,25 @@ describe("BackfillEventCard", () => {
     );
   });
 
-  it("resets local state when a new event.id is passed in", () => {
-    const onConfirm = vi.fn();
-    const { rerender } = render(
-      <BackfillEventCard
-        event={makeEvent()}
-        onConfirm={onConfirm}
-        onSkip={vi.fn()}
-        onDismiss={vi.fn()}
-        isSaving={false}
-      />
-    );
+  it("re-derives values from a new event when the parent swaps the event prop", () => {
+    // The wizard re-initializes cardValues when currentIndex changes, so when
+    // a new event arrives with new initialValues the displayed fields follow.
+    const { rerender } = render(<Harness event={makeEvent()} />);
     expect(
       screen.getByLabelText<HTMLInputElement>(/meeting title/i).value
     ).toBe("Quarterly review with Ada County");
 
-    rerender(
-      <BackfillEventCard
-        event={makeEvent({
-          id: "evt-2",
-          title: "Onboarding call with Boise ISD",
-          description: "Kickoff",
-          suggestedPlanId: null,
-          suggestedDistrictId: null,
-          suggestedDistrictName: null,
-          suggestedDistrictState: null,
-        })}
-        onConfirm={onConfirm}
-        onSkip={vi.fn()}
-        onDismiss={vi.fn()}
-        isSaving={false}
-      />
-    );
+    const nextEvent = makeEvent({
+      id: "evt-2",
+      title: "Onboarding call with Boise ISD",
+      description: "Kickoff",
+      suggestedPlanId: null,
+      suggestedDistrictId: null,
+      suggestedDistrictName: null,
+      suggestedDistrictState: null,
+    });
+    // Re-mount the harness with a new key so it re-runs useState(() => initial)
+    rerender(<Harness key="evt-2" event={nextEvent} />);
 
     expect(
       screen.getByLabelText<HTMLInputElement>(/meeting title/i).value
@@ -199,12 +188,11 @@ describe("BackfillEventCard", () => {
     const onSkip = vi.fn();
     const onDismiss = vi.fn();
     render(
-      <BackfillEventCard
+      <Harness
         event={makeEvent()}
         onConfirm={onConfirm}
         onSkip={onSkip}
         onDismiss={onDismiss}
-        isSaving={false}
       />
     );
 
@@ -217,15 +205,7 @@ describe("BackfillEventCard", () => {
   });
 
   it("disables buttons and shows spinner when isSaving is true", () => {
-    render(
-      <BackfillEventCard
-        event={makeEvent()}
-        onConfirm={vi.fn()}
-        onSkip={vi.fn()}
-        onDismiss={vi.fn()}
-        isSaving={true}
-      />
-    );
+    render(<Harness event={makeEvent()} isSaving={true} />);
     expect(screen.getByRole("button", { name: /saving/i })).toBeDisabled();
     expect(screen.getByRole("button", { name: /^skip$/i })).toBeDisabled();
     expect(screen.getByRole("button", { name: /^dismiss$/i })).toBeDisabled();
@@ -234,18 +214,26 @@ describe("BackfillEventCard", () => {
 
   it("renders 'No district match' fallback when there is no suggested district", () => {
     render(
-      <BackfillEventCard
+      <Harness
         event={makeEvent({
           suggestedDistrictId: null,
           suggestedDistrictName: null,
           suggestedDistrictState: null,
         })}
-        onConfirm={vi.fn()}
-        onSkip={vi.fn()}
-        onDismiss={vi.fn()}
-        isSaving={false}
       />
     );
     expect(screen.getByText(/no district match/i)).toBeInTheDocument();
+  });
+
+  it("renders an inline error banner when errorMessage is provided", () => {
+    render(
+      <Harness
+        event={makeEvent()}
+        errorMessage="We couldn't save this one. Try again?"
+      />
+    );
+    const banner = screen.getByTestId("backfill-event-error");
+    expect(banner).toBeInTheDocument();
+    expect(banner).toHaveTextContent(/couldn't save this one/i);
   });
 });

--- a/src/features/calendar/components/backfill/__tests__/BackfillEventCard.test.tsx
+++ b/src/features/calendar/components/backfill/__tests__/BackfillEventCard.test.tsx
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { CalendarEvent } from "@/features/shared/types/api-types";
+
+// Mock useTerritoryPlans to return a couple of plans so the MultiSelect has options.
+vi.mock("@/features/plans/lib/queries", () => ({
+  useTerritoryPlans: () => ({
+    data: [
+      { id: "plan-1", name: "NY Renewals", status: "working" },
+      { id: "plan-2", name: "CA Expansion", status: "planning" },
+      { id: "plan-3", name: "Old archived", status: "archived" },
+    ],
+  }),
+}));
+
+import BackfillEventCard from "../BackfillEventCard";
+
+function makeEvent(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+  return {
+    id: "evt-1",
+    googleEventId: "g-evt-1",
+    title: "Quarterly review with Ada County",
+    description: "Review Q4 numbers and talk renewal.",
+    startTime: "2026-03-15T15:00:00.000Z",
+    endTime: "2026-03-15T16:00:00.000Z",
+    location: null,
+    attendees: [
+      { email: "jane@adacounty.k12.id.us", name: "Jane Smith", responseStatus: "accepted" },
+      { email: "rep@fullmindlearning.com", name: "Rep", responseStatus: "accepted" },
+    ],
+    status: "pending",
+    suggestedActivityType: "program_check_in",
+    suggestedDistrictId: "1600001",
+    suggestedDistrictName: "Ada County SD",
+    suggestedDistrictState: "ID",
+    suggestedContactIds: [42],
+    suggestedContacts: [
+      { id: 42, name: "Jane Smith", title: "Superintendent", email: "jane@adacounty.k12.id.us" },
+    ],
+    suggestedPlanId: "plan-1",
+    suggestedPlanName: "NY Renewals",
+    suggestedPlanColor: "#403770",
+    matchConfidence: "high",
+    activityId: null,
+    lastSyncedAt: "2026-04-09T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("BackfillEventCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("pre-fills title, type and notes from event suggestions", () => {
+    const event = makeEvent();
+    render(
+      <BackfillEventCard
+        event={event}
+        onConfirm={vi.fn()}
+        onSkip={vi.fn()}
+        onDismiss={vi.fn()}
+        isSaving={false}
+      />
+    );
+
+    const titleInput = screen.getByLabelText<HTMLInputElement>(/meeting title/i);
+    expect(titleInput.value).toBe("Quarterly review with Ada County");
+
+    const typeSelect = screen.getByLabelText<HTMLSelectElement>(/activity type/i);
+    expect(typeSelect.value).toBe("program_check_in");
+
+    const notesInput = screen.getByLabelText<HTMLTextAreaElement>(/notes/i);
+    expect(notesInput.value).toBe("Review Q4 numbers and talk renewal.");
+  });
+
+  it("shows the high-confidence banner", () => {
+    render(
+      <BackfillEventCard
+        event={makeEvent()}
+        onConfirm={vi.fn()}
+        onSkip={vi.fn()}
+        onDismiss={vi.fn()}
+        isSaving={false}
+      />
+    );
+    expect(screen.getByText("Strong match")).toBeInTheDocument();
+  });
+
+  it("does not render a banner for confidence=none", () => {
+    render(
+      <BackfillEventCard
+        event={makeEvent({ matchConfidence: "none" })}
+        onConfirm={vi.fn()}
+        onSkip={vi.fn()}
+        onDismiss={vi.fn()}
+        isSaving={false}
+      />
+    );
+    expect(screen.queryByText("Strong match")).not.toBeInTheDocument();
+    expect(screen.queryByText("Possible match")).not.toBeInTheDocument();
+  });
+
+  it("updates local state without calling onConfirm while editing", async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+    render(
+      <BackfillEventCard
+        event={makeEvent()}
+        onConfirm={onConfirm}
+        onSkip={vi.fn()}
+        onDismiss={vi.fn()}
+        isSaving={false}
+      />
+    );
+
+    const notesInput = screen.getByLabelText(/notes/i);
+    await user.clear(notesInput);
+    await user.type(notesInput, "Very productive");
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("calls onConfirm with edited values when Save & Next is clicked", async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+    render(
+      <BackfillEventCard
+        event={makeEvent()}
+        onConfirm={onConfirm}
+        onSkip={vi.fn()}
+        onDismiss={vi.fn()}
+        isSaving={false}
+      />
+    );
+
+    const notesInput = screen.getByLabelText(/notes/i);
+    await user.clear(notesInput);
+    await user.type(notesInput, "Edited note");
+
+    await user.click(screen.getByRole("button", { name: /save & next/i }));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        activityType: "program_check_in",
+        title: "Quarterly review with Ada County",
+        planIds: ["plan-1"],
+        districtLeaids: ["1600001"],
+        notes: "Edited note",
+      })
+    );
+  });
+
+  it("resets local state when a new event.id is passed in", () => {
+    const onConfirm = vi.fn();
+    const { rerender } = render(
+      <BackfillEventCard
+        event={makeEvent()}
+        onConfirm={onConfirm}
+        onSkip={vi.fn()}
+        onDismiss={vi.fn()}
+        isSaving={false}
+      />
+    );
+    expect(
+      screen.getByLabelText<HTMLInputElement>(/meeting title/i).value
+    ).toBe("Quarterly review with Ada County");
+
+    rerender(
+      <BackfillEventCard
+        event={makeEvent({
+          id: "evt-2",
+          title: "Onboarding call with Boise ISD",
+          description: "Kickoff",
+          suggestedPlanId: null,
+          suggestedDistrictId: null,
+          suggestedDistrictName: null,
+          suggestedDistrictState: null,
+        })}
+        onConfirm={onConfirm}
+        onSkip={vi.fn()}
+        onDismiss={vi.fn()}
+        isSaving={false}
+      />
+    );
+
+    expect(
+      screen.getByLabelText<HTMLInputElement>(/meeting title/i).value
+    ).toBe("Onboarding call with Boise ISD");
+    expect(screen.getByLabelText<HTMLTextAreaElement>(/notes/i).value).toBe(
+      "Kickoff"
+    );
+  });
+
+  it("Skip and Dismiss do not call onConfirm", async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+    const onSkip = vi.fn();
+    const onDismiss = vi.fn();
+    render(
+      <BackfillEventCard
+        event={makeEvent()}
+        onConfirm={onConfirm}
+        onSkip={onSkip}
+        onDismiss={onDismiss}
+        isSaving={false}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /^skip$/i }));
+    await user.click(screen.getByRole("button", { name: /^dismiss$/i }));
+
+    expect(onSkip).toHaveBeenCalledTimes(1);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("disables buttons and shows spinner when isSaving is true", () => {
+    render(
+      <BackfillEventCard
+        event={makeEvent()}
+        onConfirm={vi.fn()}
+        onSkip={vi.fn()}
+        onDismiss={vi.fn()}
+        isSaving={true}
+      />
+    );
+    expect(screen.getByRole("button", { name: /saving/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /^skip$/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /^dismiss$/i })).toBeDisabled();
+    expect(screen.getByTestId("save-spinner")).toBeInTheDocument();
+  });
+
+  it("renders 'No district match' fallback when there is no suggested district", () => {
+    render(
+      <BackfillEventCard
+        event={makeEvent({
+          suggestedDistrictId: null,
+          suggestedDistrictName: null,
+          suggestedDistrictState: null,
+        })}
+        onConfirm={vi.fn()}
+        onSkip={vi.fn()}
+        onDismiss={vi.fn()}
+        isSaving={false}
+      />
+    );
+    expect(screen.getByText(/no district match/i)).toBeInTheDocument();
+  });
+});

--- a/src/features/calendar/components/backfill/__tests__/BackfillSetupModal.test.tsx
+++ b/src/features/calendar/components/backfill/__tests__/BackfillSetupModal.test.tsx
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { CalendarEvent } from "@/features/shared/types/api-types";
+
+// Hoisted mocks shared across vi.mock factories
+const {
+  mockStartMutate,
+  mockCompleteMutate,
+  mockConfirmMutate,
+  mockDismissMutate,
+  mockUseCalendarInbox,
+} = vi.hoisted(() => ({
+  mockStartMutate: vi.fn(),
+  mockCompleteMutate: vi.fn(),
+  mockConfirmMutate: vi.fn(),
+  mockDismissMutate: vi.fn(),
+  mockUseCalendarInbox: vi.fn(),
+}));
+
+vi.mock("@/features/calendar/lib/queries", () => ({
+  useStartBackfill: () => ({
+    mutate: mockStartMutate,
+    isPending: false,
+  }),
+  useCompleteBackfill: () => ({
+    mutate: mockCompleteMutate,
+    isPending: false,
+  }),
+  useCalendarInbox: (status?: string) => mockUseCalendarInbox(status),
+  useConfirmCalendarEvent: () => ({
+    mutate: mockConfirmMutate,
+    isPending: false,
+  }),
+  useDismissCalendarEvent: () => ({
+    mutate: mockDismissMutate,
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/features/plans/lib/queries", () => ({
+  useTerritoryPlans: () => ({
+    data: [{ id: "plan-1", name: "NY Renewals", status: "working" }],
+  }),
+}));
+
+import BackfillSetupModal from "../BackfillSetupModal";
+
+function makeEvent(id: string, overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+  return {
+    id,
+    googleEventId: `g-${id}`,
+    title: `Meeting ${id}`,
+    description: null,
+    startTime: "2026-03-15T15:00:00.000Z",
+    endTime: "2026-03-15T16:00:00.000Z",
+    location: null,
+    attendees: [],
+    status: "pending",
+    suggestedActivityType: "program_check_in",
+    suggestedDistrictId: null,
+    suggestedDistrictName: null,
+    suggestedDistrictState: null,
+    suggestedContactIds: null,
+    suggestedContacts: [],
+    suggestedPlanId: null,
+    suggestedPlanName: null,
+    suggestedPlanColor: null,
+    matchConfidence: "none",
+    activityId: null,
+    lastSyncedAt: "2026-04-09T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("BackfillSetupModal", () => {
+  beforeEach(() => {
+    mockStartMutate.mockReset();
+    mockCompleteMutate.mockReset();
+    mockConfirmMutate.mockReset();
+    mockDismissMutate.mockReset();
+    mockUseCalendarInbox.mockReturnValue({
+      data: { events: [], total: 0, pendingCount: 0 },
+      isLoading: false,
+    });
+  });
+
+  it("does not render when isOpen is false", () => {
+    const { container } = render(
+      <BackfillSetupModal isOpen={false} onClose={vi.fn()} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the picker step by default", () => {
+    render(<BackfillSetupModal isOpen={true} onClose={vi.fn()} />);
+    expect(screen.getByText(/get your calendar caught up/i)).toBeInTheDocument();
+    expect(screen.getAllByRole("radio")).toHaveLength(4);
+  });
+
+  it("transitions picker → loading → wizard on a successful Start with events", async () => {
+    mockUseCalendarInbox.mockReturnValue({
+      data: {
+        events: [makeEvent("a"), makeEvent("b")],
+        total: 2,
+        pendingCount: 2,
+      },
+      isLoading: false,
+    });
+    mockStartMutate.mockImplementation((_days, opts) => {
+      opts?.onSuccess?.({
+        eventsProcessed: 2,
+        newEvents: 2,
+        updatedEvents: 0,
+        cancelledEvents: 0,
+        errors: [],
+        pendingCount: 2,
+      });
+    });
+
+    const user = userEvent.setup();
+    render(<BackfillSetupModal isOpen={true} onClose={vi.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: /start sync/i }));
+
+    await waitFor(() => expect(screen.getByTestId("backfill-wizard")).toBeInTheDocument());
+    expect(screen.getByText("Event 1 of 2")).toBeInTheDocument();
+  });
+
+  it("shows empty state when pendingCount is 0", async () => {
+    mockStartMutate.mockImplementation((_days, opts) => {
+      opts?.onSuccess?.({
+        eventsProcessed: 0,
+        newEvents: 0,
+        updatedEvents: 0,
+        cancelledEvents: 0,
+        errors: [],
+        pendingCount: 0,
+      });
+    });
+
+    const user = userEvent.setup();
+    render(<BackfillSetupModal isOpen={true} onClose={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: /start sync/i }));
+
+    await waitFor(() => expect(screen.getByText(/all caught up/i)).toBeInTheDocument());
+  });
+
+  it("shows error state when start mutation fails", async () => {
+    mockStartMutate.mockImplementation((_days, opts) => {
+      opts?.onError?.(new Error("Network down"));
+    });
+
+    const user = userEvent.setup();
+    render(<BackfillSetupModal isOpen={true} onClose={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: /start sync/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/couldn.t reach google/i)).toBeInTheDocument()
+    );
+    expect(screen.getByText("Network down")).toBeInTheDocument();
+  });
+
+  it("initialStep='wizard' skips the picker", () => {
+    mockUseCalendarInbox.mockReturnValue({
+      data: {
+        events: [makeEvent("a")],
+        total: 1,
+        pendingCount: 1,
+      },
+      isLoading: false,
+    });
+    render(
+      <BackfillSetupModal isOpen={true} onClose={vi.fn()} initialStep="wizard" />
+    );
+    expect(screen.queryByText(/get your calendar caught up/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId("backfill-wizard")).toBeInTheDocument();
+  });
+
+  it("close button fires onClose", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(<BackfillSetupModal isOpen={true} onClose={onClose} />);
+    await user.click(screen.getByRole("button", { name: /^close$/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("Escape key fires onClose", () => {
+    const onClose = vi.fn();
+    render(<BackfillSetupModal isOpen={true} onClose={onClose} />);
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("backdrop click closes the modal", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(<BackfillSetupModal isOpen={true} onClose={onClose} />);
+    await user.click(screen.getByTestId("backfill-setup-modal"));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/features/calendar/components/backfill/__tests__/BackfillSetupModal.test.tsx
+++ b/src/features/calendar/components/backfill/__tests__/BackfillSetupModal.test.tsx
@@ -94,7 +94,7 @@ describe("BackfillSetupModal", () => {
 
   it("renders the picker step by default", () => {
     render(<BackfillSetupModal isOpen={true} onClose={vi.fn()} />);
-    expect(screen.getByText(/get your calendar caught up/i)).toBeInTheDocument();
+    expect(screen.getByText(/sync your calendar/i)).toBeInTheDocument();
     expect(screen.getAllByRole("radio")).toHaveLength(4);
   });
 
@@ -173,7 +173,7 @@ describe("BackfillSetupModal", () => {
     render(
       <BackfillSetupModal isOpen={true} onClose={vi.fn()} initialStep="wizard" />
     );
-    expect(screen.queryByText(/get your calendar caught up/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/sync your calendar/i)).not.toBeInTheDocument();
     expect(screen.getByTestId("backfill-wizard")).toBeInTheDocument();
   });
 

--- a/src/features/calendar/components/backfill/__tests__/BackfillWindowPicker.test.tsx
+++ b/src/features/calendar/components/backfill/__tests__/BackfillWindowPicker.test.tsx
@@ -4,22 +4,28 @@ import userEvent from "@testing-library/user-event";
 import BackfillWindowPicker from "../BackfillWindowPicker";
 
 describe("BackfillWindowPicker", () => {
-  it("renders 4 preset cards", () => {
+  it("renders 4 preset cards with symmetric past+future labels", () => {
     render(
       <BackfillWindowPicker onStart={vi.fn()} onCancel={vi.fn()} isLoading={false} />
     );
     expect(screen.getAllByRole("radio")).toHaveLength(4);
-    expect(screen.getByText("Last 7 days")).toBeInTheDocument();
-    expect(screen.getByText("Last 30 days")).toBeInTheDocument();
-    expect(screen.getByText("Last 60 days")).toBeInTheDocument();
-    expect(screen.getByText("Last 90 days")).toBeInTheDocument();
+    expect(screen.getByText("± 7 days")).toBeInTheDocument();
+    expect(screen.getByText("± 30 days")).toBeInTheDocument();
+    expect(screen.getByText("± 60 days")).toBeInTheDocument();
+    expect(screen.getByText("± 90 days")).toBeInTheDocument();
+    // The "back + forward" split must appear on every card so users aren't
+    // surprised by future events in the wizard.
+    expect(screen.getByText("7 days back + 7 days forward")).toBeInTheDocument();
+    expect(screen.getByText("30 days back + 30 days forward")).toBeInTheDocument();
+    expect(screen.getByText("60 days back + 60 days forward")).toBeInTheDocument();
+    expect(screen.getByText("90 days back + 90 days forward")).toBeInTheDocument();
   });
 
   it("pre-selects the 30-day card with a Recommended badge", () => {
     render(
       <BackfillWindowPicker onStart={vi.fn()} onCancel={vi.fn()} isLoading={false} />
     );
-    const thirty = screen.getByRole("radio", { name: /last 30 days/i });
+    const thirty = screen.getByRole("radio", { name: /± 30 days/i });
     expect(thirty).toHaveAttribute("aria-checked", "true");
     expect(screen.getByText("Recommended")).toBeInTheDocument();
   });
@@ -29,10 +35,10 @@ describe("BackfillWindowPicker", () => {
     render(
       <BackfillWindowPicker onStart={vi.fn()} onCancel={vi.fn()} isLoading={false} />
     );
-    const ninety = screen.getByRole("radio", { name: /last 90 days/i });
+    const ninety = screen.getByRole("radio", { name: /± 90 days/i });
     await user.click(ninety);
     expect(ninety).toHaveAttribute("aria-checked", "true");
-    expect(screen.getByRole("radio", { name: /last 30 days/i })).toHaveAttribute(
+    expect(screen.getByRole("radio", { name: /± 30 days/i })).toHaveAttribute(
       "aria-checked",
       "false"
     );
@@ -44,7 +50,7 @@ describe("BackfillWindowPicker", () => {
     render(
       <BackfillWindowPicker onStart={onStart} onCancel={vi.fn()} isLoading={false} />
     );
-    await user.click(screen.getByRole("radio", { name: /last 60 days/i }));
+    await user.click(screen.getByRole("radio", { name: /± 60 days/i }));
     await user.click(screen.getByRole("button", { name: /start sync/i }));
     expect(onStart).toHaveBeenCalledWith(60);
   });

--- a/src/features/calendar/components/backfill/__tests__/BackfillWindowPicker.test.tsx
+++ b/src/features/calendar/components/backfill/__tests__/BackfillWindowPicker.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import BackfillWindowPicker from "../BackfillWindowPicker";
+
+describe("BackfillWindowPicker", () => {
+  it("renders 4 preset cards", () => {
+    render(
+      <BackfillWindowPicker onStart={vi.fn()} onCancel={vi.fn()} isLoading={false} />
+    );
+    expect(screen.getAllByRole("radio")).toHaveLength(4);
+    expect(screen.getByText("Last 7 days")).toBeInTheDocument();
+    expect(screen.getByText("Last 30 days")).toBeInTheDocument();
+    expect(screen.getByText("Last 60 days")).toBeInTheDocument();
+    expect(screen.getByText("Last 90 days")).toBeInTheDocument();
+  });
+
+  it("pre-selects the 30-day card with a Recommended badge", () => {
+    render(
+      <BackfillWindowPicker onStart={vi.fn()} onCancel={vi.fn()} isLoading={false} />
+    );
+    const thirty = screen.getByRole("radio", { name: /last 30 days/i });
+    expect(thirty).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByText("Recommended")).toBeInTheDocument();
+  });
+
+  it("moves selection when a different card is clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <BackfillWindowPicker onStart={vi.fn()} onCancel={vi.fn()} isLoading={false} />
+    );
+    const ninety = screen.getByRole("radio", { name: /last 90 days/i });
+    await user.click(ninety);
+    expect(ninety).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByRole("radio", { name: /last 30 days/i })).toHaveAttribute(
+      "aria-checked",
+      "false"
+    );
+  });
+
+  it("calls onStart with the selected days when Start sync is clicked", async () => {
+    const user = userEvent.setup();
+    const onStart = vi.fn();
+    render(
+      <BackfillWindowPicker onStart={onStart} onCancel={vi.fn()} isLoading={false} />
+    );
+    await user.click(screen.getByRole("radio", { name: /last 60 days/i }));
+    await user.click(screen.getByRole("button", { name: /start sync/i }));
+    expect(onStart).toHaveBeenCalledWith(60);
+  });
+
+  it("defaults to 30 days on Start sync when the user doesn't change selection", async () => {
+    const user = userEvent.setup();
+    const onStart = vi.fn();
+    render(
+      <BackfillWindowPicker onStart={onStart} onCancel={vi.fn()} isLoading={false} />
+    );
+    await user.click(screen.getByRole("button", { name: /start sync/i }));
+    expect(onStart).toHaveBeenCalledWith(30);
+  });
+
+  it("calls onCancel on Maybe later", async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+    render(
+      <BackfillWindowPicker onStart={vi.fn()} onCancel={onCancel} isLoading={false} />
+    );
+    await user.click(screen.getByRole("button", { name: /maybe later/i }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables Start sync while isLoading", () => {
+    render(
+      <BackfillWindowPicker onStart={vi.fn()} onCancel={vi.fn()} isLoading={true} />
+    );
+    expect(screen.getByRole("button", { name: /starting sync/i })).toBeDisabled();
+  });
+
+  it("uses the coral Start button class", () => {
+    render(
+      <BackfillWindowPicker onStart={vi.fn()} onCancel={vi.fn()} isLoading={false} />
+    );
+    const startBtn = screen.getByRole("button", { name: /start sync/i });
+    expect(startBtn.className).toMatch(/bg-\[#F37167\]/);
+  });
+});

--- a/src/features/calendar/components/backfill/__tests__/BackfillWizard.test.tsx
+++ b/src/features/calendar/components/backfill/__tests__/BackfillWizard.test.tsx
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { CalendarEvent } from "@/features/shared/types/api-types";
+
+// Hoisted mocks so we can reach them inside vi.mock factories.
+const { mockConfirm, mockDismiss } = vi.hoisted(() => ({
+  mockConfirm: vi.fn(),
+  mockDismiss: vi.fn(),
+}));
+
+vi.mock("@/features/calendar/lib/queries", () => ({
+  useConfirmCalendarEvent: () => ({
+    mutate: mockConfirm,
+    isPending: false,
+  }),
+  useDismissCalendarEvent: () => ({
+    mutate: mockDismiss,
+    isPending: false,
+  }),
+}));
+
+// Stub useTerritoryPlans transitively used by BackfillEventCard
+vi.mock("@/features/plans/lib/queries", () => ({
+  useTerritoryPlans: () => ({
+    data: [{ id: "plan-1", name: "NY Renewals", status: "working" }],
+  }),
+}));
+
+import BackfillWizard from "../BackfillWizard";
+
+function makeEvent(id: string, overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+  return {
+    id,
+    googleEventId: `g-${id}`,
+    title: `Meeting ${id}`,
+    description: "description",
+    startTime: "2026-03-15T15:00:00.000Z",
+    endTime: "2026-03-15T16:00:00.000Z",
+    location: null,
+    attendees: [],
+    status: "pending",
+    suggestedActivityType: "program_check_in",
+    suggestedDistrictId: null,
+    suggestedDistrictName: null,
+    suggestedDistrictState: null,
+    suggestedContactIds: null,
+    suggestedContacts: [],
+    suggestedPlanId: "plan-1",
+    suggestedPlanName: "NY Renewals",
+    suggestedPlanColor: "#403770",
+    matchConfidence: "medium",
+    activityId: null,
+    lastSyncedAt: "2026-04-09T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("BackfillWizard", () => {
+  beforeEach(() => {
+    mockConfirm.mockReset();
+    mockDismiss.mockReset();
+    // Default: both mutations succeed immediately
+    mockConfirm.mockImplementation((_vars, opts) => {
+      opts?.onSuccess?.();
+    });
+    mockDismiss.mockImplementation((_id, opts) => {
+      opts?.onSuccess?.();
+    });
+  });
+
+  it("renders the first event", () => {
+    render(
+      <BackfillWizard
+        events={[makeEvent("a"), makeEvent("b")]}
+        onComplete={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+    expect(screen.getByDisplayValue("Meeting a")).toBeInTheDocument();
+    expect(screen.getByText("Event 1 of 2")).toBeInTheDocument();
+  });
+
+  it("Prev button is disabled at index 0", () => {
+    render(
+      <BackfillWizard
+        events={[makeEvent("a"), makeEvent("b")]}
+        onComplete={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+    const prev = screen.getByRole("button", { name: /prev/i });
+    expect(prev).toBeDisabled();
+  });
+
+  it("Skip advances and updates the skipped counter", async () => {
+    const user = userEvent.setup();
+    render(
+      <BackfillWizard
+        events={[makeEvent("a"), makeEvent("b"), makeEvent("c")]}
+        onComplete={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: /^skip$/i }));
+    expect(screen.getByText("Event 2 of 3")).toBeInTheDocument();
+    expect(screen.getByText(/1 skipped/)).toBeInTheDocument();
+  });
+
+  it("Dismiss calls the dismiss mutation and advances", async () => {
+    const user = userEvent.setup();
+    render(
+      <BackfillWizard
+        events={[makeEvent("a"), makeEvent("b")]}
+        onComplete={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: /^dismiss$/i }));
+    expect(mockDismiss).toHaveBeenCalledWith("a", expect.any(Object));
+    expect(screen.getByText("Event 2 of 2")).toBeInTheDocument();
+  });
+
+  it("Save & Next calls the confirm mutation with card values", async () => {
+    const user = userEvent.setup();
+    render(
+      <BackfillWizard
+        events={[makeEvent("a"), makeEvent("b")]}
+        onComplete={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: /save & next/i }));
+    expect(mockConfirm).toHaveBeenCalledTimes(1);
+    expect(mockConfirm.mock.calls[0][0]).toMatchObject({
+      eventId: "a",
+      activityType: "program_check_in",
+    });
+  });
+
+  it("onComplete fires after the last event", async () => {
+    const user = userEvent.setup();
+    const onComplete = vi.fn();
+    render(
+      <BackfillWizard events={[makeEvent("a")]} onComplete={onComplete} onClose={vi.fn()} />
+    );
+    await user.click(screen.getByRole("button", { name: /save & next/i }));
+    // onComplete is queued with queueMicrotask
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
+  });
+
+  it("keyboard: Y confirms", async () => {
+    render(
+      <BackfillWizard
+        events={[makeEvent("a"), makeEvent("b")]}
+        onComplete={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+    // Fire the Y key on the document body (not inside an input)
+    act(() => {
+      document.body.focus();
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "y", bubbles: true }));
+    });
+    await waitFor(() => expect(mockConfirm).toHaveBeenCalledTimes(1));
+  });
+
+  it("keyboard: S skips", async () => {
+    render(
+      <BackfillWizard
+        events={[makeEvent("a"), makeEvent("b")]}
+        onComplete={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "s", bubbles: true }));
+    });
+    await waitFor(() =>
+      expect(screen.getByText("Event 2 of 2")).toBeInTheDocument()
+    );
+  });
+
+  it("keyboard: X dismisses", async () => {
+    render(
+      <BackfillWizard
+        events={[makeEvent("a"), makeEvent("b")]}
+        onComplete={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "x", bubbles: true }));
+    });
+    await waitFor(() => expect(mockDismiss).toHaveBeenCalledWith("a", expect.any(Object)));
+  });
+
+  it("keyboard: ArrowLeft prev, ArrowRight next", async () => {
+    render(
+      <BackfillWizard
+        events={[makeEvent("a"), makeEvent("b"), makeEvent("c")]}
+        onComplete={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+    // Advance twice via Skip
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    });
+    await waitFor(() => expect(screen.getByText("Event 2 of 3")).toBeInTheDocument());
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }));
+    });
+    await waitFor(() => expect(screen.getByText("Event 1 of 3")).toBeInTheDocument());
+  });
+
+  it("keyboard: Escape closes", () => {
+    const onClose = vi.fn();
+    render(
+      <BackfillWizard events={[makeEvent("a")]} onComplete={vi.fn()} onClose={onClose} />
+    );
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("keyboard shortcuts are ignored when focus is inside the notes textarea", async () => {
+    const user = userEvent.setup();
+    render(
+      <BackfillWizard
+        events={[makeEvent("a"), makeEvent("b")]}
+        onComplete={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+
+    const notes = screen.getByLabelText(/notes/i) as HTMLTextAreaElement;
+    await user.click(notes);
+    expect(notes).toHaveFocus();
+
+    // With the textarea focused, typing "s" should NOT trigger Skip
+    await user.keyboard("s");
+
+    expect(screen.getByText("Event 1 of 2")).toBeInTheDocument();
+    expect(mockConfirm).not.toHaveBeenCalled();
+    expect(mockDismiss).not.toHaveBeenCalled();
+    // The "s" should end up in the textarea value
+    expect(notes.value).toMatch(/s$/);
+  });
+});

--- a/src/features/calendar/components/backfill/__tests__/BackfillWizard.test.tsx
+++ b/src/features/calendar/components/backfill/__tests__/BackfillWizard.test.tsx
@@ -138,15 +138,129 @@ describe("BackfillWizard", () => {
     });
   });
 
-  it("onComplete fires after the last event", async () => {
+  it("onComplete fires after the last event with the final counts", async () => {
+    const user = userEvent.setup();
+    const onComplete = vi.fn();
+    render(
+      <BackfillWizard
+        events={[makeEvent("a"), makeEvent("b"), makeEvent("c"), makeEvent("d")]}
+        onComplete={onComplete}
+        onClose={vi.fn()}
+      />
+    );
+
+    // Event a: confirm
+    await user.click(screen.getByRole("button", { name: /save & next/i }));
+    // Event b: confirm
+    await user.click(screen.getByRole("button", { name: /save & next/i }));
+    // Event c: skip
+    await user.click(screen.getByRole("button", { name: /^skip$/i }));
+    // Event d: dismiss (this is the last event, should trigger onComplete)
+    await user.click(screen.getByRole("button", { name: /^dismiss$/i }));
+
+    // onComplete is queued with queueMicrotask and should receive fresh counts
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
+    expect(onComplete).toHaveBeenCalledWith({
+      confirmed: 2,
+      skipped: 1,
+      dismissed: 1,
+    });
+  });
+
+  it("onComplete reports correct counts when the last event is a confirm", async () => {
     const user = userEvent.setup();
     const onComplete = vi.fn();
     render(
       <BackfillWizard events={[makeEvent("a")]} onComplete={onComplete} onClose={vi.fn()} />
     );
     await user.click(screen.getByRole("button", { name: /save & next/i }));
-    // onComplete is queued with queueMicrotask
     await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
+    expect(onComplete).toHaveBeenCalledWith({
+      confirmed: 1,
+      skipped: 0,
+      dismissed: 0,
+    });
+  });
+
+  it("does not advance and shows an inline error banner when confirm fails", async () => {
+    const user = userEvent.setup();
+    // Mock confirm to call onError instead of onSuccess
+    mockConfirm.mockImplementation((_vars, opts) => {
+      opts?.onError?.(new Error("Server exploded"));
+    });
+    render(
+      <BackfillWizard
+        events={[makeEvent("a"), makeEvent("b")]}
+        onComplete={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /save & next/i }));
+
+    // Wizard stays on event 1
+    expect(screen.getByText("Event 1 of 2")).toBeInTheDocument();
+    // Inline error banner appears with the server error
+    const banner = await screen.findByTestId("backfill-event-error");
+    expect(banner).toHaveTextContent(/server exploded/i);
+  });
+
+  it("does not advance and shows an inline error banner when dismiss fails", async () => {
+    const user = userEvent.setup();
+    mockDismiss.mockImplementation((_id, opts) => {
+      opts?.onError?.(new Error("Nope"));
+    });
+    render(
+      <BackfillWizard
+        events={[makeEvent("a"), makeEvent("b")]}
+        onComplete={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /^dismiss$/i }));
+
+    expect(screen.getByText("Event 1 of 2")).toBeInTheDocument();
+    const banner = await screen.findByTestId("backfill-event-error");
+    expect(banner).toHaveTextContent(/nope/i);
+  });
+
+  it("keyboard Y confirms with the user's edited values, not the event suggestions", async () => {
+    const user = userEvent.setup();
+    render(
+      <BackfillWizard
+        events={[makeEvent("a", { suggestedActivityType: "program_check_in" })]}
+        onComplete={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+
+    // User changes the activity type dropdown to "proposal_review"
+    const typeSelect = screen.getByLabelText<HTMLSelectElement>(/activity type/i);
+    await user.selectOptions(typeSelect, "proposal_review");
+    expect(typeSelect.value).toBe("proposal_review");
+
+    // User also edits the title
+    const titleInput = screen.getByLabelText<HTMLInputElement>(/meeting title/i);
+    await user.clear(titleInput);
+    await user.type(titleInput, "New edited title");
+
+    // User presses Y — dispatch on document since focus moves around inputs.
+    // The keyboard handler ignores events whose target is a form input, so we
+    // move focus away first before firing.
+    act(() => {
+      (document.activeElement as HTMLElement | null)?.blur?.();
+    });
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "y", bubbles: true }));
+    });
+
+    await waitFor(() => expect(mockConfirm).toHaveBeenCalledTimes(1));
+    expect(mockConfirm.mock.calls[0][0]).toMatchObject({
+      eventId: "a",
+      activityType: "proposal_review",
+      title: "New edited title",
+    });
   });
 
   it("keyboard: Y confirms", async () => {

--- a/src/features/calendar/lib/__tests__/queries.test.ts
+++ b/src/features/calendar/lib/__tests__/queries.test.ts
@@ -1,0 +1,368 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import type {
+  CalendarStatusResponse,
+  CalendarSyncResult,
+} from "@/features/shared/types/api-types";
+
+// ---------------------------------------------------------------------------
+// Mock the shared fetch helper. All four hooks funnel through fetchJson, so we
+// only need to intercept that one module.
+// ---------------------------------------------------------------------------
+vi.mock("@/features/shared/lib/api-client", () => ({
+  API_BASE: "/api",
+  fetchJson: vi.fn(),
+}));
+
+import { fetchJson } from "@/features/shared/lib/api-client";
+import {
+  useAutoSyncCalendarOnMount,
+  useBackfillStatus,
+  useStartBackfill,
+  useCompleteBackfill,
+} from "../queries";
+
+const mockedFetchJson = fetchJson as unknown as ReturnType<typeof vi.fn>;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeStatus(
+  overrides: Partial<CalendarStatusResponse["connection"]> = {},
+  opts: { connected?: boolean; pendingCount?: number } = {}
+): CalendarStatusResponse {
+  const base: CalendarStatusResponse["connection"] = {
+    id: "conn-1",
+    googleAccountEmail: "rep@fullmindlearning.com",
+    companyDomain: "fullmindlearning.com",
+    syncEnabled: true,
+    lastSyncAt: null,
+    status: "connected",
+    syncDirection: "one_way",
+    syncedActivityTypes: [],
+    reminderMinutes: 10,
+    secondReminderMinutes: null,
+    createdAt: new Date().toISOString(),
+    backfillStartDate: null,
+    backfillCompletedAt: null,
+  };
+  return {
+    connected: opts.connected ?? true,
+    connection: overrides ? { ...base, ...overrides } : base,
+    pendingCount: opts.pendingCount ?? 0,
+  };
+}
+
+function wrapper(client: QueryClient) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(
+      QueryClientProvider,
+      { client },
+      children as React.ReactElement
+    );
+  };
+}
+
+function makeClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// useBackfillStatus
+// ---------------------------------------------------------------------------
+
+describe("useBackfillStatus", () => {
+  beforeEach(() => {
+    mockedFetchJson.mockReset();
+  });
+
+  it("reports needsSetup when connected with no backfill dates", async () => {
+    mockedFetchJson.mockResolvedValue(makeStatus({}));
+    const client = makeClient();
+    const { result } = renderHook(() => useBackfillStatus(), { wrapper: wrapper(client) });
+
+    await waitFor(() => expect(result.current.connected).toBe(true));
+    expect(result.current.needsSetup).toBe(true);
+    expect(result.current.needsResume).toBe(false);
+    expect(result.current.backfillCompletedAt).toBeNull();
+  });
+
+  it("reports needsResume when backfillStartDate set but not completed", async () => {
+    mockedFetchJson.mockResolvedValue(
+      makeStatus({
+        backfillStartDate: "2026-04-01T00:00:00.000Z",
+        backfillCompletedAt: null,
+      })
+    );
+    const client = makeClient();
+    const { result } = renderHook(() => useBackfillStatus(), { wrapper: wrapper(client) });
+
+    await waitFor(() => expect(result.current.needsResume).toBe(true));
+    expect(result.current.needsSetup).toBe(false);
+  });
+
+  it("reports neither when backfill is complete", async () => {
+    mockedFetchJson.mockResolvedValue(
+      makeStatus({
+        backfillStartDate: "2026-04-01T00:00:00.000Z",
+        backfillCompletedAt: "2026-04-02T00:00:00.000Z",
+      })
+    );
+    const client = makeClient();
+    const { result } = renderHook(() => useBackfillStatus(), { wrapper: wrapper(client) });
+
+    await waitFor(() =>
+      expect(result.current.backfillCompletedAt).toBe("2026-04-02T00:00:00.000Z")
+    );
+    expect(result.current.needsSetup).toBe(false);
+    expect(result.current.needsResume).toBe(false);
+  });
+
+  it("reports not connected when connection is missing", async () => {
+    mockedFetchJson.mockResolvedValue({
+      connected: false,
+      connection: null,
+      pendingCount: 0,
+    });
+    const client = makeClient();
+    const { result } = renderHook(() => useBackfillStatus(), { wrapper: wrapper(client) });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.connected).toBe(false);
+    expect(result.current.needsSetup).toBe(false);
+    expect(result.current.needsResume).toBe(false);
+  });
+
+  it("exposes loading state from the underlying query", async () => {
+    // Never resolve — hook should remain loading
+    mockedFetchJson.mockImplementation(() => new Promise(() => {}));
+    const client = makeClient();
+    const { result } = renderHook(() => useBackfillStatus(), { wrapper: wrapper(client) });
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.connected).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useAutoSyncCalendarOnMount
+// ---------------------------------------------------------------------------
+
+describe("useAutoSyncCalendarOnMount", () => {
+  beforeEach(() => {
+    mockedFetchJson.mockReset();
+  });
+
+  it("skips sync when not connected", async () => {
+    mockedFetchJson.mockResolvedValue({
+      connected: false,
+      connection: null,
+      pendingCount: 0,
+    });
+    const client = makeClient();
+    const { result } = renderHook(() => useAutoSyncCalendarOnMount(), {
+      wrapper: wrapper(client),
+    });
+
+    // Wait for the status query to settle without triggering act warnings.
+    await waitFor(() => expect(result.current).toBeDefined());
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+    const syncCalls = mockedFetchJson.mock.calls.filter(([url]) =>
+      String(url).includes("/calendar/sync")
+    );
+    expect(syncCalls).toHaveLength(0);
+  });
+
+  it("skips sync when backfillCompletedAt is null", async () => {
+    mockedFetchJson.mockResolvedValue(
+      makeStatus({ backfillStartDate: "2026-04-01T00:00:00.000Z", backfillCompletedAt: null })
+    );
+    const client = makeClient();
+    const { result } = renderHook(() => useAutoSyncCalendarOnMount(), {
+      wrapper: wrapper(client),
+    });
+    await waitFor(() => expect(result.current).toBeDefined());
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+    const syncCalls = mockedFetchJson.mock.calls.filter(([url]) =>
+      String(url).includes("/calendar/sync")
+    );
+    expect(syncCalls).toHaveLength(0);
+  });
+
+  it("skips sync when syncEnabled is false", async () => {
+    mockedFetchJson.mockResolvedValue(
+      makeStatus({
+        syncEnabled: false,
+        backfillCompletedAt: "2026-04-02T00:00:00.000Z",
+      })
+    );
+    const client = makeClient();
+    const { result } = renderHook(() => useAutoSyncCalendarOnMount(), {
+      wrapper: wrapper(client),
+    });
+    await waitFor(() => expect(result.current).toBeDefined());
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+    const syncCalls = mockedFetchJson.mock.calls.filter(([url]) =>
+      String(url).includes("/calendar/sync")
+    );
+    expect(syncCalls).toHaveLength(0);
+  });
+
+  it("fires sync exactly once when connected and backfill complete, and calls onNewEvents", async () => {
+    const syncResult: CalendarSyncResult = {
+      eventsProcessed: 3,
+      newEvents: 2,
+      updatedEvents: 0,
+      cancelledEvents: 0,
+      errors: [],
+    };
+    mockedFetchJson.mockImplementation((url: string) => {
+      if (url.includes("/calendar/status")) {
+        return Promise.resolve(
+          makeStatus({ backfillCompletedAt: "2026-04-02T00:00:00.000Z" })
+        );
+      }
+      if (url.includes("/calendar/sync")) {
+        return Promise.resolve(syncResult);
+      }
+      return Promise.resolve({});
+    });
+
+    const client = makeClient();
+    const newEventsCb = vi.fn();
+
+    const { result, rerender } = renderHook(() => useAutoSyncCalendarOnMount(), {
+      wrapper: wrapper(client),
+    });
+
+    // Wire up the callback so the effect's onSuccess has a target
+    act(() => {
+      result.current.setOnNewEvents(newEventsCb);
+    });
+
+    await waitFor(() => {
+      const syncCalls = mockedFetchJson.mock.calls.filter(([url]) =>
+        String(url).includes("/calendar/sync")
+      );
+      expect(syncCalls).toHaveLength(1);
+    });
+
+    await waitFor(() => expect(newEventsCb).toHaveBeenCalledWith(2));
+
+    // Rerender should not fire another sync — ranRef guards it
+    rerender();
+    await new Promise((r) => setTimeout(r, 10));
+    const syncCalls = mockedFetchJson.mock.calls.filter(([url]) =>
+      String(url).includes("/calendar/sync")
+    );
+    expect(syncCalls).toHaveLength(1);
+  });
+
+  it("does not fire onNewEvents when newEvents === 0", async () => {
+    mockedFetchJson.mockImplementation((url: string) => {
+      if (url.includes("/calendar/status")) {
+        return Promise.resolve(
+          makeStatus({ backfillCompletedAt: "2026-04-02T00:00:00.000Z" })
+        );
+      }
+      if (url.includes("/calendar/sync")) {
+        return Promise.resolve({
+          eventsProcessed: 0,
+          newEvents: 0,
+          updatedEvents: 0,
+          cancelledEvents: 0,
+          errors: [],
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    const client = makeClient();
+    const newEventsCb = vi.fn();
+    const { result } = renderHook(() => useAutoSyncCalendarOnMount(), {
+      wrapper: wrapper(client),
+    });
+    act(() => {
+      result.current.setOnNewEvents(newEventsCb);
+    });
+
+    await waitFor(() => {
+      const syncCalls = mockedFetchJson.mock.calls.filter(([url]) =>
+        String(url).includes("/calendar/sync")
+      );
+      expect(syncCalls).toHaveLength(1);
+    });
+    expect(newEventsCb).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useStartBackfill + useCompleteBackfill
+// ---------------------------------------------------------------------------
+
+describe("useStartBackfill", () => {
+  beforeEach(() => {
+    mockedFetchJson.mockReset();
+  });
+
+  it("POSTs to /calendar/backfill/start with the selected days", async () => {
+    mockedFetchJson.mockResolvedValue({
+      eventsProcessed: 0,
+      newEvents: 0,
+      updatedEvents: 0,
+      cancelledEvents: 0,
+      errors: [],
+      pendingCount: 0,
+    });
+    const client = makeClient();
+    const { result } = renderHook(() => useStartBackfill(), { wrapper: wrapper(client) });
+
+    await act(async () => {
+      await result.current.mutateAsync(30);
+    });
+
+    expect(mockedFetchJson).toHaveBeenCalledWith(
+      "/api/calendar/backfill/start",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ days: 30 }),
+      })
+    );
+  });
+});
+
+describe("useCompleteBackfill", () => {
+  beforeEach(() => {
+    mockedFetchJson.mockReset();
+  });
+
+  it("POSTs to /calendar/backfill/complete", async () => {
+    mockedFetchJson.mockResolvedValue({ success: true });
+    const client = makeClient();
+    const { result } = renderHook(() => useCompleteBackfill(), {
+      wrapper: wrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+
+    expect(mockedFetchJson).toHaveBeenCalledWith(
+      "/api/calendar/backfill/complete",
+      expect.objectContaining({ method: "POST" })
+    );
+  });
+});

--- a/src/features/calendar/lib/__tests__/queries.test.ts
+++ b/src/features/calendar/lib/__tests__/queries.test.ts
@@ -48,6 +48,7 @@ function makeStatus(
     createdAt: new Date().toISOString(),
     backfillStartDate: null,
     backfillCompletedAt: null,
+    backfillWindowDays: null,
   };
   return {
     connected: opts.connected ?? true,

--- a/src/features/calendar/lib/__tests__/sync.test.ts
+++ b/src/features/calendar/lib/__tests__/sync.test.ts
@@ -99,6 +99,7 @@ function makeConnection(overrides: Record<string, unknown> = {}) {
     secondReminderMinutes: null,
     backfillStartDate: null as Date | null,
     backfillCompletedAt: null as Date | null,
+    backfillWindowDays: null as number | null,
     createdAt: new Date(),
     updatedAt: new Date(),
     ...overrides,
@@ -266,6 +267,45 @@ describe("syncCalendarEvents — window selection", () => {
     const [, timeMin] = vi.mocked(fetchCalendarEvents).mock.calls[0];
     const expected = new Date(NOW.getTime() - 7 * DAY_MS);
     expect(Math.abs(timeMin.getTime() - expected.getTime())).toBeLessThan(1000);
+  });
+
+  it("uses backfillWindowDays as the forward horizon (timeMax)", async () => {
+    primeValidSyncPath(
+      makeConnection({
+        backfillStartDate: new Date(NOW.getTime() - 30 * DAY_MS),
+        backfillCompletedAt: null,
+        backfillWindowDays: 30,
+        lastSyncAt: null,
+      }),
+      []
+    );
+    vi.mocked(prisma.activity.findMany).mockResolvedValue([] as never);
+
+    await syncCalendarEvents(USER_ID);
+
+    const [, , timeMax] = vi.mocked(fetchCalendarEvents).mock.calls[0];
+    // timeMax = now + backfillWindowDays (30), not the old hardcoded 14
+    const expected = new Date(NOW.getTime() + 30 * DAY_MS);
+    expect(Math.abs(timeMax.getTime() - expected.getTime())).toBeLessThan(1000);
+  });
+
+  it("falls back to 14-day forward window when backfillWindowDays is null", async () => {
+    primeValidSyncPath(
+      makeConnection({
+        backfillStartDate: null,
+        backfillCompletedAt: null,
+        backfillWindowDays: null,
+        lastSyncAt: null,
+      }),
+      []
+    );
+    vi.mocked(prisma.activity.findMany).mockResolvedValue([] as never);
+
+    await syncCalendarEvents(USER_ID);
+
+    const [, , timeMax] = vi.mocked(fetchCalendarEvents).mock.calls[0];
+    const expected = new Date(NOW.getTime() + 14 * DAY_MS);
+    expect(Math.abs(timeMax.getTime() - expected.getTime())).toBeLessThan(1000);
   });
 });
 

--- a/src/features/calendar/lib/__tests__/sync.test.ts
+++ b/src/features/calendar/lib/__tests__/sync.test.ts
@@ -1,0 +1,396 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock Prisma before any imports that reference it
+// ---------------------------------------------------------------------------
+vi.mock("@/lib/prisma", () => {
+  return {
+    default: {
+      userIntegration: {
+        findUnique: vi.fn(),
+        update: vi.fn(),
+      },
+      calendarConnection: {
+        findUnique: vi.fn(),
+        update: vi.fn(),
+      },
+      calendarEvent: {
+        findUnique: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+        findMany: vi.fn(),
+      },
+      activity: {
+        findMany: vi.fn(),
+      },
+      contact: {
+        findMany: vi.fn(),
+      },
+      territoryPlanDistrict: {
+        findFirst: vi.fn(),
+      },
+    },
+  };
+});
+
+// Mock the calendar Google helpers. We only care about the three functions
+// sync.ts actually calls from this module.
+vi.mock("@/features/calendar/lib/google", () => ({
+  fetchCalendarEvents: vi.fn(),
+  getValidAccessToken: vi.fn(),
+  filterExternalAttendees: vi.fn(),
+}));
+
+// Mock encryption so we don't need ENCRYPTION_KEY in the test env.
+vi.mock("@/features/integrations/lib/encryption", () => ({
+  decrypt: vi.fn((v: string) => `decrypted_${v}`),
+  encrypt: vi.fn((v: string) => `encrypted_${v}`),
+}));
+
+import prisma from "@/lib/prisma";
+import {
+  fetchCalendarEvents,
+  getValidAccessToken,
+  filterExternalAttendees,
+} from "@/features/calendar/lib/google";
+import { syncCalendarEvents } from "../sync";
+
+// ---------------------------------------------------------------------------
+// Helpers for building stable mock payloads
+// ---------------------------------------------------------------------------
+const USER_ID = "user-123";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function makeIntegration(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "int-1",
+    userId: USER_ID,
+    service: "google_calendar",
+    accountEmail: "rep@fullmindlearning.com",
+    accountName: "Rep",
+    accessToken: "enc-access",
+    refreshToken: "enc-refresh",
+    tokenExpiresAt: new Date(Date.now() + 3_600_000),
+    scopes: [],
+    metadata: { companyDomain: "fullmindlearning.com" },
+    syncEnabled: true,
+    status: "connected",
+    lastSyncAt: null,
+    ...overrides,
+  };
+}
+
+function makeConnection(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "conn-1",
+    userId: USER_ID,
+    googleAccountEmail: "rep@fullmindlearning.com",
+    accessToken: "enc-access",
+    refreshToken: "enc-refresh",
+    tokenExpiresAt: new Date(Date.now() + 3_600_000),
+    companyDomain: "fullmindlearning.com",
+    syncEnabled: true,
+    lastSyncAt: null as Date | null,
+    status: "connected",
+    syncDirection: "two_way",
+    syncedActivityTypes: [],
+    reminderMinutes: 15,
+    secondReminderMinutes: null,
+    backfillStartDate: null as Date | null,
+    backfillCompletedAt: null as Date | null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function makeGoogleEvent(id: string, overrides: Record<string, unknown> = {}) {
+  const start = new Date(Date.now() - DAY_MS);
+  const end = new Date(start.getTime() + 60 * 60 * 1000);
+  return {
+    id,
+    summary: `Meeting ${id}`,
+    description: null,
+    start: { dateTime: start.toISOString() },
+    end: { dateTime: end.toISOString() },
+    location: null,
+    status: "confirmed",
+    attendees: [
+      {
+        email: "principal@school.org",
+        displayName: "Principal",
+        responseStatus: "accepted",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function primeValidSyncPath(
+  connection: ReturnType<typeof makeConnection>,
+  googleEvents: ReturnType<typeof makeGoogleEvent>[]
+) {
+  vi.mocked(prisma.userIntegration.findUnique).mockResolvedValue(
+    makeIntegration() as never
+  );
+  vi.mocked(prisma.calendarConnection.findUnique).mockResolvedValue(
+    connection as never
+  );
+  vi.mocked(getValidAccessToken).mockResolvedValue({
+    accessToken: "decrypted_enc-access",
+    expiresAt: new Date(Date.now() + 3_600_000),
+  });
+  vi.mocked(fetchCalendarEvents).mockResolvedValue(googleEvents as never);
+  // Every event we build has one external attendee, by default.
+  vi.mocked(filterExternalAttendees).mockImplementation(
+    (attendees) =>
+      (attendees ?? []).map((a) => ({
+        email: a.email,
+        name: a.displayName ?? null,
+        responseStatus: a.responseStatus,
+      })) as never
+  );
+
+  // No pre-existing staged CalendarEvent rows — everything is "new".
+  vi.mocked(prisma.calendarEvent.findUnique).mockResolvedValue(null as never);
+  vi.mocked(prisma.calendarEvent.create).mockResolvedValue({} as never);
+  vi.mocked(prisma.calendarEvent.update).mockResolvedValue({} as never);
+  vi.mocked(prisma.calendarEvent.findMany).mockResolvedValue([] as never);
+
+  // Contact matching short-circuits to "no contacts found" — that path is fine
+  // for the tests; we're not asserting on smart-match results.
+  vi.mocked(prisma.contact.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.territoryPlanDistrict.findFirst).mockResolvedValue(
+    null as never
+  );
+
+  vi.mocked(prisma.userIntegration.update).mockResolvedValue({} as never);
+  vi.mocked(prisma.calendarConnection.update).mockResolvedValue({} as never);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("syncCalendarEvents — window selection", () => {
+  // Pin "now" so relative-date assertions are deterministic.
+  const NOW = new Date("2026-04-09T12:00:00.000Z");
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("uses backfillStartDate as timeMin when backfill is pending", async () => {
+    const backfillStart = new Date(NOW.getTime() - 30 * DAY_MS);
+    primeValidSyncPath(
+      makeConnection({
+        backfillStartDate: backfillStart,
+        backfillCompletedAt: null,
+        lastSyncAt: null,
+      }),
+      []
+    );
+    vi.mocked(prisma.activity.findMany).mockResolvedValue([] as never);
+
+    await syncCalendarEvents(USER_ID);
+
+    expect(fetchCalendarEvents).toHaveBeenCalledTimes(1);
+    const [, timeMin, timeMax] = vi.mocked(fetchCalendarEvents).mock.calls[0];
+    expect(Math.abs(timeMin.getTime() - backfillStart.getTime())).toBeLessThan(
+      1000
+    );
+    // timeMax = now + 14d
+    expect(
+      Math.abs(timeMax.getTime() - (NOW.getTime() + 14 * DAY_MS))
+    ).toBeLessThan(1000);
+  });
+
+  it("uses lastSyncAt - 2d when backfill has completed", async () => {
+    const lastSyncAt = new Date(NOW.getTime() - 1 * DAY_MS);
+    const backfillStart = new Date(NOW.getTime() - 30 * DAY_MS);
+    primeValidSyncPath(
+      makeConnection({
+        backfillStartDate: backfillStart,
+        backfillCompletedAt: new Date(NOW.getTime() - 1 * DAY_MS),
+        lastSyncAt,
+      }),
+      []
+    );
+    vi.mocked(prisma.activity.findMany).mockResolvedValue([] as never);
+
+    await syncCalendarEvents(USER_ID);
+
+    const [, timeMin] = vi.mocked(fetchCalendarEvents).mock.calls[0];
+    const expected = new Date(lastSyncAt.getTime() - 2 * DAY_MS);
+    expect(Math.abs(timeMin.getTime() - expected.getTime())).toBeLessThan(1000);
+  });
+
+  it("uses lastSyncAt - 2d when there is no backfill at all", async () => {
+    const lastSyncAt = new Date(NOW.getTime() - 1 * DAY_MS);
+    primeValidSyncPath(
+      makeConnection({
+        backfillStartDate: null,
+        backfillCompletedAt: null,
+        lastSyncAt,
+      }),
+      []
+    );
+    vi.mocked(prisma.activity.findMany).mockResolvedValue([] as never);
+
+    await syncCalendarEvents(USER_ID);
+
+    const [, timeMin] = vi.mocked(fetchCalendarEvents).mock.calls[0];
+    const expected = new Date(NOW.getTime() - 3 * DAY_MS); // lastSyncAt (-1d) - 2d = -3d
+    expect(Math.abs(timeMin.getTime() - expected.getTime())).toBeLessThan(1000);
+  });
+
+  it("falls back to now - 7d when there is no backfill and no prior sync", async () => {
+    primeValidSyncPath(
+      makeConnection({
+        backfillStartDate: null,
+        backfillCompletedAt: null,
+        lastSyncAt: null,
+      }),
+      []
+    );
+    vi.mocked(prisma.activity.findMany).mockResolvedValue([] as never);
+
+    await syncCalendarEvents(USER_ID);
+
+    const [, timeMin] = vi.mocked(fetchCalendarEvents).mock.calls[0];
+    const expected = new Date(NOW.getTime() - 7 * DAY_MS);
+    expect(Math.abs(timeMin.getTime() - expected.getTime())).toBeLessThan(1000);
+  });
+});
+
+describe("syncCalendarEvents — Activity dedupe", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("skips events that already have a matching Activity.googleEventId", async () => {
+    const events = [
+      makeGoogleEvent("evt-1"),
+      makeGoogleEvent("evt-2"),
+      makeGoogleEvent("evt-3"),
+    ];
+    primeValidSyncPath(makeConnection(), events);
+    vi.mocked(prisma.activity.findMany).mockResolvedValue([
+      { googleEventId: "evt-2" },
+    ] as never);
+
+    const result = await syncCalendarEvents(USER_ID);
+
+    // 3 events fetched, 3 processed, 1 deduped, 2 staged as new.
+    expect(prisma.activity.findMany).toHaveBeenCalledWith({
+      where: { googleEventId: { in: ["evt-1", "evt-2", "evt-3"] } },
+      select: { googleEventId: true },
+    });
+    expect(result.eventsProcessed).toBe(3);
+    expect(prisma.calendarEvent.create).toHaveBeenCalledTimes(2);
+
+    const createdIds = vi
+      .mocked(prisma.calendarEvent.create)
+      .mock.calls.map((call) => (call[0].data as { googleEventId: string }).googleEventId);
+    expect(createdIds).toEqual(["evt-1", "evt-3"]);
+  });
+
+  it("stages all events when none are deduped", async () => {
+    const events = [
+      makeGoogleEvent("evt-1"),
+      makeGoogleEvent("evt-2"),
+      makeGoogleEvent("evt-3"),
+    ];
+    primeValidSyncPath(makeConnection(), events);
+    vi.mocked(prisma.activity.findMany).mockResolvedValue([] as never);
+
+    const result = await syncCalendarEvents(USER_ID);
+
+    expect(result.eventsProcessed).toBe(3);
+    expect(prisma.calendarEvent.create).toHaveBeenCalledTimes(3);
+  });
+
+  it("skips the Activity dedupe query when Google returns no events", async () => {
+    primeValidSyncPath(makeConnection(), []);
+
+    const result = await syncCalendarEvents(USER_ID);
+
+    expect(prisma.activity.findMany).not.toHaveBeenCalled();
+    expect(result.eventsProcessed).toBe(0);
+    expect(prisma.calendarEvent.create).not.toHaveBeenCalled();
+  });
+});
+
+describe("syncCalendarEvents — lastSyncAt propagation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("updates lastSyncAt on both UserIntegration and CalendarConnection", async () => {
+    primeValidSyncPath(makeConnection(), []);
+    vi.mocked(prisma.activity.findMany).mockResolvedValue([] as never);
+
+    await syncCalendarEvents(USER_ID);
+
+    expect(prisma.userIntegration.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId_service: { userId: USER_ID, service: "google_calendar" } },
+        data: expect.objectContaining({ lastSyncAt: expect.any(Date) }),
+      })
+    );
+    expect(prisma.calendarConnection.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "conn-1" },
+        data: expect.objectContaining({ lastSyncAt: expect.any(Date) }),
+      })
+    );
+
+    const userIntegrationCall = vi
+      .mocked(prisma.userIntegration.update)
+      .mock.calls.find((call) => "lastSyncAt" in (call[0].data ?? {}));
+    const connectionCall = vi
+      .mocked(prisma.calendarConnection.update)
+      .mock.calls.find((call) => "lastSyncAt" in (call[0].data ?? {}));
+
+    const userTs = (userIntegrationCall?.[0].data as { lastSyncAt: Date })
+      .lastSyncAt;
+    const connTs = (connectionCall?.[0].data as { lastSyncAt: Date }).lastSyncAt;
+    expect(userTs.getTime()).toBe(connTs.getTime());
+  });
+});
+
+describe("syncCalendarEvents — regression guards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("short-circuits for syncDirection === 'one_way' without fetching", async () => {
+    vi.mocked(prisma.userIntegration.findUnique).mockResolvedValue(
+      makeIntegration() as never
+    );
+    vi.mocked(prisma.calendarConnection.findUnique).mockResolvedValue(
+      makeConnection({ syncDirection: "one_way" }) as never
+    );
+
+    const result = await syncCalendarEvents(USER_ID);
+
+    expect(fetchCalendarEvents).not.toHaveBeenCalled();
+    expect(prisma.activity.findMany).not.toHaveBeenCalled();
+    expect(prisma.calendarEvent.create).not.toHaveBeenCalled();
+    expect(prisma.userIntegration.update).not.toHaveBeenCalled();
+    expect(prisma.calendarConnection.update).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      eventsProcessed: 0,
+      newEvents: 0,
+      updatedEvents: 0,
+      cancelledEvents: 0,
+      errors: [],
+    });
+  });
+});

--- a/src/features/calendar/lib/__tests__/sync.test.ts
+++ b/src/features/calendar/lib/__tests__/sync.test.ts
@@ -16,6 +16,7 @@ vi.mock("@/lib/prisma", () => {
       },
       calendarEvent: {
         findUnique: vi.fn(),
+        findFirst: vi.fn(),
         create: vi.fn(),
         update: vi.fn(),
         findMany: vi.fn(),
@@ -155,6 +156,7 @@ function primeValidSyncPath(
 
   // No pre-existing staged CalendarEvent rows — everything is "new".
   vi.mocked(prisma.calendarEvent.findUnique).mockResolvedValue(null as never);
+  vi.mocked(prisma.calendarEvent.findFirst).mockResolvedValue(null as never);
   vi.mocked(prisma.calendarEvent.create).mockResolvedValue({} as never);
   vi.mocked(prisma.calendarEvent.update).mockResolvedValue({} as never);
   vi.mocked(prisma.calendarEvent.findMany).mockResolvedValue([] as never);
@@ -402,6 +404,61 @@ describe("syncCalendarEvents — lastSyncAt propagation", () => {
       .lastSyncAt;
     const connTs = (connectionCall?.[0].data as { lastSyncAt: Date }).lastSyncAt;
     expect(userTs.getTime()).toBe(connTs.getTime());
+  });
+});
+
+describe("syncCalendarEvents — dedupe against prior status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not re-stage an event previously dismissed for the same user, even when the prior row has a null connection_id", async () => {
+    // Historical context: before the 2026-04 sync rework, CalendarEvent rows
+    // were user-scoped and had no connection_id. When connection_id was
+    // re-introduced as nullable, legacy rows were left with connection_id =
+    // NULL. Dedupe that keys on (connection_id, google_event_id) misses them
+    // and happily stages a duplicate `pending` row — users reported their
+    // dismissed meetings "popping back" in the Home feed.
+    const events = [makeGoogleEvent("legacy-dismissed")];
+    primeValidSyncPath(makeConnection(), events);
+    vi.mocked(prisma.activity.findMany).mockResolvedValue([] as never);
+
+    // The dedupe lookup must find the existing dismissed row by
+    // (userId, googleEventId), not by (connectionId, googleEventId).
+    vi.mocked(prisma.calendarEvent.findFirst).mockResolvedValue({
+      id: "legacy-row",
+      userId: USER_ID,
+      connectionId: null,
+      googleEventId: "legacy-dismissed",
+      status: "dismissed",
+    } as never);
+
+    await syncCalendarEvents(USER_ID);
+
+    expect(prisma.calendarEvent.create).not.toHaveBeenCalled();
+    expect(prisma.calendarEvent.update).not.toHaveBeenCalled();
+  });
+
+  it("does not re-stage an event previously confirmed under a different connection", async () => {
+    // Defense in depth: if an OAuth reconnect ever created a row under a new
+    // connection_id while the old confirmed row still exists (cascade delete
+    // missed it, or activity.googleEventId was cleared), we still shouldn't
+    // revive it as pending.
+    const events = [makeGoogleEvent("confirmed-elsewhere")];
+    primeValidSyncPath(makeConnection({ id: "conn-new" }), events);
+    vi.mocked(prisma.activity.findMany).mockResolvedValue([] as never);
+
+    vi.mocked(prisma.calendarEvent.findFirst).mockResolvedValue({
+      id: "old-row",
+      userId: USER_ID,
+      connectionId: "conn-old",
+      googleEventId: "confirmed-elsewhere",
+      status: "confirmed",
+    } as never);
+
+    await syncCalendarEvents(USER_ID);
+
+    expect(prisma.calendarEvent.create).not.toHaveBeenCalled();
   });
 });
 

--- a/src/features/calendar/lib/queries.ts
+++ b/src/features/calendar/lib/queries.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { fetchJson, API_BASE } from "@/features/shared/lib/api-client";
 import type {
@@ -217,11 +217,17 @@ export function useAutoSyncCalendarOnMount(): AutoSyncController {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- sync is a stable mutation object; we only care about the guard refs + connection data
   }, [data]);
 
-  return {
-    setOnNewEvents: (cb: (n: number) => void) => {
-      onNewEventsRef.current = cb;
-    },
-  };
+  // Memoize the returned controller so consumers (e.g. HomeView) that depend
+  // on it in a useEffect don't re-run the effect every render. The callback
+  // only touches a ref, so it never needs to change identity.
+  return useMemo(
+    () => ({
+      setOnNewEvents: (cb: (n: number) => void) => {
+        onNewEventsRef.current = cb;
+      },
+    }),
+    []
+  );
 }
 
 // Derives whether the user needs to set up or resume the backfill wizard.

--- a/src/features/calendar/lib/queries.ts
+++ b/src/features/calendar/lib/queries.ts
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { fetchJson, API_BASE } from "@/features/shared/lib/api-client";
 import type {
@@ -179,6 +180,106 @@ export function useBatchConfirmCalendarEvents() {
       queryClient.invalidateQueries({ queryKey: ["calendarEvents"] });
       queryClient.invalidateQueries({ queryKey: ["calendarConnection"] });
       queryClient.invalidateQueries({ queryKey: ["activities"] });
+    },
+  });
+}
+
+// --- Backfill / Auto-sync Hooks ---
+
+// Fires a single incremental sync on mount once the user has completed backfill.
+// Returns a callback-ref setter so a parent (e.g. HomeView) can subscribe to
+// "new events arrived" events and show a toast.
+export interface AutoSyncController {
+  setOnNewEvents: (cb: (newEventCount: number) => void) => void;
+}
+
+export function useAutoSyncCalendarOnMount(): AutoSyncController {
+  const { data } = useCalendarConnection();
+  const sync = useTriggerCalendarSync();
+  const ranRef = useRef(false);
+  const onNewEventsRef = useRef<((n: number) => void) | null>(null);
+
+  useEffect(() => {
+    if (ranRef.current) return;
+    if (!data?.connected) return;
+    if (!data.connection?.syncEnabled) return;
+    // Skip auto-sync while backfill is still pending — the wizard owns sync
+    if (!data.connection?.backfillCompletedAt) return;
+
+    ranRef.current = true;
+    sync.mutate(undefined, {
+      onSuccess: (result) => {
+        if (result.newEvents > 0 && onNewEventsRef.current) {
+          onNewEventsRef.current(result.newEvents);
+        }
+      },
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- sync is a stable mutation object; we only care about the guard refs + connection data
+  }, [data]);
+
+  return {
+    setOnNewEvents: (cb: (n: number) => void) => {
+      onNewEventsRef.current = cb;
+    },
+  };
+}
+
+// Derives whether the user needs to set up or resume the backfill wizard.
+export interface BackfillStatus {
+  isLoading: boolean;
+  connected: boolean;
+  needsSetup: boolean;
+  needsResume: boolean;
+  backfillCompletedAt: string | null;
+}
+
+export function useBackfillStatus(): BackfillStatus {
+  const { data, isLoading } = useCalendarConnection();
+  const connection = data?.connection ?? null;
+  const connected = !!data?.connected;
+  return {
+    isLoading,
+    connected,
+    needsSetup:
+      connected && !connection?.backfillStartDate && !connection?.backfillCompletedAt,
+    needsResume:
+      connected && !!connection?.backfillStartDate && !connection?.backfillCompletedAt,
+    backfillCompletedAt: connection?.backfillCompletedAt ?? null,
+  };
+}
+
+// Start the backfill wizard: sets backfillStartDate = now - days and syncs.
+export type BackfillDays = 7 | 30 | 60 | 90;
+
+export interface BackfillStartResult extends CalendarSyncResult {
+  pendingCount: number;
+}
+
+export function useStartBackfill() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (days: BackfillDays) =>
+      fetchJson<BackfillStartResult>(`${API_BASE}/calendar/backfill/start`, {
+        method: "POST",
+        body: JSON.stringify({ days }),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["calendarConnection"] });
+      queryClient.invalidateQueries({ queryKey: ["calendarEvents"] });
+    },
+  });
+}
+
+// Mark the backfill wizard complete — sets backfillCompletedAt = now.
+export function useCompleteBackfill() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () =>
+      fetchJson<{ success: boolean }>(`${API_BASE}/calendar/backfill/complete`, {
+        method: "POST",
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["calendarConnection"] });
     },
   });
 }

--- a/src/features/calendar/lib/sync.ts
+++ b/src/features/calendar/lib/sync.ts
@@ -250,11 +250,26 @@ export async function syncCalendarEvents(userId: string): Promise<SyncResult> {
   }
 
   // Step 2: Fetch events from Google Calendar
-  // Window: 7 days in the past + 14 days in the future
-  const timeMin = new Date();
-  timeMin.setDate(timeMin.getDate() - 7);
+  // Window: timeMax is always now + 14 days; timeMin depends on backfill/sync state
+  // - If the user picked a backfill window and hasn't finished the wizard → use backfillStartDate
+  // - Else if we have a prior sync → lastSyncAt minus a 2-day buffer (catches late updates)
+  // - Else → 7 days in the past (fallback preserves the old behavior for fresh connections)
   const timeMax = new Date();
   timeMax.setDate(timeMax.getDate() + 14);
+
+  let timeMin: Date;
+  if (
+    calendarConnection.backfillStartDate &&
+    !calendarConnection.backfillCompletedAt
+  ) {
+    timeMin = new Date(calendarConnection.backfillStartDate);
+  } else if (calendarConnection.lastSyncAt) {
+    timeMin = new Date(calendarConnection.lastSyncAt);
+    timeMin.setDate(timeMin.getDate() - 2);
+  } else {
+    timeMin = new Date();
+    timeMin.setDate(timeMin.getDate() - 7);
+  }
 
   let googleEvents;
   try {
@@ -273,8 +288,25 @@ export async function syncCalendarEvents(userId: string): Promise<SyncResult> {
   const syncTimestamp = new Date();
   const companyDomain = (integration.metadata as Record<string, unknown>)?.companyDomain as string || "";
 
+  // Batch dedupe: events the user already logged manually (Activity.googleEventId is @unique)
+  // should never be re-staged. Single batch query against the unique index keeps this cheap.
+  const googleIds = googleEvents.map((e) => e.id);
+  const alreadyLogged = new Set(
+    googleIds.length === 0
+      ? []
+      : (
+          await prisma.activity.findMany({
+            where: { googleEventId: { in: googleIds } },
+            select: { googleEventId: true },
+          })
+        )
+          .map((a) => a.googleEventId)
+          .filter((id): id is string => id !== null)
+  );
+
   for (const event of googleEvents) {
     result.eventsProcessed++;
+    if (alreadyLogged.has(event.id)) continue;
 
     try {
       // Filter to only external attendees using the company domain
@@ -381,9 +413,15 @@ export async function syncCalendarEvents(userId: string): Promise<SyncResult> {
     }
   }
 
-  // Step 5: Update the last sync timestamp
+  // Step 5: Update the last sync timestamp on BOTH token store + connection
+  // The status route reads lastSyncAt from CalendarConnection; UserIntegration
+  // mirrors it so the shared integrations dashboard stays in sync too.
   await prisma.userIntegration.update({
     where: { userId_service: { userId, service: "google_calendar" } },
+    data: { lastSyncAt: syncTimestamp },
+  });
+  await prisma.calendarConnection.update({
+    where: { id: calendarConnection.id },
     data: { lastSyncAt: syncTimestamp },
   });
 

--- a/src/features/calendar/lib/sync.ts
+++ b/src/features/calendar/lib/sync.ts
@@ -250,12 +250,16 @@ export async function syncCalendarEvents(userId: string): Promise<SyncResult> {
   }
 
   // Step 2: Fetch events from Google Calendar
-  // Window: timeMax is always now + 14 days; timeMin depends on backfill/sync state
-  // - If the user picked a backfill window and hasn't finished the wizard → use backfillStartDate
-  // - Else if we have a prior sync → lastSyncAt minus a 2-day buffer (catches late updates)
-  // - Else → 7 days in the past (fallback preserves the old behavior for fresh connections)
+  // Window is symmetric around "now" based on the user's chosen backfillWindowDays:
+  // - timeMax = now + backfillWindowDays (forward horizon — new meetings get picked up)
+  // - timeMin depends on backfill/sync state:
+  //     - If the user picked a backfill window and hasn't finished the wizard → use backfillStartDate
+  //     - Else if we have a prior sync → lastSyncAt minus a 2-day buffer (catches late updates)
+  //     - Else → 7 days in the past (fallback preserves the old behavior for fresh connections)
+  // - Legacy fallback: if backfillWindowDays is null (older connections), use the old 14-day forward.
+  const windowDays = calendarConnection.backfillWindowDays ?? 14;
   const timeMax = new Date();
-  timeMax.setDate(timeMax.getDate() + 14);
+  timeMax.setDate(timeMax.getDate() + windowDays);
 
   let timeMin: Date;
   if (

--- a/src/features/calendar/lib/sync.ts
+++ b/src/features/calendar/lib/sync.ts
@@ -331,13 +331,18 @@ export async function syncCalendarEvents(userId: string): Promise<SyncResult> {
         externalAttendees.length
       );
 
-      // Check if this event already exists in our staging table
-      const existingEvent = await prisma.calendarEvent.findUnique({
+      // Check if this event already exists in our staging table.
+      // Lookup is scoped to (userId, googleEventId), NOT (connectionId,
+      // googleEventId): legacy rows from before connection_id was re-added
+      // have connection_id = NULL, and an OAuth reconnect can produce a new
+      // connection_id. The user-scoped key is the only one that reliably
+      // dedupes against a prior dismissed/confirmed row for the same Google
+      // event. See sync.test.ts "dedupe against prior status" for the bug
+      // this guards against.
+      const existingEvent = await prisma.calendarEvent.findFirst({
         where: {
-          connectionId_googleEventId: {
-            connectionId: calendarConnection.id,
-            googleEventId: event.id,
-          },
+          userId,
+          googleEventId: event.id,
         },
       });
 

--- a/src/features/home/components/HomeView.tsx
+++ b/src/features/home/components/HomeView.tsx
@@ -1,11 +1,18 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import ProfileSidebar from "./ProfileSidebar";
 import HomeTabBar, { type HomeTab } from "./HomeTabBar";
 import FeedTab from "./FeedTab";
 import ActivitiesTab from "./ActivitiesTab";
 import PlansTab from "./PlansTab";
+import {
+  useAutoSyncCalendarOnMount,
+  useBackfillStatus,
+} from "@/features/calendar/lib/queries";
+import BackfillSetupModal from "@/features/calendar/components/backfill/BackfillSetupModal";
+import CalendarSyncToast from "@/features/calendar/components/CalendarSyncToast";
 
 // ============================================================================
 // HomeView — the new Home Base landing page
@@ -18,6 +25,61 @@ export default function HomeView() {
 
   const handleFeedBadge = useCallback((count: number) => setFeedBadge(count), []);
   const handlePlansBadge = useCallback((count: number) => setPlansBadge(count), []);
+
+  // Calendar sync integration
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const backfillStatus = useBackfillStatus();
+  const autoSync = useAutoSyncCalendarOnMount();
+
+  const [backfillModalOpen, setBackfillModalOpen] = useState(false);
+  const [toastVisible, setToastVisible] = useState(false);
+  const [toastCount, setToastCount] = useState(0);
+
+  // Open the backfill modal on the right triggers and strip transient flags.
+  // Explicit user intent (query params) always opens. Implicit open based on
+  // backfill status only fires AT MOST ONCE per HomeView mount — so closing
+  // the modal via "Maybe later" sticks instead of bouncing back open on the
+  // next render.
+  const hasAutoOpenedRef = useRef(false);
+  useEffect(() => {
+    const justConnected = searchParams?.get("calendarJustConnected") === "true";
+    const resumeBackfill = searchParams?.get("resumeBackfill") === "true";
+
+    if (justConnected || resumeBackfill) {
+      setBackfillModalOpen(true);
+    } else if (
+      !hasAutoOpenedRef.current &&
+      (backfillStatus.needsSetup || backfillStatus.needsResume)
+    ) {
+      hasAutoOpenedRef.current = true;
+      setBackfillModalOpen(true);
+    }
+
+    if (justConnected || resumeBackfill) {
+      const next = new URLSearchParams(searchParams?.toString() ?? "");
+      next.delete("calendarJustConnected");
+      next.delete("resumeBackfill");
+      next.delete("from");
+      const qs = next.toString();
+      router.replace(qs ? `?${qs}` : "?tab=home", { scroll: false });
+    }
+  }, [searchParams, router, backfillStatus.needsSetup, backfillStatus.needsResume]);
+
+  // Navigation handler used by the backfill completion screen CTA — closes the
+  // modal and routes the rep to the Activities tab so they can see what landed.
+  const handleGoToActivities = () => {
+    setBackfillModalOpen(false);
+    router.push("?tab=activities");
+  };
+
+  // Hook the auto-sync "new events arrived" callback up to the toast
+  useEffect(() => {
+    autoSync.setOnNewEvents((n) => {
+      setToastCount(n);
+      setToastVisible(true);
+    });
+  }, [autoSync]);
 
   return (
     <div className="h-full flex bg-[#FFFCFA]">
@@ -46,6 +108,23 @@ export default function HomeView() {
           )}
         </div>
       </div>
+
+      {/* Calendar backfill wizard + post-sync toast */}
+      <BackfillSetupModal
+        isOpen={backfillModalOpen}
+        onClose={() => setBackfillModalOpen(false)}
+        initialStep={backfillStatus.needsResume ? "wizard" : "picker"}
+        onGoToActivities={handleGoToActivities}
+      />
+      <CalendarSyncToast
+        visible={toastVisible}
+        newEventCount={toastCount}
+        onDismiss={() => setToastVisible(false)}
+        onReview={() => {
+          setToastVisible(false);
+          router.push("?tab=activities");
+        }}
+      />
     </div>
   );
 }

--- a/src/features/shared/components/views/HomeView.tsx
+++ b/src/features/shared/components/views/HomeView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useRef } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
   useProfile,
@@ -301,17 +301,23 @@ export default function HomeView() {
   const [toastVisible, setToastVisible] = useState(false);
   const [toastCount, setToastCount] = useState(0);
 
-  // Open the backfill modal on the right triggers and strip transient flags
+  // Open the backfill modal on the right triggers and strip transient flags.
+  // Explicit user intent (query params) always opens. Implicit open based on
+  // backfill status only fires AT MOST ONCE per HomeView mount — so closing
+  // the modal via "Maybe later" sticks instead of bouncing back open on the
+  // next render.
+  const hasAutoOpenedRef = useRef(false);
   useEffect(() => {
     const justConnected = searchParams?.get("calendarJustConnected") === "true";
     const resumeBackfill = searchParams?.get("resumeBackfill") === "true";
 
-    if (
-      justConnected ||
-      resumeBackfill ||
-      backfillStatus.needsSetup ||
-      backfillStatus.needsResume
+    if (justConnected || resumeBackfill) {
+      setBackfillModalOpen(true);
+    } else if (
+      !hasAutoOpenedRef.current &&
+      (backfillStatus.needsSetup || backfillStatus.needsResume)
     ) {
+      hasAutoOpenedRef.current = true;
       setBackfillModalOpen(true);
     }
 
@@ -323,6 +329,13 @@ export default function HomeView() {
       router.replace(qs ? `?${qs}` : "?tab=home", { scroll: false });
     }
   }, [searchParams, router, backfillStatus.needsSetup, backfillStatus.needsResume]);
+
+  // Navigation handler used by the backfill completion screen CTA — closes the
+  // modal and routes the rep to the Activities tab so they can see what landed.
+  const handleGoToActivities = () => {
+    setBackfillModalOpen(false);
+    router.push("?tab=activities");
+  };
 
   // Hook the auto-sync "new events arrived" callback up to the toast
   useEffect(() => {
@@ -767,6 +780,7 @@ export default function HomeView() {
         isOpen={backfillModalOpen}
         onClose={() => setBackfillModalOpen(false)}
         initialStep={backfillStatus.needsResume ? "wizard" : "picker"}
+        onGoToActivities={handleGoToActivities}
       />
       <CalendarSyncToast
         visible={toastVisible}

--- a/src/features/shared/components/views/HomeView.tsx
+++ b/src/features/shared/components/views/HomeView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useMemo, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import {
   useProfile,
   useGoalDashboard,
@@ -33,6 +34,12 @@ import PlanCardFilters, {
   filterAndSortPlans,
   type PlanSortKey,
 } from "@/features/plans/components/PlanCardFilters";
+import {
+  useAutoSyncCalendarOnMount,
+  useBackfillStatus,
+} from "@/features/calendar/lib/queries";
+import BackfillSetupModal from "@/features/calendar/components/backfill/BackfillSetupModal";
+import CalendarSyncToast from "@/features/calendar/components/CalendarSyncToast";
 
 // ============================================================================
 // Helpers
@@ -283,6 +290,47 @@ export default function HomeView() {
   const [planOwnerId, setPlanOwnerId] = useState<string | null>(null);
   const [planSortBy, setPlanSortBy] = useState<PlanSortKey>("updated");
   const [selectedPlanId, setSelectedPlanId] = useState<string | null>(null);
+
+  // Calendar sync integration
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const backfillStatus = useBackfillStatus();
+  const autoSync = useAutoSyncCalendarOnMount();
+
+  const [backfillModalOpen, setBackfillModalOpen] = useState(false);
+  const [toastVisible, setToastVisible] = useState(false);
+  const [toastCount, setToastCount] = useState(0);
+
+  // Open the backfill modal on the right triggers and strip transient flags
+  useEffect(() => {
+    const justConnected = searchParams?.get("calendarJustConnected") === "true";
+    const resumeBackfill = searchParams?.get("resumeBackfill") === "true";
+
+    if (
+      justConnected ||
+      resumeBackfill ||
+      backfillStatus.needsSetup ||
+      backfillStatus.needsResume
+    ) {
+      setBackfillModalOpen(true);
+    }
+
+    if (justConnected || resumeBackfill) {
+      const next = new URLSearchParams(searchParams?.toString() ?? "");
+      next.delete("calendarJustConnected");
+      next.delete("resumeBackfill");
+      const qs = next.toString();
+      router.replace(qs ? `?${qs}` : "?tab=home", { scroll: false });
+    }
+  }, [searchParams, router, backfillStatus.needsSetup, backfillStatus.needsResume]);
+
+  // Hook the auto-sync "new events arrived" callback up to the toast
+  useEffect(() => {
+    autoSync.setOnNewEvents((n) => {
+      setToastCount(n);
+      setToastVisible(true);
+    });
+  }, [autoSync]);
 
   const firstName = profile?.fullName?.split(" ")[0] || "there";
 
@@ -713,6 +761,22 @@ export default function HomeView() {
           onClose={() => setSelectedPlanId(null)}
         />
       )}
+
+      {/* Calendar backfill wizard + post-sync toast */}
+      <BackfillSetupModal
+        isOpen={backfillModalOpen}
+        onClose={() => setBackfillModalOpen(false)}
+        initialStep={backfillStatus.needsResume ? "wizard" : "picker"}
+      />
+      <CalendarSyncToast
+        visible={toastVisible}
+        newEventCount={toastCount}
+        onDismiss={() => setToastVisible(false)}
+        onReview={() => {
+          setToastVisible(false);
+          router.push("?tab=activities");
+        }}
+      />
     </div>
   );
 }

--- a/src/features/shared/components/views/__tests__/HomeView.test.tsx
+++ b/src/features/shared/components/views/__tests__/HomeView.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import HomeView from "../HomeView";
 
 // ---------------------------------------------------------------------------
@@ -80,14 +81,30 @@ vi.mock("@/features/progress/components/LaggingIndicatorsPanel", () => ({
   default: () => <div data-testid="lagging-panel" />,
 }));
 
-// Backfill modal + toast — stubbed out so we can assert on props
+// Backfill modal + toast — stubbed out so we can assert on props. The stub
+// renders a "close" button so tests can simulate the user dismissing the
+// modal (e.g. "Maybe later") and verify it stays closed on re-render.
 vi.mock("@/features/calendar/components/backfill/BackfillSetupModal", () => ({
-  default: (props: { isOpen: boolean; initialStep: string }) => (
+  default: (props: {
+    isOpen: boolean;
+    initialStep: string;
+    onClose: () => void;
+    onGoToActivities?: () => void;
+  }) => (
     <div
       data-testid="backfill-modal"
       data-open={props.isOpen ? "true" : "false"}
       data-initial-step={props.initialStep}
-    />
+      data-has-go-to-activities={props.onGoToActivities ? "true" : "false"}
+    >
+      <button
+        type="button"
+        data-testid="backfill-modal-close"
+        onClick={props.onClose}
+      >
+        Close
+      </button>
+    </div>
   ),
 }));
 
@@ -223,5 +240,31 @@ describe("HomeView — calendar sync integration", () => {
     expect(modal.dataset.open).toBe("true");
     expect(modal.dataset.initialStep).toBe("wizard");
     expect(mockRouterReplace).toHaveBeenCalled();
+  });
+
+  it("does not re-open the backfill modal after the user dismisses it via 'Maybe later'", async () => {
+    const user = userEvent.setup();
+    mockBackfillStatus.needsSetup = true;
+    const { rerender } = render(<HomeView />);
+
+    // Auto-opens on mount
+    const modal = screen.getByTestId("backfill-modal");
+    expect(modal.dataset.open).toBe("true");
+
+    // User dismisses the modal via the close (Maybe later) button
+    await user.click(screen.getByTestId("backfill-modal-close"));
+    expect(screen.getByTestId("backfill-modal").dataset.open).toBe("false");
+
+    // Force a re-render — nothing about the backfill status has changed and
+    // no explicit query param intent is set, so the modal must stay closed.
+    rerender(<HomeView />);
+    expect(screen.getByTestId("backfill-modal").dataset.open).toBe("false");
+  });
+
+  it("passes onGoToActivities to the backfill modal", () => {
+    mockBackfillStatus.needsSetup = true;
+    render(<HomeView />);
+    const modal = screen.getByTestId("backfill-modal");
+    expect(modal.dataset.hasGoToActivities).toBe("true");
   });
 });

--- a/src/features/shared/components/views/__tests__/HomeView.test.tsx
+++ b/src/features/shared/components/views/__tests__/HomeView.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
-import { render } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
 import HomeView from "../HomeView";
 
 // ---------------------------------------------------------------------------
@@ -80,11 +80,74 @@ vi.mock("@/features/progress/components/LaggingIndicatorsPanel", () => ({
   default: () => <div data-testid="lagging-panel" />,
 }));
 
+// Backfill modal + toast — stubbed out so we can assert on props
+vi.mock("@/features/calendar/components/backfill/BackfillSetupModal", () => ({
+  default: (props: { isOpen: boolean; initialStep: string }) => (
+    <div
+      data-testid="backfill-modal"
+      data-open={props.isOpen ? "true" : "false"}
+      data-initial-step={props.initialStep}
+    />
+  ),
+}));
+
+vi.mock("@/features/calendar/components/CalendarSyncToast", () => ({
+  default: (props: { visible: boolean; newEventCount: number }) => (
+    <div
+      data-testid="sync-toast"
+      data-visible={props.visible ? "true" : "false"}
+      data-count={String(props.newEventCount)}
+    />
+  ),
+}));
+
+// next/navigation — routerReplace + searchParams are swappable per-test
+const mockRouterReplace = vi.fn();
+const mockRouterPush = vi.fn();
+const searchParamsRef: { current: URLSearchParams } = {
+  current: new URLSearchParams(),
+};
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockRouterPush,
+    replace: mockRouterReplace,
+  }),
+  useSearchParams: () => searchParamsRef.current,
+}));
+
+// Calendar hooks — swappable per-test
+const mockBackfillStatus = {
+  isLoading: false,
+  connected: false,
+  needsSetup: false,
+  needsResume: false,
+  backfillCompletedAt: null as string | null,
+};
+const newEventsCallbacks: Array<(n: number) => void> = [];
+
+vi.mock("@/features/calendar/lib/queries", () => ({
+  useBackfillStatus: () => ({ ...mockBackfillStatus }),
+  useAutoSyncCalendarOnMount: () => ({
+    setOnNewEvents: (cb: (n: number) => void) => {
+      newEventsCallbacks.push(cb);
+    },
+  }),
+}));
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 describe("HomeView — regression after DonutChart extraction", () => {
+  beforeEach(() => {
+    mockRouterReplace.mockReset();
+    mockRouterPush.mockReset();
+    searchParamsRef.current = new URLSearchParams();
+    mockBackfillStatus.needsSetup = false;
+    mockBackfillStatus.needsResume = false;
+    newEventsCallbacks.length = 0;
+  });
+
   // Test 15: HomeView still renders 4 donuts after extraction
   it("renders 4 donut chart SVGs after extraction to shared component", () => {
     const { container } = render(<HomeView />);
@@ -94,5 +157,71 @@ describe("HomeView — regression after DonutChart extraction", () => {
       (svg) => svg.querySelectorAll("circle").length === 2,
     );
     expect(donutSvgs).toHaveLength(4);
+  });
+});
+
+describe("HomeView — calendar sync integration", () => {
+  beforeEach(() => {
+    mockRouterReplace.mockReset();
+    mockRouterPush.mockReset();
+    searchParamsRef.current = new URLSearchParams();
+    mockBackfillStatus.needsSetup = false;
+    mockBackfillStatus.needsResume = false;
+    newEventsCallbacks.length = 0;
+  });
+
+  it("keeps the backfill modal closed on a neutral mount", () => {
+    render(<HomeView />);
+    const modal = screen.getByTestId("backfill-modal");
+    expect(modal.dataset.open).toBe("false");
+  });
+
+  it("opens the backfill modal when ?calendarJustConnected=true is present", () => {
+    searchParamsRef.current = new URLSearchParams("calendarJustConnected=true");
+    render(<HomeView />);
+    const modal = screen.getByTestId("backfill-modal");
+    expect(modal.dataset.open).toBe("true");
+    expect(modal.dataset.initialStep).toBe("picker");
+    // Query param should be stripped
+    expect(mockRouterReplace).toHaveBeenCalled();
+  });
+
+  it("opens the backfill modal at the wizard step when needsResume is true", () => {
+    mockBackfillStatus.needsResume = true;
+    render(<HomeView />);
+    const modal = screen.getByTestId("backfill-modal");
+    expect(modal.dataset.open).toBe("true");
+    expect(modal.dataset.initialStep).toBe("wizard");
+  });
+
+  it("opens the backfill modal when needsSetup is true", () => {
+    mockBackfillStatus.needsSetup = true;
+    render(<HomeView />);
+    const modal = screen.getByTestId("backfill-modal");
+    expect(modal.dataset.open).toBe("true");
+  });
+
+  it("fires the calendar sync toast when autoSync.setOnNewEvents callback is invoked", () => {
+    render(<HomeView />);
+    expect(screen.getByTestId("sync-toast").dataset.visible).toBe("false");
+
+    // Simulate the auto-sync hook firing its callback with 3 new events
+    act(() => {
+      newEventsCallbacks.forEach((cb) => cb(3));
+    });
+
+    const toast = screen.getByTestId("sync-toast");
+    expect(toast.dataset.visible).toBe("true");
+    expect(toast.dataset.count).toBe("3");
+  });
+
+  it("opens the backfill modal when ?resumeBackfill=true is present", () => {
+    searchParamsRef.current = new URLSearchParams("resumeBackfill=true");
+    mockBackfillStatus.needsResume = true;
+    render(<HomeView />);
+    const modal = screen.getByTestId("backfill-modal");
+    expect(modal.dataset.open).toBe("true");
+    expect(modal.dataset.initialStep).toBe("wizard");
+    expect(mockRouterReplace).toHaveBeenCalled();
   });
 });

--- a/src/features/shared/types/api-types.ts
+++ b/src/features/shared/types/api-types.ts
@@ -946,6 +946,7 @@ export interface CalendarConnection {
   createdAt: string;
   backfillStartDate: string | null;
   backfillCompletedAt: string | null;
+  backfillWindowDays: number | null;
 }
 
 export interface CalendarStatusResponse {

--- a/src/features/shared/types/api-types.ts
+++ b/src/features/shared/types/api-types.ts
@@ -944,6 +944,8 @@ export interface CalendarConnection {
   reminderMinutes: number;
   secondReminderMinutes: number | null;
   createdAt: string;
+  backfillStartDate: string | null;
+  backfillCompletedAt: string | null;
 }
 
 export interface CalendarStatusResponse {


### PR DESCRIPTION
## Summary

- **Backfill wizard:** After first Google Calendar OAuth connect, a full-screen modal walks the user through past + future calendar events one at a time. User picks a symmetric ± window (7/30/60/90 days), reviews each external-attendee meeting with pre-filled fields (activity type, plan, district, contacts, notes), and confirms/skips/dismisses. Keyboard shortcuts (Y/S/X/arrows/Esc) for fast triage.
- **Auto-sync on mount:** Fires an incremental sync once per app mount after backfill is complete. Surfaces new events via a bottom-right toast with a link to the Calendar Inbox.
- **Sync engine enhancements:** Configurable timeMin/timeMax from `backfillWindowDays`, batch Activity dedupe on `googleEventId`, `CalendarConnection.lastSyncAt` propagation, `findFirst`-based event dedup for legacy row compat.
- **OAuth callback fix:** Now upserts both `UserIntegration` + `CalendarConnection`, defers sync to the wizard instead of firing immediately.
- **Disconnect fix:** Cleans up both tables, preserves confirmed/dismissed event history across disconnect→reconnect cycles.
- **Schema:** 3 new nullable fields on `CalendarConnection`: `backfill_start_date`, `backfill_completed_at`, `backfill_window_days`. Manual migration files included.

## New files

- `src/features/calendar/components/backfill/` — 5 wizard components (SetupModal, WindowPicker, Wizard, EventCard, CompletionScreen)
- `src/features/calendar/components/CalendarSyncToast.tsx` — post-sync bottom-right toast
- `src/app/api/calendar/backfill/{start,complete}/route.ts` — 2 new API routes
- `prisma/migrations/manual/2026-04-09-calendar-backfill-*.sql` — 2 migration files
- `docs/superpowers/specs/2026-04-09-google-calendar-sync-*.md` — spec + backend context + plan

## Pre-deploy checklist

- [ ] Run both migration files against production DB
- [ ] Add `ENCRYPTION_KEY` env var to Vercel (64 hex chars, AES-256-GCM)
- [ ] Verify Google Calendar OAuth redirect URI includes the production domain

## Test plan

- [x] 103 unit tests pass (Vitest) — sync engine, hooks, all 5 wizard components, toast, HomeView integration
- [x] TypeScript strict — zero errors
- [x] Production build clean (`npm run build`)
- [ ] Manual: Connect Google Calendar → pick ± 90 days → walk wizard → completion screen → navigate to Activities
- [ ] Manual: Disconnect → reconnect → verify backfill wizard reopens
- [ ] Manual: Close wizard mid-flow ("Maybe later") → reopen app → wizard reopens once, stays closed after second dismiss
- [ ] Manual: Confirm future event → Activity created with status "planned"
- [ ] Verify auto-sync toast appears on subsequent app mount when new events exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)