### PR TITLE
DB normalization phases 1-4 + MCP-prep additions

### DIFF
--- a/Docs/superpowers/followups/2026-04-11-opportunity-sync-historical-gap.md
+++ b/Docs/superpowers/followups/2026-04-11-opportunity-sync-historical-gap.md
@@ -1,0 +1,83 @@
+# Follow-up: Opportunity sync drops historical years, leaving 95K orphaned sessions
+
+## Summary
+
+The OpenSearch opportunity sync filters by recency (~3 fiscal years deep), but the session sync brings back **all historical sessions**. This asymmetry leaves **95,345 sessions (33.1% of all sessions)** with `opportunity_id` values that point to opportunities not present in the local `opportunities` table.
+
+These aren't bad references — the opportunity IDs are real Salesforce-format IDs, and the parent opportunities still exist in OpenSearch/Salesforce. They just aren't being synced down to the local Postgres because they're outside the active window.
+
+## Discovered during
+
+DB normalization work on 2026-04-11. We were about to add a `Session.opportunity_id → Opportunity.id` foreign key constraint and discovered the orphan rate during the pre-migration cleanup check.
+
+## Numbers
+
+| Metric | Value |
+|---|---|
+| Total sessions | 287,821 |
+| Total opportunities | 2,565 |
+| Orphaned sessions | 95,345 (33.1%) |
+| Distinct missing opportunity IDs | 294 |
+| Sessions in `unmatched_opportunities` table | 0 (none are tracked there) |
+| Sync state | Up to date — `sync_state.last_synced_at` was 2 hours ago at investigation time |
+
+## Opportunity counts by school year (showing the recency filter)
+
+| School Year | Opportunity Count |
+|---|---|
+| 2026-27 | 345 |
+| 2025-26 | 1,334 |
+| 2024-25 | 747 |
+| 2023-24 | 108 |
+| 2022-23 | 14 |
+| 2021-22 | 3 |
+| 2020-21 | 2 |
+| 2019-20 | 2 |
+| 2018-19 | 1 |
+
+## Orphaned session distribution by year (showing where the gap is)
+
+| Session start_time year | Orphan Sessions | Distinct Missing Opportunity IDs |
+|---|---|---|
+| 2026 | 5 | 1 |
+| 2025 | 314 | 13 |
+| 2024 | 1,089 | 38 |
+| **2023** | **24,051** | **102** |
+| **2022** | **33,048** | **122** |
+| **2021** | **21,101** | **94** |
+| 2020 | 12,794 | 87 |
+| 2019 | 2,942 | 48 |
+
+~94K of 95K orphans are from 2019-2023.
+
+## Likely root cause
+
+The OpenSearch opportunity sync query is filtered by some combination of stage, close date, or fiscal year that excludes historical opportunities. The session sync doesn't apply the same filter.
+
+## Impact
+
+1. **Session→Opportunity foreign key cannot be added** without losing 95K linkages. We deferred adding the constraint as part of the 2026-04-11 normalization work.
+2. **Financial reports** that join sessions to opportunities will under-count historical data.
+3. **MCP tools** that try to navigate from a session to its opportunity will hit nulls for 33% of sessions.
+
+## Proposed fix
+
+One of the following:
+- **Backfill option:** Run a one-time backfill of all historical opportunities from OpenSearch → local Postgres, then maintain them going forward. After this, the Session→Opportunity FK can be added.
+- **Expand sync window option:** Change the OpenSearch opportunity sync query to remove the recency filter (or expand it to cover all historical years that have sessions). Pulls more data per cycle but creates referential integrity.
+- **Document and accept option:** Document the asymmetry as intentional, add a NULL check helper, and don't add the FK. Cheapest but leaves 33% of sessions orphaned permanently.
+
+## Files to investigate
+
+- `scheduler/sync/` (Railway scheduler) — opportunity sync query and session sync query
+- `prisma/migrations/20260409000000_add_opensearch_sync_fields/` — recent sync field additions
+- `src/lib/opportunity-actuals.ts` — how the app reads opportunity↔session data today
+
+## Acceptance criteria
+
+- [ ] Investigation: identify which opportunities are missing and why
+- [ ] Decide which fix option to pursue
+- [ ] If backfilling: run the backfill, verify orphan count drops to 0 (or small known set)
+- [ ] If FK is now safe: add `sessions.opportunity_id → opportunities.id` foreign key
+- [ ] Add `Session.opportunity` Prisma relation (or remove the optional one we left in place)
+- [ ] Document the decision in `Documentation/.md Files/data-model.md`

--- a/prisma/migrations/20260411_add_missing_indexes_and_timestamps/migration.sql
+++ b/prisma/migrations/20260411_add_missing_indexes_and_timestamps/migration.sql
@@ -1,0 +1,14 @@
+-- Add missing indexes and updatedAt timestamps for MCP query support and incremental sync.
+-- See plan: Docs/superpowers/plans/2026-04-11-schema-quick-wins.md
+
+-- Indexes for MCP query support
+CREATE INDEX IF NOT EXISTS "districts_icp_tier_idx" ON "districts"("icp_tier");
+CREATE INDEX IF NOT EXISTS "districts_account_type_idx" ON "districts"("account_type");
+CREATE INDEX IF NOT EXISTS "activities_type_start_date_idx" ON "activities"("type", "start_date");
+CREATE INDEX IF NOT EXISTS "district_financials_fiscal_year_idx" ON "district_financials"("fiscal_year");
+
+-- Timestamps for incremental sync support
+ALTER TABLE "district_data_history" ADD COLUMN IF NOT EXISTS "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE "district_grade_enrollment" ADD COLUMN IF NOT EXISTS "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE "district_grade_enrollment" ADD COLUMN IF NOT EXISTS "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE "unmatched_accounts" ADD COLUMN IF NOT EXISTS "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/prisma/migrations/20260411_add_opportunity_session_fk/migration.sql
+++ b/prisma/migrations/20260411_add_opportunity_session_fk/migration.sql
@@ -1,9 +1,22 @@
--- Add FK relations from Opportunity → District and Session → Opportunity.
+-- Add FK relation Opportunity → District. Cleans up 355 orphaned opportunity
+-- rows whose district_lea_id doesn't reference an existing district.
+--
 -- See plan: Docs/superpowers/plans/2026-04-11-opportunity-session-fk.md
--- Production check (2026-04-11) found 355 orphaned opportunities and an unknown
--- number of orphaned sessions; both must be NULLed before adding the constraints.
+--
+-- IMPORTANT: The original plan also added a Session → Opportunity FK, but
+-- production has 95,345 orphaned sessions (33.1%) whose opportunity_id values
+-- reference real Salesforce opportunities that aren't in our local
+-- opportunities table because the Railway opportunity sync filters by recency
+-- while the session sync doesn't. NULLing those would lose real data linkages.
+-- We make sessions.opportunity_id nullable (so the Prisma model matches the
+-- DB) but skip the FK constraint. Tracked as a follow-up:
+-- Docs/superpowers/followups/2026-04-11-opportunity-sync-historical-gap.md
+--
+-- We also have to drop and recreate 5 views (1 materialized, 4 regular) that
+-- reference opportunities.district_lea_id, since Postgres won't allow ALTER
+-- COLUMN TYPE while views depend on the column.
 
--- Step 1: Clean up orphaned references BEFORE adding FK constraints
+-- Step 1: Clean up orphaned opportunity → district references (355 known rows)
 UPDATE opportunities
 SET district_lea_id = NULL
 WHERE district_lea_id IS NOT NULL
@@ -11,18 +24,20 @@ AND NOT EXISTS (
   SELECT 1 FROM districts WHERE leaid = opportunities.district_lea_id
 );
 
-UPDATE sessions
-SET opportunity_id = NULL
-WHERE opportunity_id IS NOT NULL
-AND NOT EXISTS (
-  SELECT 1 FROM opportunities WHERE id = sessions.opportunity_id
-);
+-- Step 2: Drop dependent views (4 regular + 1 materialized)
+DROP VIEW IF EXISTS district_health_view CASCADE;
+DROP VIEW IF EXISTS district_opportunities_view CASCADE;
+DROP VIEW IF EXISTS opportunity_sessions_view CASCADE;
+DROP VIEW IF EXISTS plan_district_engagement_view CASCADE;
+DROP MATERIALIZED VIEW IF EXISTS district_opportunity_actuals CASCADE;
 
--- Step 2: Change column types and nullability
+-- Step 3: Change opportunities.district_lea_id from TEXT to VARCHAR(7)
 ALTER TABLE "opportunities" ALTER COLUMN "district_lea_id" TYPE VARCHAR(7);
+
+-- Step 4: Make sessions.opportunity_id nullable (no FK; see header comment)
 ALTER TABLE "sessions" ALTER COLUMN "opportunity_id" DROP NOT NULL;
 
--- Step 3: Add FK constraints (idempotent via DO block)
+-- Step 5: Add the opportunities → districts FK constraint
 DO $$
 BEGIN
   IF NOT EXISTS (
@@ -33,13 +48,165 @@ BEGIN
       FOREIGN KEY ("district_lea_id") REFERENCES "districts"("leaid")
       ON DELETE SET NULL ON UPDATE CASCADE;
   END IF;
-
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_constraint WHERE conname = 'sessions_opportunity_id_fkey'
-  ) THEN
-    ALTER TABLE "sessions"
-      ADD CONSTRAINT "sessions_opportunity_id_fkey"
-      FOREIGN KEY ("opportunity_id") REFERENCES "opportunities"("id")
-      ON DELETE SET NULL ON UPDATE CASCADE;
-  END IF;
 END $$;
+
+-- Step 6: Recreate district_health_view (definition pulled from production 2026-04-11)
+CREATE VIEW district_health_view AS
+SELECT d.leaid,
+    d.name AS district_name,
+    d.state_abbrev AS district_state,
+    d.city_location AS district_city,
+    d.enrollment,
+    d.is_customer,
+    d.has_open_pipeline,
+    count(DISTINCT o.id) AS opportunity_count,
+    count(DISTINCT o.id) FILTER (WHERE o.stage = 'Closed Won'::text) AS won_opportunity_count,
+    count(DISTINCT o.id) FILTER (WHERE o.stage <> ALL (ARRAY['Closed Lost'::text, 'Closed Won'::text])) AS open_opportunity_count,
+    COALESCE(sum(DISTINCT o.net_booking_amount) FILTER (WHERE o.stage = 'Closed Won'::text), 0::numeric) AS won_bookings,
+    COALESCE(sum(DISTINCT o.net_booking_amount) FILTER (WHERE o.stage <> ALL (ARRAY['Closed Lost'::text, 'Closed Won'::text])), 0::numeric) AS open_pipeline,
+    count(DISTINCT ad.activity_id) AS activity_count,
+    count(DISTINCT ad.activity_id) FILTER (WHERE a.status::text = 'completed'::text) AS completed_activity_count,
+    max(a.start_date) AS last_activity_date,
+    count(DISTINCT c.id) AS contact_count,
+    count(DISTINCT c.id) FILTER (WHERE c.is_primary = true) AS primary_contact_count,
+    count(DISTINCT s.id) AS session_count,
+    COALESCE(sum(s.session_price), 0::numeric) AS total_session_revenue,
+    COALESCE(sum(ae.amount), 0::numeric) AS total_expenses,
+    count(DISTINCT td.task_id) AS task_count
+   FROM districts d
+     LEFT JOIN opportunities o ON o.district_lea_id::text = d.leaid::text
+     LEFT JOIN activity_districts ad ON ad.district_leaid::text = d.leaid::text
+     LEFT JOIN activities a ON a.id = ad.activity_id
+     LEFT JOIN activity_expenses ae ON ae.activity_id = a.id
+     LEFT JOIN contacts c ON c.leaid::text = d.leaid::text
+     LEFT JOIN sessions s ON s.opportunity_id = o.id
+     LEFT JOIN task_districts td ON td.district_leaid::text = d.leaid::text
+  GROUP BY d.leaid;
+
+-- Step 7: Recreate district_opportunities_view
+CREATE VIEW district_opportunities_view AS
+SELECT d.leaid,
+    d.name AS district_name,
+    d.state_abbrev AS district_state,
+    d.city_location AS district_city,
+    d.enrollment,
+    d.is_customer,
+    d.has_open_pipeline,
+    count(o.id) AS opportunity_count,
+    count(o.id) FILTER (WHERE o.stage <> ALL (ARRAY['Closed Lost'::text, 'Closed Won'::text])) AS open_opportunity_count,
+    count(o.id) FILTER (WHERE o.stage = 'Closed Won'::text) AS won_opportunity_count,
+    COALESCE(sum(o.net_booking_amount), 0::numeric) AS total_bookings,
+    COALESCE(sum(o.net_booking_amount) FILTER (WHERE o.stage = 'Closed Won'::text), 0::numeric) AS won_bookings,
+    COALESCE(sum(o.net_booking_amount) FILTER (WHERE o.stage <> ALL (ARRAY['Closed Lost'::text, 'Closed Won'::text])), 0::numeric) AS open_pipeline,
+    max(o.close_date) AS latest_close_date,
+    min(o.created_at) AS first_opportunity_date
+   FROM districts d
+     LEFT JOIN opportunities o ON o.district_lea_id::text = d.leaid::text
+  GROUP BY d.leaid;
+
+-- Step 8: Recreate opportunity_sessions_view
+CREATE VIEW opportunity_sessions_view AS
+SELECT o.id AS opportunity_id,
+    o.name AS opportunity_name,
+    o.school_yr,
+    o.contract_type,
+    o.stage,
+    o.sales_rep_name,
+    o.district_name,
+    o.district_lea_id AS leaid,
+    o.state,
+    o.net_booking_amount,
+    o.close_date,
+    count(s.id) AS session_count,
+    COALESCE(sum(s.session_price), 0::numeric) AS total_session_revenue,
+    COALESCE(sum(s.educator_price), 0::numeric) AS total_educator_cost,
+    min(s.start_time) AS first_session_date,
+    max(s.start_time) AS last_session_date
+   FROM opportunities o
+     LEFT JOIN sessions s ON s.opportunity_id = o.id
+  GROUP BY o.id;
+
+-- Step 9: Recreate plan_district_engagement_view
+CREATE VIEW plan_district_engagement_view AS
+SELECT tpd.plan_id,
+    tpd.district_leaid AS leaid,
+    tp.name AS plan_name,
+    tp.fiscal_year,
+    d.name AS district_name,
+    d.state_abbrev AS district_state,
+    d.city_location AS district_city,
+    d.enrollment,
+    d.is_customer,
+    COALESCE(tpd.renewal_target, 0::numeric) + COALESCE(tpd.winback_target, 0::numeric) + COALESCE(tpd.expansion_target, 0::numeric) + COALESCE(tpd.new_business_target, 0::numeric) AS target_revenue,
+    count(DISTINCT o.id) AS opportunity_count,
+    COALESCE(sum(o.net_booking_amount) FILTER (WHERE o.stage <> ALL (ARRAY['Closed Lost'::text, 'Closed Won'::text])), 0::numeric) AS open_pipeline,
+    COALESCE(sum(o.net_booking_amount) FILTER (WHERE o.stage = 'Closed Won'::text), 0::numeric) AS won_bookings,
+    count(DISTINCT ad.activity_id) AS activity_count,
+    max(a.start_date) AS last_activity_date,
+    count(DISTINCT c.id) AS contact_count,
+    COALESCE(sum(ae.amount), 0::numeric) AS total_expenses
+   FROM territory_plan_districts tpd
+     JOIN territory_plans tp ON tp.id = tpd.plan_id
+     JOIN districts d ON d.leaid::text = tpd.district_leaid::text
+     LEFT JOIN opportunities o ON o.district_lea_id::text = d.leaid::text
+     LEFT JOIN activity_districts ad ON ad.district_leaid::text = d.leaid::text
+     LEFT JOIN activities a ON a.id = ad.activity_id
+     LEFT JOIN activity_expenses ae ON ae.activity_id = a.id
+     LEFT JOIN contacts c ON c.leaid::text = d.leaid::text
+  GROUP BY tpd.plan_id, tpd.district_leaid, tp.name, tp.fiscal_year, d.leaid, tpd.renewal_target, tpd.winback_target, tpd.expansion_target, tpd.new_business_target;
+
+-- Step 10: Recreate the district_opportunity_actuals materialized view
+CREATE MATERIALIZED VIEW district_opportunity_actuals AS
+WITH stage_weights AS (
+  SELECT unnest(ARRAY[0, 1, 2, 3, 4, 5]) AS prefix,
+         unnest(ARRAY[0.05, 0.10, 0.25, 0.50, 0.75, 0.90]) AS weight
+), categorized_opps AS (
+  SELECT o.id, o.name, o.school_yr, o.contract_type, o.state,
+         o.sales_rep_name, o.sales_rep_email,
+         o.district_name, o.district_lms_id, o.district_nces_id, o.district_lea_id,
+         o.created_at, o.close_date, o.brand_ambassador, o.stage,
+         o.net_booking_amount, o.contract_through, o.funding_through,
+         o.payment_type, o.payment_terms, o.lead_source,
+         o.invoiced, o.credited,
+         o.completed_revenue, o.completed_take, o.scheduled_sessions,
+         o.scheduled_revenue, o.scheduled_take, o.total_revenue, o.total_take,
+         o.average_take_rate, o.synced_at,
+         CASE
+           WHEN lower(o.contract_type) LIKE '%renewal%' THEN 'renewal'::text
+           WHEN lower(o.contract_type) LIKE '%winback%' OR lower(o.contract_type) LIKE '%win back%' THEN 'winback'::text
+           WHEN lower(o.contract_type) LIKE '%expansion%' THEN 'expansion'::text
+           ELSE 'new_business'::text
+         END AS category,
+         CASE
+           WHEN o.stage ~ '^\d' THEN (regexp_match(o.stage, '^(\d+)'))[1]::integer
+           ELSE NULL::integer
+         END AS stage_prefix
+    FROM opportunities o
+   WHERE o.district_lea_id IS NOT NULL
+)
+SELECT co.district_lea_id, co.school_yr, co.sales_rep_email, co.category,
+       COALESCE(sum(co.net_booking_amount) FILTER (WHERE co.stage_prefix >= 6), 0::numeric) AS bookings,
+       COALESCE(sum(co.net_booking_amount) FILTER (WHERE co.stage_prefix >= 0 AND co.stage_prefix <= 5), 0::numeric) AS open_pipeline,
+       COALESCE(sum(co.net_booking_amount * sw.weight) FILTER (WHERE co.stage_prefix >= 0 AND co.stage_prefix <= 5), 0::numeric) AS weighted_pipeline,
+       COALESCE(sum(co.total_revenue), 0::numeric) AS total_revenue,
+       COALESCE(sum(co.completed_revenue), 0::numeric) AS completed_revenue,
+       COALESCE(sum(co.scheduled_revenue), 0::numeric) AS scheduled_revenue,
+       COALESCE(sum(co.total_take), 0::numeric) AS total_take,
+       COALESCE(sum(co.completed_take), 0::numeric) AS completed_take,
+       COALESCE(sum(co.scheduled_take), 0::numeric) AS scheduled_take,
+       CASE WHEN sum(co.total_revenue) > 0::numeric THEN sum(co.total_take) / sum(co.total_revenue) ELSE NULL::numeric END AS avg_take_rate,
+       COALESCE(sum(co.invoiced), 0::numeric) AS invoiced,
+       COALESCE(sum(co.credited), 0::numeric) AS credited,
+       count(*)::integer AS opp_count
+  FROM categorized_opps co
+  LEFT JOIN stage_weights sw ON sw.prefix = co.stage_prefix
+ GROUP BY co.district_lea_id, co.school_yr, co.sales_rep_email, co.category;
+
+-- Step 11: Recreate the materialized view's indexes
+CREATE INDEX idx_doa_district ON public.district_opportunity_actuals USING btree (district_lea_id);
+CREATE INDEX idx_doa_school_yr ON public.district_opportunity_actuals USING btree (school_yr);
+CREATE INDEX idx_doa_rep ON public.district_opportunity_actuals USING btree (sales_rep_email);
+CREATE INDEX idx_doa_category ON public.district_opportunity_actuals USING btree (category);
+CREATE INDEX idx_doa_district_yr ON public.district_opportunity_actuals USING btree (district_lea_id, school_yr);
+CREATE INDEX idx_doa_district_yr_rep ON public.district_opportunity_actuals USING btree (district_lea_id, school_yr, sales_rep_email);
+CREATE UNIQUE INDEX idx_doa_unique ON public.district_opportunity_actuals USING btree (district_lea_id, school_yr, sales_rep_email, category);

--- a/prisma/migrations/20260411_add_opportunity_session_fk/migration.sql
+++ b/prisma/migrations/20260411_add_opportunity_session_fk/migration.sql
@@ -1,0 +1,45 @@
+-- Add FK relations from Opportunity → District and Session → Opportunity.
+-- See plan: Docs/superpowers/plans/2026-04-11-opportunity-session-fk.md
+-- Production check (2026-04-11) found 355 orphaned opportunities and an unknown
+-- number of orphaned sessions; both must be NULLed before adding the constraints.
+
+-- Step 1: Clean up orphaned references BEFORE adding FK constraints
+UPDATE opportunities
+SET district_lea_id = NULL
+WHERE district_lea_id IS NOT NULL
+AND NOT EXISTS (
+  SELECT 1 FROM districts WHERE leaid = opportunities.district_lea_id
+);
+
+UPDATE sessions
+SET opportunity_id = NULL
+WHERE opportunity_id IS NOT NULL
+AND NOT EXISTS (
+  SELECT 1 FROM opportunities WHERE id = sessions.opportunity_id
+);
+
+-- Step 2: Change column types and nullability
+ALTER TABLE "opportunities" ALTER COLUMN "district_lea_id" TYPE VARCHAR(7);
+ALTER TABLE "sessions" ALTER COLUMN "opportunity_id" DROP NOT NULL;
+
+-- Step 3: Add FK constraints (idempotent via DO block)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'opportunities_district_lea_id_fkey'
+  ) THEN
+    ALTER TABLE "opportunities"
+      ADD CONSTRAINT "opportunities_district_lea_id_fkey"
+      FOREIGN KEY ("district_lea_id") REFERENCES "districts"("leaid")
+      ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'sessions_opportunity_id_fkey'
+  ) THEN
+    ALTER TABLE "sessions"
+      ADD CONSTRAINT "sessions_opportunity_id_fkey"
+      FOREIGN KEY ("opportunity_id") REFERENCES "opportunities"("id")
+      ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END $$;

--- a/prisma/migrations/20260411_drop_calendar_connections/migration.sql
+++ b/prisma/migrations/20260411_drop_calendar_connections/migration.sql
@@ -76,7 +76,13 @@ SET metadata = jsonb_build_object(
 FROM calendar_connections cc
 WHERE ui.user_id = cc.user_id AND ui.service = 'google_calendar';
 
--- Step 3: Re-point calendar_events.connection_id from calendar_connections.id
+-- Step 3: Drop the old FK constraint on calendar_events.connection_id BEFORE
+-- we re-point the connection_ids — otherwise the UPDATE fails because the new
+-- ui.id values don't exist in calendar_connections yet.
+ALTER TABLE calendar_events
+  DROP CONSTRAINT IF EXISTS calendar_events_connection_id_fkey;
+
+-- Step 4: Re-point calendar_events.connection_id from calendar_connections.id
 -- to the matching user_integrations.id. Map by user_id since each user has at
 -- most one row in each table for calendar.
 UPDATE calendar_events ce
@@ -85,11 +91,6 @@ FROM calendar_connections cc, user_integrations ui
 WHERE ce.connection_id = cc.id
 AND cc.user_id = ui.user_id
 AND ui.service = 'google_calendar';
-
--- Step 4: Drop the old FK constraint on calendar_events.connection_id (if any)
--- so the cascade chain doesn't fire when we drop calendar_connections.
-ALTER TABLE calendar_events
-  DROP CONSTRAINT IF EXISTS calendar_events_connection_id_fkey;
 
 -- Step 5: Drop calendar_connections table.
 DROP TABLE IF EXISTS calendar_connections CASCADE;

--- a/prisma/migrations/20260411_drop_calendar_connections/migration.sql
+++ b/prisma/migrations/20260411_drop_calendar_connections/migration.sql
@@ -1,0 +1,108 @@
+-- Drop calendar_connections, migrate calendar-specific settings into
+-- user_integrations.metadata (JSON), and re-point calendar_events.connection_id
+-- from calendar_connections.id → user_integrations.id.
+--
+-- See plan: Docs/superpowers/plans/2026-04-11-calendar-connection-migration.md
+--
+-- Production state at migration time:
+--   * 2 calendar_connections rows (sierra, melodie)
+--   * 2 user_integrations rows where service='google_calendar' (same 2 users)
+--   * 12 calendar_events rows still tied to calendar_connections.id (sierra)
+--
+-- Migration order is critical: we must remap calendar_events BEFORE dropping
+-- calendar_connections, otherwise the FK cascade would delete the events.
+
+-- Step 1: Backfill any missing user_integrations rows from calendar_connections.
+-- Both production rows already exist in user_integrations, but this is defensive
+-- so the migration is replayable on any environment.
+INSERT INTO user_integrations (
+  id,
+  user_id,
+  service,
+  account_email,
+  access_token,
+  refresh_token,
+  token_expires_at,
+  metadata,
+  sync_enabled,
+  status,
+  last_sync_at,
+  created_at,
+  updated_at
+)
+SELECT
+  gen_random_uuid(),
+  cc.user_id,
+  'google_calendar',
+  cc.google_account_email,
+  cc.access_token,
+  cc.refresh_token,
+  cc.token_expires_at,
+  jsonb_build_object(
+    'companyDomain', cc.company_domain,
+    'syncDirection', cc.sync_direction,
+    'syncedActivityTypes', cc.synced_activity_types,
+    'reminderMinutes', cc.reminder_minutes,
+    'secondReminderMinutes', cc.second_reminder_minutes,
+    'backfillStartDate', cc.backfill_start_date,
+    'backfillCompletedAt', cc.backfill_completed_at,
+    'backfillWindowDays', cc.backfill_window_days
+  ),
+  cc.sync_enabled,
+  cc.status,
+  cc.last_sync_at,
+  cc.created_at,
+  cc.updated_at
+FROM calendar_connections cc
+WHERE NOT EXISTS (
+  SELECT 1 FROM user_integrations ui
+  WHERE ui.user_id = cc.user_id AND ui.service = 'google_calendar'
+);
+
+-- Step 2: For existing user_integrations rows, merge calendar-specific settings
+-- into the metadata JSON. Preserve any existing metadata keys (e.g. companyDomain
+-- already set by the OAuth callback) by spreading the existing metadata last.
+UPDATE user_integrations ui
+SET metadata = jsonb_build_object(
+    'companyDomain', cc.company_domain,
+    'syncDirection', cc.sync_direction,
+    'syncedActivityTypes', cc.synced_activity_types,
+    'reminderMinutes', cc.reminder_minutes,
+    'secondReminderMinutes', cc.second_reminder_minutes,
+    'backfillStartDate', cc.backfill_start_date,
+    'backfillCompletedAt', cc.backfill_completed_at,
+    'backfillWindowDays', cc.backfill_window_days
+  ) || COALESCE(ui.metadata, '{}'::jsonb)
+FROM calendar_connections cc
+WHERE ui.user_id = cc.user_id AND ui.service = 'google_calendar';
+
+-- Step 3: Re-point calendar_events.connection_id from calendar_connections.id
+-- to the matching user_integrations.id. Map by user_id since each user has at
+-- most one row in each table for calendar.
+UPDATE calendar_events ce
+SET connection_id = ui.id
+FROM calendar_connections cc, user_integrations ui
+WHERE ce.connection_id = cc.id
+AND cc.user_id = ui.user_id
+AND ui.service = 'google_calendar';
+
+-- Step 4: Drop the old FK constraint on calendar_events.connection_id (if any)
+-- so the cascade chain doesn't fire when we drop calendar_connections.
+ALTER TABLE calendar_events
+  DROP CONSTRAINT IF EXISTS calendar_events_connection_id_fkey;
+
+-- Step 5: Drop calendar_connections table.
+DROP TABLE IF EXISTS calendar_connections CASCADE;
+
+-- Step 6: Add the new FK constraint pointing at user_integrations.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'calendar_events_connection_id_fkey'
+  ) THEN
+    ALTER TABLE calendar_events
+      ADD CONSTRAINT calendar_events_connection_id_fkey
+      FOREIGN KEY (connection_id) REFERENCES user_integrations(id)
+      ON DELETE CASCADE ON UPDATE CASCADE;
+  END IF;
+END $$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -765,8 +765,6 @@ model UserProfile {
   assignedTasks   Task[] @relation("TaskAssignee")
   // OAuth service integrations (Gmail, Google Calendar, Slack, Mixmax)
   integrations    UserIntegration[]
-  // Legacy calendar connection (migrating to UserIntegration)
-  calendarConnection CalendarConnection?
   // Initiative leaderboard scores
   initiativeScores       InitiativeScore[]
   // Inverse relations for normalized person FKs
@@ -800,6 +798,7 @@ model UserIntegration {
   updatedAt      DateTime  @updatedAt @map("updated_at")
 
   user UserProfile @relation(fields: [userId], references: [id], onDelete: Cascade)
+  calendarEvents CalendarEvent[]
 
   @@unique([userId, service])
   @@index([userId])
@@ -963,42 +962,13 @@ model TaskContact {
   @@map("task_contacts")
 }
 
-// ===== Google Calendar Integration =====
-// Stores OAuth tokens for a user's Google Calendar connection
-// One connection per user — enables two-way sync between activities and calendar events
-
-model CalendarConnection {
-  id                 String    @id @default(uuid())
-  userId             String    @unique @map("user_id") @db.Uuid
-  googleAccountEmail String    @map("google_account_email") @db.VarChar(255)
-  accessToken        String    @map("access_token") // encrypted at rest
-  refreshToken       String    @map("refresh_token") // encrypted at rest
-  tokenExpiresAt     DateTime  @map("token_expires_at")
-  companyDomain      String    @map("company_domain") @db.VarChar(100) // e.g. "fullmindlearning.com" — filters internal attendees
-  syncEnabled        Boolean   @default(true) @map("sync_enabled")
-  lastSyncAt         DateTime? @map("last_sync_at")
-  status             String    @default("connected") @db.VarChar(20) // connected, disconnected, error
-  syncDirection          String   @default("two_way") @map("sync_direction") @db.VarChar(20) // one_way (app→cal) or two_way
-  syncedActivityTypes    String[] @default([]) @map("synced_activity_types") // empty = all types synced
-  reminderMinutes        Int      @default(15) @map("reminder_minutes") // 0 = none
-  secondReminderMinutes  Int?     @map("second_reminder_minutes")
-  backfillStartDate      DateTime? @map("backfill_start_date") // user-chosen timeMin for initial backfill sync; NULL once backfill pass is done
-  backfillCompletedAt    DateTime? @map("backfill_completed_at") // set when first-time logging wizard finishes; NULL = wizard still pending
-  backfillWindowDays     Int?      @map("backfill_window_days") // symmetric window (7/30/60/90) — drives both timeMin (initial) and timeMax (all syncs)
-  createdAt          DateTime  @default(now()) @map("created_at")
-  updatedAt          DateTime  @updatedAt @map("updated_at")
-
-  // Relations
-  user   UserProfile     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  events CalendarEvent[]
-
-  @@map("calendar_connections")
-}
-
 // ===== Calendar Event Staging =====
 // Incoming Google Calendar events land here for rep review before becoming Activities
 // Smart matching suggests district/contact/plan associations based on attendee emails
-// Calendar OAuth tokens are now stored in UserIntegration (service = "google_calendar")
+// Calendar OAuth tokens are stored in UserIntegration (service = "google_calendar")
+// — including calendar-specific settings (companyDomain, syncDirection,
+// syncedActivityTypes, reminderMinutes, backfillStartDate, etc.) which live
+// in UserIntegration.metadata as JSON.
 
 model CalendarEvent {
   id                    String   @id @default(uuid())
@@ -1022,8 +992,9 @@ model CalendarEvent {
   createdAt             DateTime @default(now()) @map("created_at")
   updatedAt             DateTime @updatedAt @map("updated_at")
 
-  // Relations
-  connection CalendarConnection? @relation(fields: [connectionId], references: [id], onDelete: Cascade)
+  // Relations — connection_id now references user_integrations.id
+  // (was calendar_connections.id; the table was dropped in 20260411_drop_calendar_connections)
+  integration UserIntegration? @relation(fields: [connectionId], references: [id], onDelete: Cascade)
 
   @@unique([connectionId, googleEventId])
   @@index([userId, status])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -256,6 +256,7 @@ model District {
   gradeEnrollment DistrictGradeEnrollment[]
   vacancyScans    VacancyScan[]
   vacancies       Vacancy[]
+  opportunities   Opportunity[]
 
   @@index([stateFips])
   @@index([isCustomer, hasOpenPipeline])
@@ -1218,7 +1219,8 @@ model Opportunity {
   districtName       String?   @map("district_name") @db.Text
   districtLmsId      String?   @map("district_lms_id") @db.Text
   districtNcesId     String?   @map("district_nces_id") @db.Text
-  districtLeaId      String?   @map("district_lea_id") @db.Text
+  districtLeaId      String?   @map("district_lea_id") @db.VarChar(7)
+  district           District? @relation(fields: [districtLeaId], references: [leaid])
   createdAt          DateTime? @map("created_at") @db.Timestamptz
   closeDate          DateTime? @map("close_date") @db.Timestamptz
   brandAmbassador    String?   @map("brand_ambassador") @db.Text
@@ -1249,6 +1251,7 @@ model Opportunity {
   syncedAt              DateTime? @map("synced_at") @db.Timestamptz
 
   activityLinks ActivityOpportunity[]
+  sessions      Session[]
 
   @@index([schoolYr])
   @@index([districtNcesId])
@@ -1261,10 +1264,11 @@ model Opportunity {
 
 // ===== Sessions =====
 // Individual session records synced from OpenSearch.
-// Linked to opportunities by opportunity_id (no FK constraint).
+// Linked to opportunities by opportunity_id.
 model Session {
   id                    String    @id @db.Text
-  opportunityId         String    @map("opportunity_id") @db.Text
+  opportunityId         String?   @map("opportunity_id") @db.Text
+  opportunity           Opportunity? @relation(fields: [opportunityId], references: [id])
   serviceType           String?   @map("service_type") @db.Text
   sessionPrice          Decimal?  @map("session_price") @db.Decimal(15, 2)
   educatorPrice         Decimal?  @map("educator_price") @db.Decimal(15, 2)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -266,6 +266,8 @@ model District {
   @@index([vacancyPressureSignal])
   @@index([ownerId])
   @@index([salesExecutiveId])
+  @@index([icpTier])
+  @@index([accountType])
   @@map("districts")
 }
 
@@ -325,6 +327,7 @@ model DistrictFinancials {
   @@unique([unmatchedAccountId, vendor, fiscalYear])
   @@index([leaid])
   @@index([vendor, fiscalYear])
+  @@index([fiscalYear])
   @@map("district_financials")
 }
 
@@ -364,6 +367,7 @@ model UnmatchedAccount {
   isCustomer         Boolean  @default(false) @map("is_customer")
   hasOpenPipeline    Boolean  @default(false) @map("has_open_pipeline")
   createdAt          DateTime @default(now()) @map("created_at")
+  updatedAt          DateTime @updatedAt @map("updated_at")
 
   districtFinancials DistrictFinancials[]
 
@@ -613,6 +617,7 @@ model Activity {
   @@index([createdByUserId])
   @@index([type])
   @@index([startDate])
+  @@index([type, startDate])
   @@map("activities")
 }
 
@@ -1165,6 +1170,7 @@ model DistrictDataHistory {
   readProficiency Decimal? @map("read_proficiency_pct") @db.Decimal(5, 2)
 
   createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
 
   district District @relation(fields: [leaid], references: [leaid])
 
@@ -1184,6 +1190,9 @@ model DistrictGradeEnrollment {
   year       Int
   grade      String @db.VarChar(10) // K, 01, 02, ... 12, PK, UG
   enrollment Int?
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
 
   district District @relation(fields: [leaid], references: [leaid])
 

--- a/src/app/api/admin/integrations/route.ts
+++ b/src/app/api/admin/integrations/route.ts
@@ -14,14 +14,14 @@ export async function GET() {
 
     const totalUsers = await prisma.userProfile.count();
 
-    // Google Calendar integration status
+    // Google Calendar integration status (stored in user_integrations where service='google_calendar')
     const [calendarConnected, calendarError, calendarDisconnected, calendarLastSync] =
       await Promise.all([
-        prisma.calendarConnection.count({ where: { status: "connected" } }),
-        prisma.calendarConnection.count({ where: { status: "error" } }),
-        prisma.calendarConnection.count({ where: { status: "disconnected" } }),
-        prisma.calendarConnection.findFirst({
-          where: { status: "connected" },
+        prisma.userIntegration.count({ where: { service: "google_calendar", status: "connected" } }),
+        prisma.userIntegration.count({ where: { service: "google_calendar", status: "error" } }),
+        prisma.userIntegration.count({ where: { service: "google_calendar", status: "disconnected" } }),
+        prisma.userIntegration.findFirst({
+          where: { service: "google_calendar", status: "connected" },
           orderBy: { lastSyncAt: "desc" },
           select: { lastSyncAt: true },
         }),

--- a/src/app/api/admin/stats/route.ts
+++ b/src/app/api/admin/stats/route.ts
@@ -34,8 +34,8 @@ export async function GET() {
       prisma.userProfile.count({
         where: { lastLoginAt: { gte: todayStart } },
       }),
-      prisma.calendarConnection.count({ where: { status: "connected" } }),
-      prisma.calendarConnection.count({ where: { status: "error" } }),
+      prisma.userIntegration.count({ where: { service: "google_calendar", status: "connected" } }),
+      prisma.userIntegration.count({ where: { service: "google_calendar", status: "error" } }),
       prisma.dataRefreshLog.findFirst({ orderBy: { completedAt: "desc" } }),
       prisma.dataRefreshLog.count({
         where: { status: "error", completedAt: { gte: oneWeekAgo } },

--- a/src/app/api/calendar/backfill/complete/route.ts
+++ b/src/app/api/calendar/backfill/complete/route.ts
@@ -1,6 +1,6 @@
 // POST /api/calendar/backfill/complete — Marks the first-connect backfill wizard finished
-// Sets CalendarConnection.backfillCompletedAt to now so HomeView stops
-// reopening the setup modal on subsequent mounts.
+// Sets backfillCompletedAt in the calendar integration metadata so HomeView
+// stops reopening the setup modal on subsequent mounts.
 
 import { NextResponse } from "next/server";
 import { getUser } from "@/lib/supabase/server";
@@ -15,17 +15,23 @@ export async function POST() {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const existing = await prisma.calendarConnection.findUnique({
-      where: { userId: user.id },
-      select: { id: true },
+    const existing = await prisma.userIntegration.findUnique({
+      where: { userId_service: { userId: user.id, service: "google_calendar" } },
+      select: { id: true, metadata: true },
     });
     if (!existing) {
       return NextResponse.json({ error: "Not connected" }, { status: 404 });
     }
 
-    await prisma.calendarConnection.update({
-      where: { userId: user.id },
-      data: { backfillCompletedAt: new Date() },
+    const existingMetadata = (existing.metadata ?? {}) as Record<string, unknown>;
+    await prisma.userIntegration.update({
+      where: { userId_service: { userId: user.id, service: "google_calendar" } },
+      data: {
+        metadata: {
+          ...existingMetadata,
+          backfillCompletedAt: new Date().toISOString(),
+        },
+      },
     });
 
     return NextResponse.json({ success: true });

--- a/src/app/api/calendar/backfill/start/route.ts
+++ b/src/app/api/calendar/backfill/start/route.ts
@@ -1,7 +1,7 @@
 // POST /api/calendar/backfill/start — Kicks off the first-connect backfill pass
-// Sets the user-chosen timeMin window on CalendarConnection, runs a single
-// sync, and returns the sync result plus the total pending count so the
-// wizard can show progress.
+// Sets the user-chosen timeMin window in the calendar integration metadata,
+// runs a single sync, and returns the sync result plus the total pending count
+// so the wizard can show progress.
 
 import { NextResponse } from "next/server";
 import { getUser } from "@/lib/supabase/server";
@@ -36,12 +36,12 @@ export async function POST(request: Request) {
 
     const backfillStartDate = new Date(Date.now() - days * 86_400_000);
 
-    // Ensure the connection exists before we attempt a sync. If the user
+    // Ensure the integration exists before we attempt a sync. If the user
     // never completed OAuth (or the row was deleted), bail early with 404 so
     // the UI can prompt them to reconnect.
-    const existing = await prisma.calendarConnection.findUnique({
-      where: { userId: user.id },
-      select: { id: true },
+    const existing = await prisma.userIntegration.findUnique({
+      where: { userId_service: { userId: user.id, service: "google_calendar" } },
+      select: { id: true, metadata: true },
     });
     if (!existing) {
       return NextResponse.json(
@@ -50,12 +50,16 @@ export async function POST(request: Request) {
       );
     }
 
-    await prisma.calendarConnection.update({
-      where: { userId: user.id },
+    const existingMetadata = (existing.metadata ?? {}) as Record<string, unknown>;
+    await prisma.userIntegration.update({
+      where: { userId_service: { userId: user.id, service: "google_calendar" } },
       data: {
-        backfillStartDate,
-        backfillCompletedAt: null,
-        backfillWindowDays: days, // drives forward window on every subsequent sync
+        metadata: {
+          ...existingMetadata,
+          backfillStartDate: backfillStartDate.toISOString(),
+          backfillCompletedAt: null,
+          backfillWindowDays: days, // drives forward window on every subsequent sync
+        },
       },
     });
 

--- a/src/app/api/calendar/callback/route.ts
+++ b/src/app/api/calendar/callback/route.ts
@@ -74,6 +74,16 @@ export async function GET(request: NextRequest) {
     const encryptedAccessToken = encrypt(tokens.accessToken);
     const encryptedRefreshToken = encrypt(tokens.refreshToken);
 
+    // On reconnect, fetch any existing metadata so we don't blow away the
+    // user's previous backfill settings, sync direction, reminder preferences,
+    // etc. Only the OAuth fields (tokens, expiry, accountEmail, status) get
+    // overwritten; calendar settings persist across reconnect.
+    const existing = await prisma.userIntegration.findUnique({
+      where: { userId_service: { userId: user.id, service: "google_calendar" } },
+      select: { metadata: true },
+    });
+    const existingMetadata = (existing?.metadata ?? {}) as Record<string, unknown>;
+
     await prisma.userIntegration.upsert({
       where: { userId_service: { userId: user.id, service: "google_calendar" } },
       update: {
@@ -81,7 +91,10 @@ export async function GET(request: NextRequest) {
         accessToken: encryptedAccessToken,
         refreshToken: encryptedRefreshToken,
         tokenExpiresAt: tokens.expiresAt,
-        metadata: { companyDomain },
+        // Preserve existing metadata (backfill state, sync prefs); update companyDomain
+        // in case the user's email domain changed (e.g. they reconnected with a
+        // different account).
+        metadata: { ...existingMetadata, companyDomain },
         status: "connected",
         syncEnabled: true,
       },
@@ -93,34 +106,6 @@ export async function GET(request: NextRequest) {
         refreshToken: encryptedRefreshToken,
         tokenExpiresAt: tokens.expiresAt,
         metadata: { companyDomain },
-        status: "connected",
-        syncEnabled: true,
-      },
-    });
-
-    // Upsert the CalendarConnection row — the sync engine reads connection-level
-    // fields (syncDirection, companyDomain, backfillStartDate, etc.) from this
-    // table. Without this upsert, first-time users hit "No calendar connection
-    // found" on sync. On create, backfillStartDate and backfillCompletedAt are
-    // left NULL; the wizard sets them when the user picks a window.
-    await prisma.calendarConnection.upsert({
-      where: { userId: user.id },
-      update: {
-        googleAccountEmail: tokens.email,
-        accessToken: encryptedAccessToken,
-        refreshToken: encryptedRefreshToken,
-        tokenExpiresAt: tokens.expiresAt,
-        companyDomain,
-        status: "connected",
-        syncEnabled: true,
-      },
-      create: {
-        userId: user.id,
-        googleAccountEmail: tokens.email,
-        accessToken: encryptedAccessToken,
-        refreshToken: encryptedRefreshToken,
-        tokenExpiresAt: tokens.expiresAt,
-        companyDomain,
         status: "connected",
         syncEnabled: true,
       },

--- a/src/app/api/calendar/disconnect/route.ts
+++ b/src/app/api/calendar/disconnect/route.ts
@@ -1,7 +1,6 @@
 // POST /api/calendar/disconnect — Removes the Google Calendar connection
-// Deletes the stored tokens, the calendar connection record, and pending
-// calendar events. Does NOT delete activities that were already created
-// from calendar events.
+// Deletes the stored tokens and pending calendar events. Does NOT delete
+// activities that were already created from calendar events.
 
 import { NextResponse } from "next/server";
 import { getUser } from "@/lib/supabase/server";
@@ -16,18 +15,11 @@ export async function POST() {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    // Find either half of the connection (UserIntegration or CalendarConnection).
-    // If neither exists, there's nothing to disconnect.
-    const [integration, calendarConnection] = await Promise.all([
-      prisma.userIntegration.findUnique({
-        where: { userId_service: { userId: user.id, service: "google_calendar" } },
-      }),
-      prisma.calendarConnection.findUnique({
-        where: { userId: user.id },
-      }),
-    ]);
+    const integration = await prisma.userIntegration.findUnique({
+      where: { userId_service: { userId: user.id, service: "google_calendar" } },
+    });
 
-    if (!integration && !calendarConnection) {
+    if (!integration) {
       return NextResponse.json(
         { error: "No calendar connection found" },
         { status: 404 }
@@ -38,8 +30,8 @@ export async function POST() {
     // triage decisions survive a disconnect→reconnect cycle. The sync engine
     // dedupes by (userId, googleEventId) and will skip any event the user
     // already handled — but only if the row still exists. Detach them from
-    // the connection (set connection_id = NULL) so the CASCADE DELETE on
-    // CalendarConnection doesn't destroy them.
+    // the integration (set connection_id = NULL) so the CASCADE DELETE on
+    // UserIntegration doesn't destroy them.
     //
     // Pending rows are throwaway — delete them outright.
     await prisma.$transaction([
@@ -52,19 +44,12 @@ export async function POST() {
       prisma.calendarEvent.deleteMany({
         where: { userId: user.id, status: "pending" },
       }),
-      // 3. Delete the connection (cascade now only hits rows still linked — none)
-      ...(calendarConnection
-        ? [prisma.calendarConnection.delete({ where: { userId: user.id } })]
-        : []),
-      ...(integration
-        ? [
-            prisma.userIntegration.delete({
-              where: {
-                userId_service: { userId: user.id, service: "google_calendar" },
-              },
-            }),
-          ]
-        : []),
+      // 3. Delete the integration (cascade now only hits rows still linked — none)
+      prisma.userIntegration.delete({
+        where: {
+          userId_service: { userId: user.id, service: "google_calendar" },
+        },
+      }),
     ]);
 
     return NextResponse.json({ success: true });

--- a/src/app/api/calendar/status/route.ts
+++ b/src/app/api/calendar/status/route.ts
@@ -1,5 +1,9 @@
 // GET /api/calendar/status — Returns the current calendar connection status
 // Used by the UI to show "Connected as jane@gmail.com" or "Connect Calendar" CTA
+//
+// All calendar settings (companyDomain, syncDirection, syncedActivityTypes,
+// reminderMinutes, secondReminderMinutes, backfillStartDate, backfillCompletedAt,
+// backfillWindowDays) are stored in user_integrations.metadata as JSON.
 
 import { NextResponse } from "next/server";
 import { getUser } from "@/lib/supabase/server";
@@ -8,6 +12,21 @@ import { ALL_ACTIVITY_TYPES } from "@/features/activities/types";
 
 const VALID_SYNC_DIRECTIONS = ["one_way", "two_way"] as const;
 const VALID_REMINDER_MINUTES = [0, 5, 10, 15, 30, 60, 1440] as const;
+
+type CalendarMetadata = {
+  companyDomain?: string;
+  syncDirection?: string;
+  syncedActivityTypes?: string[];
+  reminderMinutes?: number;
+  secondReminderMinutes?: number | null;
+  backfillStartDate?: string | null;
+  backfillCompletedAt?: string | null;
+  backfillWindowDays?: number | null;
+};
+
+function getCalendarMetadata(integration: { metadata: unknown }): CalendarMetadata {
+  return (integration.metadata ?? {}) as CalendarMetadata;
+}
 
 export const dynamic = "force-dynamic";
 
@@ -18,29 +37,24 @@ export async function GET() {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const connection = await prisma.calendarConnection.findUnique({
-      where: { userId: user.id },
+    const integration = await prisma.userIntegration.findUnique({
+      where: { userId_service: { userId: user.id, service: "google_calendar" } },
       select: {
         id: true,
-        googleAccountEmail: true,
-        companyDomain: true,
+        accountEmail: true,
         syncEnabled: true,
         lastSyncAt: true,
         status: true,
-        syncDirection: true,
-        syncedActivityTypes: true,
-        reminderMinutes: true,
-        secondReminderMinutes: true,
         createdAt: true,
-        backfillStartDate: true,
-        backfillCompletedAt: true,
-        backfillWindowDays: true,
+        metadata: true,
       },
     });
 
-    if (!connection) {
+    if (!integration) {
       return NextResponse.json({ connected: false, connection: null });
     }
+
+    const meta = getCalendarMetadata(integration);
 
     // Also get the count of pending calendar events for badge display
     const pendingCount = await prisma.calendarEvent.count({
@@ -53,20 +67,20 @@ export async function GET() {
     return NextResponse.json({
       connected: true,
       connection: {
-        id: connection.id,
-        googleAccountEmail: connection.googleAccountEmail,
-        companyDomain: connection.companyDomain,
-        syncEnabled: connection.syncEnabled,
-        lastSyncAt: connection.lastSyncAt?.toISOString() || null,
-        status: connection.status,
-        syncDirection: connection.syncDirection,
-        syncedActivityTypes: connection.syncedActivityTypes,
-        reminderMinutes: connection.reminderMinutes,
-        secondReminderMinutes: connection.secondReminderMinutes,
-        createdAt: connection.createdAt.toISOString(),
-        backfillStartDate: connection.backfillStartDate?.toISOString() || null,
-        backfillCompletedAt: connection.backfillCompletedAt?.toISOString() || null,
-        backfillWindowDays: connection.backfillWindowDays,
+        id: integration.id,
+        googleAccountEmail: integration.accountEmail ?? "",
+        companyDomain: meta.companyDomain ?? "",
+        syncEnabled: integration.syncEnabled,
+        lastSyncAt: integration.lastSyncAt?.toISOString() || null,
+        status: integration.status,
+        syncDirection: meta.syncDirection ?? "two_way",
+        syncedActivityTypes: meta.syncedActivityTypes ?? [],
+        reminderMinutes: meta.reminderMinutes ?? 15,
+        secondReminderMinutes: meta.secondReminderMinutes ?? null,
+        createdAt: integration.createdAt.toISOString(),
+        backfillStartDate: meta.backfillStartDate ?? null,
+        backfillCompletedAt: meta.backfillCompletedAt ?? null,
+        backfillWindowDays: meta.backfillWindowDays ?? null,
       },
       pendingCount,
     });
@@ -91,8 +105,9 @@ export async function PATCH(request: Request) {
     const body = await request.json();
     const { syncEnabled, companyDomain, syncDirection, syncedActivityTypes, reminderMinutes, secondReminderMinutes } = body;
 
-    const existing = await prisma.calendarConnection.findUnique({
-      where: { userId: user.id },
+    const existing = await prisma.userIntegration.findUnique({
+      where: { userId_service: { userId: user.id, service: "google_calendar" } },
+      select: { id: true, metadata: true },
     });
 
     if (!existing) {
@@ -102,9 +117,12 @@ export async function PATCH(request: Request) {
       );
     }
 
-    const updateData: Record<string, unknown> = {};
-    if (typeof syncEnabled === "boolean") updateData.syncEnabled = syncEnabled;
-    if (typeof companyDomain === "string") updateData.companyDomain = companyDomain;
+    const existingMeta = getCalendarMetadata(existing);
+    const updatedMeta: CalendarMetadata = { ...existingMeta };
+
+    const integrationUpdate: Record<string, unknown> = {};
+    if (typeof syncEnabled === "boolean") integrationUpdate.syncEnabled = syncEnabled;
+    if (typeof companyDomain === "string") updatedMeta.companyDomain = companyDomain;
 
     // Sync direction validation
     if (syncDirection !== undefined) {
@@ -114,7 +132,7 @@ export async function PATCH(request: Request) {
           { status: 400 }
         );
       }
-      updateData.syncDirection = syncDirection;
+      updatedMeta.syncDirection = syncDirection;
     }
 
     // Synced activity types validation
@@ -125,7 +143,7 @@ export async function PATCH(request: Request) {
           { status: 400 }
         );
       }
-      updateData.syncedActivityTypes = syncedActivityTypes;
+      updatedMeta.syncedActivityTypes = syncedActivityTypes;
     }
 
     // Reminder minutes validation
@@ -136,7 +154,7 @@ export async function PATCH(request: Request) {
           { status: 400 }
         );
       }
-      updateData.reminderMinutes = reminderMinutes;
+      updatedMeta.reminderMinutes = reminderMinutes;
     }
 
     // Second reminder validation
@@ -147,44 +165,50 @@ export async function PATCH(request: Request) {
           { status: 400 }
         );
       }
-      if (secondReminderMinutes !== null && secondReminderMinutes === (updateData.reminderMinutes ?? existing.reminderMinutes)) {
+      const effectiveReminder = updatedMeta.reminderMinutes ?? existingMeta.reminderMinutes ?? 15;
+      if (secondReminderMinutes !== null && secondReminderMinutes === effectiveReminder) {
         return NextResponse.json(
           { error: "secondReminderMinutes must differ from reminderMinutes" },
           { status: 400 }
         );
       }
-      updateData.secondReminderMinutes = secondReminderMinutes;
+      updatedMeta.secondReminderMinutes = secondReminderMinutes;
     }
 
-    const updated = await prisma.calendarConnection.update({
-      where: { userId: user.id },
-      data: updateData,
+    integrationUpdate.metadata = updatedMeta;
+
+    const updated = await prisma.userIntegration.update({
+      where: { userId_service: { userId: user.id, service: "google_calendar" } },
+      data: integrationUpdate,
       select: {
         id: true,
-        googleAccountEmail: true,
-        companyDomain: true,
+        accountEmail: true,
         syncEnabled: true,
         lastSyncAt: true,
         status: true,
-        syncDirection: true,
-        syncedActivityTypes: true,
-        reminderMinutes: true,
-        secondReminderMinutes: true,
         createdAt: true,
-        backfillStartDate: true,
-        backfillCompletedAt: true,
-        backfillWindowDays: true,
+        metadata: true,
       },
     });
 
+    const updatedFinalMeta = getCalendarMetadata(updated);
+
     return NextResponse.json({
       connection: {
-        ...updated,
+        id: updated.id,
+        googleAccountEmail: updated.accountEmail ?? "",
+        companyDomain: updatedFinalMeta.companyDomain ?? "",
+        syncEnabled: updated.syncEnabled,
         lastSyncAt: updated.lastSyncAt?.toISOString() || null,
+        status: updated.status,
+        syncDirection: updatedFinalMeta.syncDirection ?? "two_way",
+        syncedActivityTypes: updatedFinalMeta.syncedActivityTypes ?? [],
+        reminderMinutes: updatedFinalMeta.reminderMinutes ?? 15,
+        secondReminderMinutes: updatedFinalMeta.secondReminderMinutes ?? null,
         createdAt: updated.createdAt.toISOString(),
-        backfillStartDate: updated.backfillStartDate?.toISOString() || null,
-        backfillCompletedAt: updated.backfillCompletedAt?.toISOString() || null,
-        backfillWindowDays: updated.backfillWindowDays,
+        backfillStartDate: updatedFinalMeta.backfillStartDate ?? null,
+        backfillCompletedAt: updatedFinalMeta.backfillCompletedAt ?? null,
+        backfillWindowDays: updatedFinalMeta.backfillWindowDays ?? null,
       },
     });
   } catch (error) {

--- a/src/features/calendar/lib/__tests__/sync.test.ts
+++ b/src/features/calendar/lib/__tests__/sync.test.ts
@@ -10,10 +10,6 @@ vi.mock("@/lib/prisma", () => {
         findUnique: vi.fn(),
         update: vi.fn(),
       },
-      calendarConnection: {
-        findUnique: vi.fn(),
-        update: vi.fn(),
-      },
       calendarEvent: {
         findUnique: vi.fn(),
         findFirst: vi.fn(),
@@ -63,9 +59,47 @@ const USER_ID = "user-123";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
-function makeIntegration(overrides: Record<string, unknown> = {}) {
+interface CalendarMetaOverrides {
+  companyDomain?: string;
+  syncDirection?: "one_way" | "two_way";
+  syncedActivityTypes?: string[];
+  reminderMinutes?: number;
+  secondReminderMinutes?: number | null;
+  backfillStartDate?: Date | string | null;
+  backfillCompletedAt?: Date | string | null;
+  backfillWindowDays?: number | null;
+}
+
+interface IntegrationOverrides {
+  id?: string;
+  lastSyncAt?: Date | null;
+  metadata?: CalendarMetaOverrides;
+}
+
+function makeIntegration(overrides: IntegrationOverrides = {}) {
+  const meta: CalendarMetaOverrides = {
+    companyDomain: "fullmindlearning.com",
+    syncDirection: "two_way",
+    syncedActivityTypes: [],
+    reminderMinutes: 15,
+    secondReminderMinutes: null,
+    backfillStartDate: null,
+    backfillCompletedAt: null,
+    backfillWindowDays: null,
+    ...overrides.metadata,
+  };
+  // Date fields in the metadata JSON are stored as ISO strings (because JSON
+  // can't represent Date directly). The sync code reads them via new Date(...)
+  // so the test fixtures should mirror that storage shape.
+  if (meta.backfillStartDate instanceof Date) {
+    meta.backfillStartDate = meta.backfillStartDate.toISOString();
+  }
+  if (meta.backfillCompletedAt instanceof Date) {
+    meta.backfillCompletedAt = meta.backfillCompletedAt.toISOString();
+  }
+
   return {
-    id: "int-1",
+    id: overrides.id ?? "int-1",
     userId: USER_ID,
     service: "google_calendar",
     accountEmail: "rep@fullmindlearning.com",
@@ -74,36 +108,10 @@ function makeIntegration(overrides: Record<string, unknown> = {}) {
     refreshToken: "enc-refresh",
     tokenExpiresAt: new Date(Date.now() + 3_600_000),
     scopes: [],
-    metadata: { companyDomain: "fullmindlearning.com" },
+    metadata: meta,
     syncEnabled: true,
     status: "connected",
-    lastSyncAt: null,
-    ...overrides,
-  };
-}
-
-function makeConnection(overrides: Record<string, unknown> = {}) {
-  return {
-    id: "conn-1",
-    userId: USER_ID,
-    googleAccountEmail: "rep@fullmindlearning.com",
-    accessToken: "enc-access",
-    refreshToken: "enc-refresh",
-    tokenExpiresAt: new Date(Date.now() + 3_600_000),
-    companyDomain: "fullmindlearning.com",
-    syncEnabled: true,
-    lastSyncAt: null as Date | null,
-    status: "connected",
-    syncDirection: "two_way",
-    syncedActivityTypes: [],
-    reminderMinutes: 15,
-    secondReminderMinutes: null,
-    backfillStartDate: null as Date | null,
-    backfillCompletedAt: null as Date | null,
-    backfillWindowDays: null as number | null,
-    createdAt: new Date(),
-    updatedAt: new Date(),
-    ...overrides,
+    lastSyncAt: overrides.lastSyncAt ?? null,
   };
 }
 
@@ -130,14 +138,11 @@ function makeGoogleEvent(id: string, overrides: Record<string, unknown> = {}) {
 }
 
 function primeValidSyncPath(
-  connection: ReturnType<typeof makeConnection>,
+  integration: ReturnType<typeof makeIntegration>,
   googleEvents: ReturnType<typeof makeGoogleEvent>[]
 ) {
   vi.mocked(prisma.userIntegration.findUnique).mockResolvedValue(
-    makeIntegration() as never
-  );
-  vi.mocked(prisma.calendarConnection.findUnique).mockResolvedValue(
-    connection as never
+    integration as never
   );
   vi.mocked(getValidAccessToken).mockResolvedValue({
     accessToken: "decrypted_enc-access",
@@ -169,7 +174,6 @@ function primeValidSyncPath(
   );
 
   vi.mocked(prisma.userIntegration.update).mockResolvedValue({} as never);
-  vi.mocked(prisma.calendarConnection.update).mockResolvedValue({} as never);
 }
 
 // ---------------------------------------------------------------------------
@@ -192,9 +196,11 @@ describe("syncCalendarEvents — window selection", () => {
   it("uses backfillStartDate as timeMin when backfill is pending", async () => {
     const backfillStart = new Date(NOW.getTime() - 30 * DAY_MS);
     primeValidSyncPath(
-      makeConnection({
-        backfillStartDate: backfillStart,
-        backfillCompletedAt: null,
+      makeIntegration({
+        metadata: {
+          backfillStartDate: backfillStart,
+          backfillCompletedAt: null,
+        },
         lastSyncAt: null,
       }),
       []
@@ -218,9 +224,11 @@ describe("syncCalendarEvents — window selection", () => {
     const lastSyncAt = new Date(NOW.getTime() - 1 * DAY_MS);
     const backfillStart = new Date(NOW.getTime() - 30 * DAY_MS);
     primeValidSyncPath(
-      makeConnection({
-        backfillStartDate: backfillStart,
-        backfillCompletedAt: new Date(NOW.getTime() - 1 * DAY_MS),
+      makeIntegration({
+        metadata: {
+          backfillStartDate: backfillStart,
+          backfillCompletedAt: new Date(NOW.getTime() - 1 * DAY_MS),
+        },
         lastSyncAt,
       }),
       []
@@ -237,9 +245,11 @@ describe("syncCalendarEvents — window selection", () => {
   it("uses lastSyncAt - 2d when there is no backfill at all", async () => {
     const lastSyncAt = new Date(NOW.getTime() - 1 * DAY_MS);
     primeValidSyncPath(
-      makeConnection({
-        backfillStartDate: null,
-        backfillCompletedAt: null,
+      makeIntegration({
+        metadata: {
+          backfillStartDate: null,
+          backfillCompletedAt: null,
+        },
         lastSyncAt,
       }),
       []
@@ -255,9 +265,11 @@ describe("syncCalendarEvents — window selection", () => {
 
   it("falls back to now - 7d when there is no backfill and no prior sync", async () => {
     primeValidSyncPath(
-      makeConnection({
-        backfillStartDate: null,
-        backfillCompletedAt: null,
+      makeIntegration({
+        metadata: {
+          backfillStartDate: null,
+          backfillCompletedAt: null,
+        },
         lastSyncAt: null,
       }),
       []
@@ -273,10 +285,12 @@ describe("syncCalendarEvents — window selection", () => {
 
   it("uses backfillWindowDays as the forward horizon (timeMax)", async () => {
     primeValidSyncPath(
-      makeConnection({
-        backfillStartDate: new Date(NOW.getTime() - 30 * DAY_MS),
-        backfillCompletedAt: null,
-        backfillWindowDays: 30,
+      makeIntegration({
+        metadata: {
+          backfillStartDate: new Date(NOW.getTime() - 30 * DAY_MS),
+          backfillCompletedAt: null,
+          backfillWindowDays: 30,
+        },
         lastSyncAt: null,
       }),
       []
@@ -293,10 +307,12 @@ describe("syncCalendarEvents — window selection", () => {
 
   it("falls back to 14-day forward window when backfillWindowDays is null", async () => {
     primeValidSyncPath(
-      makeConnection({
-        backfillStartDate: null,
-        backfillCompletedAt: null,
-        backfillWindowDays: null,
+      makeIntegration({
+        metadata: {
+          backfillStartDate: null,
+          backfillCompletedAt: null,
+          backfillWindowDays: null,
+        },
         lastSyncAt: null,
       }),
       []
@@ -322,7 +338,7 @@ describe("syncCalendarEvents — Activity dedupe", () => {
       makeGoogleEvent("evt-2"),
       makeGoogleEvent("evt-3"),
     ];
-    primeValidSyncPath(makeConnection(), events);
+    primeValidSyncPath(makeIntegration(), events);
     vi.mocked(prisma.activity.findMany).mockResolvedValue([
       { googleEventId: "evt-2" },
     ] as never);
@@ -349,7 +365,7 @@ describe("syncCalendarEvents — Activity dedupe", () => {
       makeGoogleEvent("evt-2"),
       makeGoogleEvent("evt-3"),
     ];
-    primeValidSyncPath(makeConnection(), events);
+    primeValidSyncPath(makeIntegration(), events);
     vi.mocked(prisma.activity.findMany).mockResolvedValue([] as never);
 
     const result = await syncCalendarEvents(USER_ID);
@@ -359,7 +375,7 @@ describe("syncCalendarEvents — Activity dedupe", () => {
   });
 
   it("skips the Activity dedupe query when Google returns no events", async () => {
-    primeValidSyncPath(makeConnection(), []);
+    primeValidSyncPath(makeIntegration(), []);
 
     const result = await syncCalendarEvents(USER_ID);
 
@@ -374,8 +390,8 @@ describe("syncCalendarEvents — lastSyncAt propagation", () => {
     vi.clearAllMocks();
   });
 
-  it("updates lastSyncAt on both UserIntegration and CalendarConnection", async () => {
-    primeValidSyncPath(makeConnection(), []);
+  it("updates lastSyncAt on the user_integrations row", async () => {
+    primeValidSyncPath(makeIntegration(), []);
     vi.mocked(prisma.activity.findMany).mockResolvedValue([] as never);
 
     await syncCalendarEvents(USER_ID);
@@ -386,24 +402,14 @@ describe("syncCalendarEvents — lastSyncAt propagation", () => {
         data: expect.objectContaining({ lastSyncAt: expect.any(Date) }),
       })
     );
-    expect(prisma.calendarConnection.update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { id: "conn-1" },
-        data: expect.objectContaining({ lastSyncAt: expect.any(Date) }),
-      })
-    );
 
-    const userIntegrationCall = vi
+    const lastSyncCall = vi
       .mocked(prisma.userIntegration.update)
       .mock.calls.find((call) => "lastSyncAt" in (call[0].data ?? {}));
-    const connectionCall = vi
-      .mocked(prisma.calendarConnection.update)
-      .mock.calls.find((call) => "lastSyncAt" in (call[0].data ?? {}));
 
-    const userTs = (userIntegrationCall?.[0].data as { lastSyncAt: Date })
-      .lastSyncAt;
-    const connTs = (connectionCall?.[0].data as { lastSyncAt: Date }).lastSyncAt;
-    expect(userTs.getTime()).toBe(connTs.getTime());
+    expect(lastSyncCall).toBeDefined();
+    const ts = (lastSyncCall![0].data as { lastSyncAt: Date }).lastSyncAt;
+    expect(ts).toBeInstanceOf(Date);
   });
 });
 
@@ -420,7 +426,7 @@ describe("syncCalendarEvents — dedupe against prior status", () => {
     // and happily stages a duplicate `pending` row — users reported their
     // dismissed meetings "popping back" in the Home feed.
     const events = [makeGoogleEvent("legacy-dismissed")];
-    primeValidSyncPath(makeConnection(), events);
+    primeValidSyncPath(makeIntegration(), events);
     vi.mocked(prisma.activity.findMany).mockResolvedValue([] as never);
 
     // The dedupe lookup must find the existing dismissed row by
@@ -445,13 +451,13 @@ describe("syncCalendarEvents — dedupe against prior status", () => {
     // missed it, or activity.googleEventId was cleared), we still shouldn't
     // revive it as pending.
     const events = [makeGoogleEvent("confirmed-elsewhere")];
-    primeValidSyncPath(makeConnection({ id: "conn-new" }), events);
+    primeValidSyncPath(makeIntegration({ id: "int-new" }), events);
     vi.mocked(prisma.activity.findMany).mockResolvedValue([] as never);
 
     vi.mocked(prisma.calendarEvent.findFirst).mockResolvedValue({
       id: "old-row",
       userId: USER_ID,
-      connectionId: "conn-old",
+      connectionId: "int-old",
       googleEventId: "confirmed-elsewhere",
       status: "confirmed",
     } as never);
@@ -469,10 +475,9 @@ describe("syncCalendarEvents — regression guards", () => {
 
   it("short-circuits for syncDirection === 'one_way' without fetching", async () => {
     vi.mocked(prisma.userIntegration.findUnique).mockResolvedValue(
-      makeIntegration() as never
-    );
-    vi.mocked(prisma.calendarConnection.findUnique).mockResolvedValue(
-      makeConnection({ syncDirection: "one_way" }) as never
+      makeIntegration({
+        metadata: { syncDirection: "one_way" },
+      }) as never
     );
 
     const result = await syncCalendarEvents(USER_ID);
@@ -481,7 +486,6 @@ describe("syncCalendarEvents — regression guards", () => {
     expect(prisma.activity.findMany).not.toHaveBeenCalled();
     expect(prisma.calendarEvent.create).not.toHaveBeenCalled();
     expect(prisma.userIntegration.update).not.toHaveBeenCalled();
-    expect(prisma.calendarConnection.update).not.toHaveBeenCalled();
     expect(result).toEqual({
       eventsProcessed: 0,
       newEvents: 0,

--- a/src/features/calendar/lib/sync.ts
+++ b/src/features/calendar/lib/sync.ts
@@ -186,7 +186,10 @@ export async function syncCalendarEvents(userId: string): Promise<SyncResult> {
     errors: [],
   };
 
-  // Step 1: Get the user's calendar integration and validate tokens
+  // Step 1: Get the user's calendar integration and validate tokens.
+  // All calendar settings (syncDirection, companyDomain, backfillStartDate,
+  // backfillCompletedAt, backfillWindowDays) live in metadata JSON on the
+  // single user_integrations row.
   const integration = await prisma.userIntegration.findUnique({
     where: { userId_service: { userId, service: "google_calendar" } },
   });
@@ -201,18 +204,16 @@ export async function syncCalendarEvents(userId: string): Promise<SyncResult> {
     return result;
   }
 
-  // Get the CalendarConnection for connection-specific fields (syncDirection, connectionId)
-  const calendarConnection = await prisma.calendarConnection.findUnique({
-    where: { userId },
-  });
-
-  if (!calendarConnection) {
-    result.errors.push("No calendar connection found");
-    return result;
-  }
+  const meta = (integration.metadata ?? {}) as {
+    companyDomain?: string;
+    syncDirection?: string;
+    backfillStartDate?: string | null;
+    backfillCompletedAt?: string | null;
+    backfillWindowDays?: number | null;
+  };
 
   // One-way = app→calendar only (push). Skip pull sync entirely.
-  if (calendarConnection.syncDirection === "one_way") {
+  if (meta.syncDirection === "one_way") {
     return result;
   }
 
@@ -257,18 +258,15 @@ export async function syncCalendarEvents(userId: string): Promise<SyncResult> {
   //     - Else if we have a prior sync → lastSyncAt minus a 2-day buffer (catches late updates)
   //     - Else → 7 days in the past (fallback preserves the old behavior for fresh connections)
   // - Legacy fallback: if backfillWindowDays is null (older connections), use the old 14-day forward.
-  const windowDays = calendarConnection.backfillWindowDays ?? 14;
+  const windowDays = meta.backfillWindowDays ?? 14;
   const timeMax = new Date();
   timeMax.setDate(timeMax.getDate() + windowDays);
 
   let timeMin: Date;
-  if (
-    calendarConnection.backfillStartDate &&
-    !calendarConnection.backfillCompletedAt
-  ) {
-    timeMin = new Date(calendarConnection.backfillStartDate);
-  } else if (calendarConnection.lastSyncAt) {
-    timeMin = new Date(calendarConnection.lastSyncAt);
+  if (meta.backfillStartDate && !meta.backfillCompletedAt) {
+    timeMin = new Date(meta.backfillStartDate);
+  } else if (integration.lastSyncAt) {
+    timeMin = new Date(integration.lastSyncAt);
     timeMin.setDate(timeMin.getDate() - 2);
   } else {
     timeMin = new Date();
@@ -290,7 +288,7 @@ export async function syncCalendarEvents(userId: string): Promise<SyncResult> {
 
   // Step 3: Process each event
   const syncTimestamp = new Date();
-  const companyDomain = (integration.metadata as Record<string, unknown>)?.companyDomain as string || "";
+  const companyDomain = meta.companyDomain ?? "";
 
   // Batch dedupe: events the user already logged manually (Activity.googleEventId is @unique)
   // should never be re-staged. Single batch query against the unique index keeps this cheap.
@@ -374,7 +372,7 @@ export async function syncCalendarEvents(userId: string): Promise<SyncResult> {
         await prisma.calendarEvent.create({
           data: {
             userId,
-            connectionId: calendarConnection.id,
+            connectionId: integration.id,
             googleEventId: event.id,
             title: event.summary,
             description: event.description,
@@ -422,15 +420,9 @@ export async function syncCalendarEvents(userId: string): Promise<SyncResult> {
     }
   }
 
-  // Step 5: Update the last sync timestamp on BOTH token store + connection
-  // The status route reads lastSyncAt from CalendarConnection; UserIntegration
-  // mirrors it so the shared integrations dashboard stays in sync too.
+  // Step 5: Update the last sync timestamp on the calendar integration.
   await prisma.userIntegration.update({
     where: { userId_service: { userId, service: "google_calendar" } },
-    data: { lastSyncAt: syncTimestamp },
-  });
-  await prisma.calendarConnection.update({
-    where: { id: calendarConnection.id },
     data: { lastSyncAt: syncTimestamp },
   });
 

--- a/src/lib/district-column-metadata.ts
+++ b/src/lib/district-column-metadata.ts
@@ -1,0 +1,1283 @@
+/**
+ * Column metadata registry for the districts table.
+ * Used by MCP tools, query builder, and explore grid to understand column semantics.
+ */
+
+export type ColumnDomain =
+  | "core"
+  | "crm"
+  | "finance"
+  | "poverty"
+  | "graduation"
+  | "staffing"
+  | "demographics"
+  | "absenteeism"
+  | "assessment"
+  | "sped"
+  | "esser"
+  | "tech_capital"
+  | "outsourcing"
+  | "trends"
+  | "benchmarks"
+  | "icp"
+  | "links"
+  | "user_edits";
+
+export type DataFormat =
+  | "text"
+  | "integer"
+  | "decimal"
+  | "currency"
+  | "percentage"
+  | "ratio"
+  | "boolean"
+  | "date"
+  | "year"
+  | "quartile";
+
+export type DataSource =
+  | "nces"
+  | "urban_institute"
+  | "fullmind_crm"
+  | "computed"
+  | "user"
+  | "govspend"
+  | "etl_link";
+
+export interface ColumnMetadata {
+  /** Prisma camelCase field name */
+  field: string;
+  /** Snake_case DB column name */
+  column: string;
+  /** Human-readable label for UI */
+  label: string;
+  /** One-line description for MCP tool context */
+  description: string;
+  /** Semantic domain grouping */
+  domain: ColumnDomain;
+  /** How to format/interpret the value */
+  format: DataFormat;
+  /** Where this data comes from */
+  source: DataSource;
+  /** Whether this column is useful for filtering/sorting in queries */
+  queryable: boolean;
+  /** The data_year column that tracks this field's freshness (if any) */
+  yearColumn?: string;
+}
+
+export const DISTRICT_COLUMNS: ColumnMetadata[] = [
+  // ===== Core District Info =====
+  {
+    field: "leaid",
+    column: "leaid",
+    label: "LEA ID",
+    description: "NCES Local Education Agency identifier (primary key, 7 chars)",
+    domain: "core",
+    format: "text",
+    source: "nces",
+    queryable: true,
+  },
+  {
+    field: "name",
+    column: "name",
+    label: "District Name",
+    description: "Official district name from NCES",
+    domain: "core",
+    format: "text",
+    source: "nces",
+    queryable: true,
+  },
+  {
+    field: "stateAbbrev",
+    column: "state_abbrev",
+    label: "State",
+    description: "Two-letter state abbreviation (e.g., CA, TX)",
+    domain: "core",
+    format: "text",
+    source: "nces",
+    queryable: true,
+  },
+  {
+    field: "stateFips",
+    column: "state_fips",
+    label: "State FIPS",
+    description: "Two-digit state FIPS code (e.g., 06 for California)",
+    domain: "core",
+    format: "text",
+    source: "nces",
+    queryable: true,
+  },
+  {
+    field: "enrollment",
+    column: "enrollment",
+    label: "Enrollment",
+    description: "Total student enrollment from CCD directory",
+    domain: "core",
+    format: "integer",
+    source: "nces",
+    queryable: true,
+  },
+  {
+    field: "lograde",
+    column: "lograde",
+    label: "Lowest Grade",
+    description: "Lowest grade served (PK, KG, 01-12)",
+    domain: "core",
+    format: "text",
+    source: "nces",
+    queryable: true,
+  },
+  {
+    field: "higrade",
+    column: "higrade",
+    label: "Highest Grade",
+    description: "Highest grade served (01-12)",
+    domain: "core",
+    format: "text",
+    source: "nces",
+    queryable: true,
+  },
+  {
+    field: "numberOfSchools",
+    column: "number_of_schools",
+    label: "Number of Schools",
+    description: "Count of schools in the district",
+    domain: "core",
+    format: "integer",
+    source: "nces",
+    queryable: true,
+  },
+  {
+    field: "urbanCentricLocale",
+    column: "urban_centric_locale",
+    label: "Locale Code",
+    description: "NCES urban-centric locale (11=Large City, 43=Remote Rural)",
+    domain: "core",
+    format: "integer",
+    source: "nces",
+    queryable: true,
+  },
+  {
+    field: "countyName",
+    column: "county_name",
+    label: "County",
+    description: "County name",
+    domain: "core",
+    format: "text",
+    source: "nces",
+    queryable: true,
+  },
+  {
+    field: "cityLocation",
+    column: "city_location",
+    label: "City",
+    description: "City of district office",
+    domain: "core",
+    format: "text",
+    source: "nces",
+    queryable: true,
+  },
+  {
+    field: "zipLocation",
+    column: "zip_location",
+    label: "ZIP Code",
+    description: "ZIP code of district office",
+    domain: "core",
+    format: "text",
+    source: "nces",
+    queryable: true,
+  },
+  {
+    field: "phone",
+    column: "phone",
+    label: "Phone",
+    description: "District main phone number",
+    domain: "core",
+    format: "text",
+    source: "nces",
+    queryable: false,
+  },
+  {
+    field: "accountType",
+    column: "account_type",
+    label: "Account Type",
+    description: "Entity type: district, cmo, esa, etc.",
+    domain: "core",
+    format: "text",
+    source: "fullmind_crm",
+    queryable: true,
+  },
+  {
+    field: "specEdStudents",
+    column: "spec_ed_students",
+    label: "Special Ed Students",
+    description: "Count of students with disabilities (SWD)",
+    domain: "core",
+    format: "integer",
+    source: "nces",
+    queryable: true,
+  },
+  {
+    field: "ellStudents",
+    column: "ell_students",
+    label: "ELL Students",
+    description: "Count of English Language Learners",
+    domain: "core",
+    format: "integer",
+    source: "nces",
+    queryable: true,
+  },
+
+  // ===== Fullmind CRM =====
+  {
+    field: "accountName",
+    column: "account_name",
+    label: "Account Name",
+    description: "CRM account name (may differ from NCES name)",
+    domain: "crm",
+    format: "text",
+    source: "fullmind_crm",
+    queryable: true,
+  },
+  {
+    field: "salesExecutiveId",
+    column: "sales_executive_id",
+    label: "Sales Executive",
+    description: "Assigned sales rep (FK to user_profiles.id) — join to UserProfile for name/email",
+    domain: "crm",
+    format: "text",
+    source: "fullmind_crm",
+    queryable: true,
+  },
+  {
+    field: "isCustomer",
+    column: "is_customer",
+    label: "Is Customer",
+    description: "Has current or past Fullmind revenue",
+    domain: "crm",
+    format: "boolean",
+    source: "fullmind_crm",
+    queryable: true,
+  },
+  {
+    field: "hasOpenPipeline",
+    column: "has_open_pipeline",
+    label: "Has Pipeline",
+    description: "Has open pipeline opportunities",
+    domain: "crm",
+    format: "boolean",
+    source: "fullmind_crm",
+    queryable: true,
+  },
+  {
+    field: "ownerId",
+    column: "owner_id",
+    label: "Owner",
+    description: "Assigned territory owner (FK to user_profiles.id) — join to UserProfile for name/email",
+    domain: "crm",
+    format: "text",
+    source: "user",
+    queryable: true,
+  },
+
+  // ===== Finance =====
+  {
+    field: "totalRevenue",
+    column: "total_revenue",
+    label: "Total Revenue",
+    description: "Total district revenue (federal + state + local)",
+    domain: "finance",
+    format: "currency",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "financeDataYear",
+  },
+  {
+    field: "federalRevenue",
+    column: "federal_revenue",
+    label: "Federal Revenue",
+    description: "Revenue from federal sources",
+    domain: "finance",
+    format: "currency",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "financeDataYear",
+  },
+  {
+    field: "stateRevenue",
+    column: "state_revenue",
+    label: "State Revenue",
+    description: "Revenue from state sources",
+    domain: "finance",
+    format: "currency",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "financeDataYear",
+  },
+  {
+    field: "localRevenue",
+    column: "local_revenue",
+    label: "Local Revenue",
+    description: "Revenue from local sources (property tax, etc.)",
+    domain: "finance",
+    format: "currency",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "financeDataYear",
+  },
+  {
+    field: "totalExpenditure",
+    column: "total_expenditure",
+    label: "Total Expenditure",
+    description: "Total district spending",
+    domain: "finance",
+    format: "currency",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "financeDataYear",
+  },
+  {
+    field: "expenditurePerPupil",
+    column: "expenditure_per_pupil",
+    label: "Per-Pupil Expenditure",
+    description: "Total expenditure divided by enrollment",
+    domain: "finance",
+    format: "currency",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "financeDataYear",
+  },
+  {
+    field: "titleIRevenue",
+    column: "title_i_revenue",
+    label: "Title I Revenue",
+    description: "Federal Title I funding received",
+    domain: "finance",
+    format: "currency",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "financeDataYear",
+  },
+
+  // ===== Poverty =====
+  {
+    field: "childrenPovertyCount",
+    column: "children_poverty_count",
+    label: "Children in Poverty",
+    description: "Number of children in poverty (SAIPE)",
+    domain: "poverty",
+    format: "integer",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "saipeDataYear",
+  },
+  {
+    field: "childrenPovertyPercent",
+    column: "children_poverty_percent",
+    label: "Poverty Rate",
+    description: "Percentage of children in poverty",
+    domain: "poverty",
+    format: "percentage",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "saipeDataYear",
+  },
+  {
+    field: "medianHouseholdIncome",
+    column: "median_household_income",
+    label: "Median Household Income",
+    description: "Area median household income",
+    domain: "poverty",
+    format: "currency",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "saipeDataYear",
+  },
+  {
+    field: "frplRate",
+    column: "frpl_rate",
+    label: "FRPL Rate",
+    description: "Free/reduced price lunch rate (proxy for poverty)",
+    domain: "poverty",
+    format: "percentage",
+    source: "urban_institute",
+    queryable: true,
+  },
+
+  // ===== Graduation =====
+  {
+    field: "graduationRateTotal",
+    column: "graduation_rate",
+    label: "Graduation Rate",
+    description: "Overall 4-year graduation rate",
+    domain: "graduation",
+    format: "percentage",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "graduationDataYear",
+  },
+
+  // ===== Staffing =====
+  {
+    field: "teachersFte",
+    column: "teachers_fte",
+    label: "Teachers FTE",
+    description: "Full-time equivalent teacher count",
+    domain: "staffing",
+    format: "decimal",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "staffDataYear",
+  },
+  {
+    field: "adminFte",
+    column: "admin_fte",
+    label: "Admin FTE",
+    description: "Full-time equivalent administrator count",
+    domain: "staffing",
+    format: "decimal",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "staffDataYear",
+  },
+  {
+    field: "guidanceCounselorsFte",
+    column: "guidance_counselors_fte",
+    label: "Counselors FTE",
+    description: "Full-time equivalent guidance counselor count",
+    domain: "staffing",
+    format: "decimal",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "staffDataYear",
+  },
+  {
+    field: "staffTotalFte",
+    column: "staff_total_fte",
+    label: "Total Staff FTE",
+    description: "Total full-time equivalent staff count",
+    domain: "staffing",
+    format: "decimal",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "staffDataYear",
+  },
+  {
+    field: "salariesTotal",
+    column: "salaries_total",
+    label: "Total Salaries",
+    description: "Total salary expenditure across all staff",
+    domain: "staffing",
+    format: "currency",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "staffDataYear",
+  },
+  {
+    field: "salariesInstruction",
+    column: "salaries_instruction",
+    label: "Instructional Salaries",
+    description: "Salary expenditure for instructional staff",
+    domain: "staffing",
+    format: "currency",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "staffDataYear",
+  },
+  {
+    field: "studentTeacherRatio",
+    column: "student_teacher_ratio",
+    label: "Student:Teacher Ratio",
+    description: "Enrollment / teachers FTE — higher = more understaffed",
+    domain: "staffing",
+    format: "ratio",
+    source: "computed",
+    queryable: true,
+  },
+  {
+    field: "studentStaffRatio",
+    column: "student_staff_ratio",
+    label: "Student:Staff Ratio",
+    description: "Enrollment / total staff FTE",
+    domain: "staffing",
+    format: "ratio",
+    source: "computed",
+    queryable: true,
+  },
+  {
+    field: "spedStudentTeacherRatio",
+    column: "sped_student_teacher_ratio",
+    label: "SpEd Student:Teacher Ratio",
+    description: "Special ed students / teachers FTE",
+    domain: "staffing",
+    format: "ratio",
+    source: "computed",
+    queryable: true,
+  },
+
+  // ===== Absenteeism =====
+  {
+    field: "chronicAbsenteeismCount",
+    column: "chronic_absenteeism_count",
+    label: "Chronic Absentees",
+    description: "Count of chronically absent students",
+    domain: "absenteeism",
+    format: "integer",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "absenteeismDataYear",
+  },
+  {
+    field: "chronicAbsenteeismRate",
+    column: "chronic_absenteeism_rate",
+    label: "Chronic Absenteeism Rate",
+    description: "Percentage of students chronically absent",
+    domain: "absenteeism",
+    format: "percentage",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "absenteeismDataYear",
+  },
+
+  // ===== Demographics =====
+  {
+    field: "enrollmentWhite",
+    column: "enrollment_white",
+    label: "White Enrollment",
+    description: "White student enrollment",
+    domain: "demographics",
+    format: "integer",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "demographicsDataYear",
+  },
+  {
+    field: "enrollmentBlack",
+    column: "enrollment_black",
+    label: "Black Enrollment",
+    description: "Black student enrollment",
+    domain: "demographics",
+    format: "integer",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "demographicsDataYear",
+  },
+  {
+    field: "enrollmentHispanic",
+    column: "enrollment_hispanic",
+    label: "Hispanic Enrollment",
+    description: "Hispanic student enrollment",
+    domain: "demographics",
+    format: "integer",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "demographicsDataYear",
+  },
+  {
+    field: "enrollmentAsian",
+    column: "enrollment_asian",
+    label: "Asian Enrollment",
+    description: "Asian student enrollment",
+    domain: "demographics",
+    format: "integer",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "demographicsDataYear",
+  },
+  {
+    field: "totalEnrollment",
+    column: "total_enrollment",
+    label: "Total Demographic Enrollment",
+    description: "Sum of all race/ethnicity enrollment (may differ from CCD enrollment)",
+    domain: "demographics",
+    format: "integer",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "demographicsDataYear",
+  },
+  {
+    field: "swdPct",
+    column: "swd_pct",
+    label: "SWD %",
+    description: "Students with disabilities as percentage of enrollment",
+    domain: "demographics",
+    format: "percentage",
+    source: "computed",
+    queryable: true,
+  },
+  {
+    field: "ellPct",
+    column: "ell_pct",
+    label: "ELL %",
+    description: "English Language Learners as percentage of enrollment",
+    domain: "demographics",
+    format: "percentage",
+    source: "computed",
+    queryable: true,
+  },
+
+  // ===== Assessments =====
+  {
+    field: "mathProficiencyPct",
+    column: "math_proficiency_pct",
+    label: "Math Proficiency",
+    description: "Percentage of students proficient in math",
+    domain: "assessment",
+    format: "percentage",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "assessmentDataYear",
+  },
+  {
+    field: "readProficiencyPct",
+    column: "read_proficiency_pct",
+    label: "Reading Proficiency",
+    description: "Percentage of students proficient in reading",
+    domain: "assessment",
+    format: "percentage",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "assessmentDataYear",
+  },
+
+  // ===== Special Education Finance =====
+  {
+    field: "spedExpenditureTotal",
+    column: "sped_expenditure_total",
+    label: "SpEd Total Expenditure",
+    description: "Total special education current expenditure",
+    domain: "sped",
+    format: "currency",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "financeDataYear",
+  },
+  {
+    field: "spedExpenditureInstruction",
+    column: "sped_expenditure_instruction",
+    label: "SpEd Instructional Spend",
+    description: "Special education instruction spending",
+    domain: "sped",
+    format: "currency",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "financeDataYear",
+  },
+  {
+    field: "spedExpenditurePerStudent",
+    column: "sped_expenditure_per_student",
+    label: "SpEd Per-Student Spend",
+    description: "Special ed expenditure / special ed student count",
+    domain: "sped",
+    format: "currency",
+    source: "computed",
+    queryable: true,
+  },
+
+  // ===== ESSER / COVID =====
+  {
+    field: "esserFundingTotal",
+    column: "esser_funding_total",
+    label: "ESSER Funding",
+    description: "Total ESSER COVID relief funding received",
+    domain: "esser",
+    format: "currency",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "financeDataYear",
+  },
+  {
+    field: "esserSpendingTotal",
+    column: "esser_spending_total",
+    label: "ESSER Spending",
+    description: "Total ESSER COVID relief spending",
+    domain: "esser",
+    format: "currency",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "financeDataYear",
+  },
+
+  // ===== Tech & Capital =====
+  {
+    field: "techSpending",
+    column: "tech_spending",
+    label: "Tech Spending",
+    description: "Technology supplies/services + equipment spending",
+    domain: "tech_capital",
+    format: "currency",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "financeDataYear",
+  },
+  {
+    field: "capitalOutlayTotal",
+    column: "capital_outlay_total",
+    label: "Capital Outlay",
+    description: "Total capital outlay expenditure",
+    domain: "tech_capital",
+    format: "currency",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "financeDataYear",
+  },
+  {
+    field: "debtOutstanding",
+    column: "debt_outstanding",
+    label: "Debt Outstanding",
+    description: "Long-term debt outstanding at end of fiscal year",
+    domain: "tech_capital",
+    format: "currency",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "financeDataYear",
+  },
+
+  // ===== Outsourcing Signals =====
+  {
+    field: "paymentsToCharterSchools",
+    column: "payments_to_charter_schools",
+    label: "Charter Payments",
+    description: "Payments to charter schools — proven outsourcing buyer signal",
+    domain: "outsourcing",
+    format: "currency",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "financeDataYear",
+  },
+  {
+    field: "paymentsToPrivateSchools",
+    column: "payments_to_private_schools",
+    label: "Private School Payments",
+    description: "Payments to private schools for services",
+    domain: "outsourcing",
+    format: "currency",
+    source: "urban_institute",
+    queryable: true,
+    yearColumn: "financeDataYear",
+  },
+  {
+    field: "charterSchoolCount",
+    column: "charter_school_count",
+    label: "Charter School Count",
+    description: "Number of charter schools in district boundaries",
+    domain: "outsourcing",
+    format: "integer",
+    source: "computed",
+    queryable: true,
+  },
+
+  // ===== Trend Signals =====
+  {
+    field: "enrollmentTrend3yr",
+    column: "enrollment_trend_3yr",
+    label: "Enrollment Trend (3yr)",
+    description: "Percent change in enrollment over 3 years",
+    domain: "trends",
+    format: "percentage",
+    source: "computed",
+    queryable: true,
+  },
+  {
+    field: "staffingTrend3yr",
+    column: "staffing_trend_3yr",
+    label: "Staffing Trend (3yr)",
+    description: "Percent change in teacher FTE over 3 years",
+    domain: "trends",
+    format: "percentage",
+    source: "computed",
+    queryable: true,
+  },
+  {
+    field: "vacancyPressureSignal",
+    column: "vacancy_pressure_signal",
+    label: "Vacancy Pressure",
+    description: "Enrollment trend minus staffing trend — positive = growing gap",
+    domain: "trends",
+    format: "ratio",
+    source: "computed",
+    queryable: true,
+  },
+  {
+    field: "swdTrend3yr",
+    column: "swd_trend_3yr",
+    label: "SWD Trend (3yr)",
+    description: "Percent change in special ed students over 3 years",
+    domain: "trends",
+    format: "percentage",
+    source: "computed",
+    queryable: true,
+  },
+  {
+    field: "ellTrend3yr",
+    column: "ell_trend_3yr",
+    label: "ELL Trend (3yr)",
+    description: "Percent change in ELL students over 3 years",
+    domain: "trends",
+    format: "percentage",
+    source: "computed",
+    queryable: true,
+  },
+  {
+    field: "graduationTrend3yr",
+    column: "graduation_trend_3yr",
+    label: "Graduation Trend (3yr)",
+    description: "Percent change in graduation rate over 3 years",
+    domain: "trends",
+    format: "percentage",
+    source: "computed",
+    queryable: true,
+  },
+  {
+    field: "absenteeismTrend3yr",
+    column: "absenteeism_trend_3yr",
+    label: "Absenteeism Trend (3yr)",
+    description: "Percent change in chronic absenteeism over 3 years",
+    domain: "trends",
+    format: "percentage",
+    source: "computed",
+    queryable: true,
+  },
+  {
+    field: "expenditurePpTrend3yr",
+    column: "expenditure_pp_trend_3yr",
+    label: "Per-Pupil Spend Trend (3yr)",
+    description: "Percent change in per-pupil expenditure over 3 years",
+    domain: "trends",
+    format: "percentage",
+    source: "computed",
+    queryable: true,
+  },
+
+  // ===== State Benchmarks =====
+  {
+    field: "absenteeismVsState",
+    column: "absenteeism_vs_state",
+    label: "Absenteeism vs State Avg",
+    description: "District absenteeism rate minus state average (positive = worse)",
+    domain: "benchmarks",
+    format: "percentage",
+    source: "computed",
+    queryable: true,
+  },
+  {
+    field: "graduationVsState",
+    column: "graduation_vs_state",
+    label: "Graduation vs State Avg",
+    description: "District graduation rate minus state average (positive = better)",
+    domain: "benchmarks",
+    format: "percentage",
+    source: "computed",
+    queryable: true,
+  },
+  {
+    field: "studentTeacherRatioVsState",
+    column: "student_teacher_ratio_vs_state",
+    label: "ST Ratio vs State Avg",
+    description: "District student:teacher ratio minus state average (positive = more understaffed)",
+    domain: "benchmarks",
+    format: "ratio",
+    source: "computed",
+    queryable: true,
+  },
+  {
+    field: "expenditurePpVsState",
+    column: "expenditure_pp_vs_state",
+    label: "Per-Pupil Spend vs State Avg",
+    description: "District per-pupil expenditure minus state average",
+    domain: "benchmarks",
+    format: "currency",
+    source: "computed",
+    queryable: true,
+  },
+
+  // ===== Quartile Flags =====
+  {
+    field: "absenteeismQuartileState",
+    column: "absenteeism_quartile_state",
+    label: "Absenteeism Quartile",
+    description: "Within-state quartile: well_above, above, below, well_below",
+    domain: "benchmarks",
+    format: "quartile",
+    source: "computed",
+    queryable: true,
+  },
+  {
+    field: "graduationQuartileState",
+    column: "graduation_quartile_state",
+    label: "Graduation Quartile",
+    description: "Within-state quartile: well_above, above, below, well_below",
+    domain: "benchmarks",
+    format: "quartile",
+    source: "computed",
+    queryable: true,
+  },
+  {
+    field: "studentTeacherRatioQuartileState",
+    column: "student_teacher_ratio_quartile_state",
+    label: "ST Ratio Quartile",
+    description: "Within-state quartile: well_above, above, below, well_below",
+    domain: "benchmarks",
+    format: "quartile",
+    source: "computed",
+    queryable: true,
+  },
+  {
+    field: "expenditurePpQuartileState",
+    column: "expenditure_pp_quartile_state",
+    label: "Per-Pupil Spend Quartile",
+    description: "Within-state quartile: well_above, above, below, well_below",
+    domain: "benchmarks",
+    format: "quartile",
+    source: "computed",
+    queryable: true,
+  },
+
+  // ===== ICP Scoring =====
+  {
+    field: "icpCompositeScore",
+    column: "icp_composite_score",
+    label: "ICP Score",
+    description: "Composite Ideal Customer Profile score (0-100)",
+    domain: "icp",
+    format: "integer",
+    source: "computed",
+    queryable: true,
+  },
+  {
+    field: "icpTier",
+    column: "icp_tier",
+    label: "ICP Tier",
+    description: "ICP tier classification: T1, T2, T3, T4",
+    domain: "icp",
+    format: "text",
+    source: "computed",
+    queryable: true,
+  },
+  {
+    field: "icpFitScore",
+    column: "icp_fit_score",
+    label: "ICP Fit Score",
+    description: "How well district profile matches ideal customer",
+    domain: "icp",
+    format: "integer",
+    source: "computed",
+    queryable: true,
+  },
+  {
+    field: "icpValueScore",
+    column: "icp_value_score",
+    label: "ICP Value Score",
+    description: "Estimated revenue potential",
+    domain: "icp",
+    format: "integer",
+    source: "computed",
+    queryable: true,
+  },
+  {
+    field: "icpReadinessScore",
+    column: "icp_readiness_score",
+    label: "ICP Readiness Score",
+    description: "Signals of buying readiness (outsourcing, budget, etc.)",
+    domain: "icp",
+    format: "integer",
+    source: "computed",
+    queryable: true,
+  },
+
+  // ===== Links =====
+  {
+    field: "websiteUrl",
+    column: "website_url",
+    label: "Website",
+    description: "District website URL",
+    domain: "links",
+    format: "text",
+    source: "etl_link",
+    queryable: false,
+  },
+  {
+    field: "jobBoardUrl",
+    column: "job_board_url",
+    label: "Job Board URL",
+    description: "District job board URL for vacancy scanning",
+    domain: "links",
+    format: "text",
+    source: "etl_link",
+    queryable: false,
+  },
+
+  // ===== Title I =====
+  {
+    field: "titleISchoolCount",
+    column: "title_i_school_count",
+    label: "Title I Schools",
+    description: "Number of Title I eligible schools",
+    domain: "finance",
+    format: "integer",
+    source: "urban_institute",
+    queryable: true,
+  },
+  {
+    field: "titleISchoolwideCount",
+    column: "title_i_schoolwide_count",
+    label: "Title I Schoolwide",
+    description: "Number of Title I schoolwide program schools",
+    domain: "finance",
+    format: "integer",
+    source: "urban_institute",
+    queryable: true,
+  },
+
+  // ===== User Edits =====
+  {
+    field: "notes",
+    column: "notes",
+    label: "Notes",
+    description: "Free-form notes from sales team",
+    domain: "user_edits",
+    format: "text",
+    source: "user",
+    queryable: false,
+  },
+];
+
+/** Lookup helpers */
+export const COLUMN_BY_FIELD = new Map(
+  DISTRICT_COLUMNS.map((c) => [c.field, c])
+);
+export const COLUMN_BY_DB_NAME = new Map(
+  DISTRICT_COLUMNS.map((c) => [c.column, c])
+);
+export const COLUMNS_BY_DOMAIN = DISTRICT_COLUMNS.reduce(
+  (acc, col) => {
+    (acc[col.domain] ??= []).push(col);
+    return acc;
+  },
+  {} as Record<ColumnDomain, ColumnMetadata[]>
+);
+export const QUERYABLE_COLUMNS = DISTRICT_COLUMNS.filter((c) => c.queryable);
+
+// ============================================================================
+// district_financials registry
+// ============================================================================
+//
+// Normalized financial metrics across all vendors (Fullmind + competitors).
+// One row per (leaid, vendor, fiscal_year). Vendor is one of: 'fullmind',
+// 'elevate', 'proximity', 'tbt'.
+//
+// IMPORTANT: fiscal_year is stored as 'FY26', 'FY27' (with the 'FY' prefix),
+// NOT bare '26'/'27'. MCP tools and queries must use the prefixed format.
+
+export const DISTRICT_FINANCIALS_COLUMNS: ColumnMetadata[] = [
+  {
+    field: "leaid",
+    column: "leaid",
+    label: "LEA ID",
+    description: "FK to districts.leaid (nullable for unmatched accounts)",
+    domain: "core",
+    format: "text",
+    source: "fullmind_crm",
+    queryable: true,
+  },
+  {
+    field: "vendor",
+    column: "vendor",
+    label: "Vendor",
+    description: "Vendor identifier — one of: fullmind, elevate, proximity, tbt",
+    domain: "crm",
+    format: "text",
+    source: "fullmind_crm",
+    queryable: true,
+  },
+  {
+    field: "fiscalYear",
+    column: "fiscal_year",
+    label: "Fiscal Year",
+    description: "Fiscal year stored with 'FY' prefix (e.g. 'FY26', 'FY27')",
+    domain: "crm",
+    format: "text",
+    source: "fullmind_crm",
+    queryable: true,
+  },
+  {
+    field: "openPipeline",
+    column: "open_pipeline",
+    label: "Open Pipeline",
+    description: "Total value of open opportunities not yet closed",
+    domain: "crm",
+    format: "currency",
+    source: "fullmind_crm",
+    queryable: true,
+  },
+  {
+    field: "weightedPipeline",
+    column: "weighted_pipeline",
+    label: "Weighted Pipeline",
+    description: "Pipeline value weighted by stage probability",
+    domain: "crm",
+    format: "currency",
+    source: "fullmind_crm",
+    queryable: true,
+  },
+  {
+    field: "openPipelineOppCount",
+    column: "open_pipeline_opp_count",
+    label: "Open Pipeline Opp Count",
+    description: "Number of open opportunities",
+    domain: "crm",
+    format: "integer",
+    source: "fullmind_crm",
+    queryable: true,
+  },
+  {
+    field: "closedWonBookings",
+    column: "closed_won_bookings",
+    label: "Closed Won Bookings",
+    description: "Total value of closed-won opportunities (net booking)",
+    domain: "crm",
+    format: "currency",
+    source: "fullmind_crm",
+    queryable: true,
+  },
+  {
+    field: "closedWonOppCount",
+    column: "closed_won_opp_count",
+    label: "Closed Won Opp Count",
+    description: "Number of closed-won opportunities",
+    domain: "crm",
+    format: "integer",
+    source: "fullmind_crm",
+    queryable: true,
+  },
+  {
+    field: "invoicing",
+    column: "invoicing",
+    label: "Net Invoicing",
+    description: "Total invoiced amount (net of credits)",
+    domain: "crm",
+    format: "currency",
+    source: "fullmind_crm",
+    queryable: true,
+  },
+  {
+    field: "scheduledRevenue",
+    column: "scheduled_revenue",
+    label: "Scheduled Revenue",
+    description: "Revenue from scheduled but not yet completed sessions",
+    domain: "crm",
+    format: "currency",
+    source: "fullmind_crm",
+    queryable: true,
+  },
+  {
+    field: "completedRevenue",
+    column: "completed_revenue",
+    label: "Completed Revenue",
+    description: "Revenue from completed (delivered) sessions",
+    domain: "crm",
+    format: "currency",
+    source: "fullmind_crm",
+    queryable: true,
+  },
+  {
+    field: "deferredRevenue",
+    column: "deferred_revenue",
+    label: "Deferred Revenue",
+    description: "Revenue invoiced but not yet recognized",
+    domain: "crm",
+    format: "currency",
+    source: "fullmind_crm",
+    queryable: true,
+  },
+  {
+    field: "totalRevenue",
+    column: "total_revenue",
+    label: "Total Revenue",
+    description: "Sum of completed + scheduled + deferred revenue",
+    domain: "crm",
+    format: "currency",
+    source: "fullmind_crm",
+    queryable: true,
+  },
+  {
+    field: "scheduledTake",
+    column: "scheduled_take",
+    label: "Scheduled Take",
+    description: "Fullmind margin on scheduled sessions",
+    domain: "crm",
+    format: "currency",
+    source: "fullmind_crm",
+    queryable: true,
+  },
+  {
+    field: "completedTake",
+    column: "completed_take",
+    label: "Completed Take",
+    description: "Fullmind margin on completed sessions",
+    domain: "crm",
+    format: "currency",
+    source: "fullmind_crm",
+    queryable: true,
+  },
+  {
+    field: "totalTake",
+    column: "total_take",
+    label: "Total Take",
+    description: "Sum of completed + scheduled take (Fullmind margin)",
+    domain: "crm",
+    format: "currency",
+    source: "fullmind_crm",
+    queryable: true,
+  },
+  {
+    field: "sessionCount",
+    column: "session_count",
+    label: "Session Count",
+    description: "Total number of sessions delivered",
+    domain: "crm",
+    format: "integer",
+    source: "fullmind_crm",
+    queryable: true,
+  },
+  {
+    field: "poCount",
+    column: "po_count",
+    label: "PO Count",
+    description: "Number of purchase orders (used for competitor vendors via GovSpend data)",
+    domain: "outsourcing",
+    format: "integer",
+    source: "govspend",
+    queryable: true,
+  },
+  {
+    field: "unmatchedAccountId",
+    column: "unmatched_account_id",
+    label: "Unmatched Account ID",
+    description: "FK to unmatched_accounts for financial data not tied to a district",
+    domain: "crm",
+    format: "integer",
+    source: "fullmind_crm",
+    queryable: false,
+  },
+];
+
+export const FINANCIALS_COLUMN_BY_FIELD = new Map(
+  DISTRICT_FINANCIALS_COLUMNS.map((c) => [c.field, c])
+);
+export const FINANCIALS_COLUMN_BY_DB_NAME = new Map(
+  DISTRICT_FINANCIALS_COLUMNS.map((c) => [c.column, c])
+);
+export const FINANCIALS_QUERYABLE_COLUMNS = DISTRICT_FINANCIALS_COLUMNS.filter(
+  (c) => c.queryable
+);
+
+/** Known vendor identifiers in district_financials.vendor */
+export const KNOWN_VENDORS = ["fullmind", "elevate", "proximity", "tbt"] as const;
+export type KnownVendor = (typeof KNOWN_VENDORS)[number];
+
+/** Format fiscal year string for queries — vendor_financials uses 'FY' prefix */
+export function formatFiscalYear(year: number | string): string {
+  const numStr = String(year).replace(/^FY/, "");
+  return `FY${numStr.padStart(2, "0")}`;
+}


### PR DESCRIPTION
## Summary

Completes the multi-phase database normalization that was started weeks ago, plus six MCP-tool prep additions on top.

**Status: migrations already applied to production as of 2026-04-11.** This PR ships the matching code changes. Merging will deploy code that the database already expects.

## What's in here

### Phases 1-4: Database normalization (134 commits)

Phased work that's been ongoing on this branch:

- **Phase 1**: Add normalized FK columns (`owner_id`, `sales_executive_id`) alongside the legacy string columns. Backfill from string names where matching succeeded.
- **Phase 2**: Migrate route reads from string columns to FK relations. Add `getFinancial()` shim for FY-agnostic financial data access.
- **Phase 3a**: Use `getFinancial()` everywhere. Delete `extractFullmindFinancials` shim. Drop dev connection pool sizes to fit Supabase pooler limits.
- **Phase 3b**: Drop deprecated FY columns (`fy25_*`, `fy26_*`, `fy27_*`) and person string columns (`owner`, `sales_executive`, `state_location`) from District, UnmatchedAccount, State, School models.
- **Phase 3c**: Rename `competitorSpend` → `competitors`, document ETL stop.
- **Phase 4**: Drop deprecated columns/tables, rename `vendor_financials` → `district_financials`, migrate ETL.

### MCP-prep additions (6 commits at the tip)

Six additions made on 2026-04-11 to set up for MCP tool building:

| # | Commit | What |
|---|---|---|
| 1 | \`60ced3aa\` | **Indexes + timestamps** — 4 new indexes (\`districts.icp_tier\`, \`districts.account_type\`, \`activities(type, start_date)\`, \`district_financials.fiscal_year\`). \`updatedAt\` columns on \`district_data_history\`, \`district_grade_enrollment\`, \`unmatched_accounts\` for incremental sync support. |
| 2 | \`7f85aa91\` | **Column metadata dictionary** — \`src/lib/district-column-metadata.ts\` with ~90 typed entries for districts columns + 18 for district_financials columns, organized by domain (finance, demographics, staffing, CRM, signals, trends, benchmarks, ICP). For MCP tool schema introspection. |
| 3 | \`365a7d9b\` | **Opportunity → District FK** — Adds proper Prisma relation. Cleans up 355 orphaned opportunity rows whose \`district_lea_id\` didn't reference an existing district. Changes \`district_lea_id\` from \`TEXT\` to \`VARCHAR(7)\`. Drops and recreates 5 dependent views (4 regular + \`district_opportunity_actuals\` matview). |
| 4 | \`6b5cfa32\` | **CalendarConnection migration** — Drops the legacy \`calendar_connections\` table. All calendar OAuth and settings now stored in \`user_integrations\` where \`service='google_calendar'\`, with calendar-specific settings (companyDomain, syncDirection, reminderMinutes, backfillStartDate, etc.) in \`metadata\` JSON. Re-points 12 existing calendar events from old → new connection IDs. Updates 9 consumer files + the sync engine + tests. API response shape unchanged. |
| 5 | \`5967dade\` | **Migration SQL fixes** — Discovered during the production apply. Adds the view drop/recreate to migration 3, fixes the constraint-drop ordering in migration 4. |
| 6 | \`186c5026\` | **Follow-up doc** — Documents the 95K orphaned sessions discovered during opportunity FK work. |

## Migrations applied to production

All three new migrations were applied to production tonight (2026-04-11) before this PR was opened:

| Migration | What |
|---|---|
| \`20260411_add_missing_indexes_and_timestamps\` | 8 statements: 4 indexes + 4 timestamp columns |
| \`20260411_add_opportunity_session_fk\` | 21 statements: orphan cleanup, view drop/recreate, column type change, FK constraint, matview refresh |
| \`20260411_drop_calendar_connections\` | 6 statements: data backfill, FK drop, connection_id remap, table drop, new FK |

Verification queries confirmed:
- 4/4 new indexes present
- All timestamp columns added
- 0 orphaned opportunities (was 355)
- All 12 calendar events still linked to a valid \`user_integrations\` row
- Both \`sierra.arcega@\` and \`melodie.blackwood@\` calendar metadata preserved (companyDomain, syncDirection, reminderMinutes, backfillCompletedAt, backfillWindowDays=90 for sierra)

## Deferred: Session → Opportunity FK

The original plan included a \`Session.opportunity_id → Opportunity.id\` foreign key. Production check found **95,345 orphaned sessions (33% of all sessions)** whose opportunity_id values reference real Salesforce opportunities that aren't in the local opportunities table. Root cause is asymmetric sync — opportunity sync filters by recency, session sync doesn't. NULLing these would lose real linkages.

We made \`sessions.opportunity_id\` nullable so the Prisma model aligns with the DB, but skipped the FK constraint. Filed as a follow-up:
- \`Docs/superpowers/followups/2026-04-11-opportunity-sync-historical-gap.md\`

## Test plan

- [ ] Open the app — does it load?
- [ ] District detail panel — district queries work, FK relations don't break anything
- [ ] Calendar status panel — connection email displays correctly, reminder/sync settings persist on save
- [ ] Calendar inbox — 12 existing events still appear for sierra.arcega
- [ ] Disconnect + reconnect calendar — confirm OAuth flow and dismissed/confirmed events survive
- [ ] Admin → integrations page — Google Calendar count shows correctly (read from user_integrations)
- [ ] Explore grid — sort by ICP tier, filter by account type (uses new indexes)
- [ ] Materialized view dashboards (anywhere reading \`district_opportunity_actuals\`) — should show 831 rows after refresh
- [ ] No console errors mentioning \`prisma.calendarConnection\` or missing tables

## Rollback story

The migrations are not trivially reversible:
- Indexes can be dropped: \`DROP INDEX IF EXISTS\`
- New timestamp columns can be dropped: \`ALTER TABLE ... DROP COLUMN\`
- The opportunity FK can be dropped: \`ALTER TABLE opportunities DROP CONSTRAINT opportunities_district_lea_id_fkey\`
- The 355 NULLed orphan opportunities cannot be restored without a Supabase backup
- The dropped \`calendar_connections\` table cannot be restored without a Supabase backup, but the data lives in \`user_integrations\` now

Supabase keeps daily automatic backups. Worst case rollback is a point-in-time restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)