### PR TITLE
feat: surface EK12 subscriptions and text-stage closed-won in leaderboard

### DIFF
--- a/prisma/migrations/20260412_actuals_view_includes_subscriptions/migration.sql
+++ b/prisma/migrations/20260412_actuals_view_includes_subscriptions/migration.sql
@@ -1,0 +1,106 @@
+-- Extend district_opportunity_actuals materialized view to include
+-- Elevate K12 subscription revenue AND fix a long-standing stage parser
+-- gap that hid all closed-won bookings.
+--
+-- Background (subscription revenue):
+-- After PR #109 added the subscriptions table and rolled subscription
+-- revenue into vendor='fullmind' rows in district_financials, the district
+-- detail panel showed correct numbers. But the leaderboard reads from a
+-- different source — the district_opportunity_actuals materialized view —
+-- which aggregates only from the opportunities table. EK12 opportunities
+-- have $0 in their session-derived revenue columns, so EK12 reps showed
+-- $0 revenue and $0 take on the leaderboard despite having $13.8M of
+-- contracted subscription revenue. The new opp_subscriptions CTE pre-
+-- aggregates subscriptions per opportunity (avoiding row multiplication on
+-- the join), then adds sub_revenue into total_revenue and completed_revenue.
+-- Take is intentionally untouched — we don't have a take rate concept for
+-- subscriptions. avg_take_rate is computed against the session-only revenue
+-- base (the raw column reference, not the new output column) so it stays
+-- meaningful as a session-margin metric.
+--
+-- Background (stage parser):
+-- The previous matview's stage_prefix expression only handled numeric stage
+-- prefixes (e.g., "0 - Lead", "3 - Proposal"). The Salesforce LMS does NOT
+-- use numeric stages for closed-won; closed-won is the text label
+-- "Closed Won" (and variants like "Active", "Position Purchased",
+-- "Requisition Received", "Return Position Pending"). As a result, every
+-- closed-won opportunity returned NULL stage_prefix and was excluded from
+-- both bookings AND open_pipeline. The matview's "bookings" column has been
+-- $0 across the board since it was created. This migration fixes the parser
+-- to match what refresh_fullmind_financials() already does, surfacing
+-- ~$68M of previously-invisible closed-won bookings (Fullmind + EK12).
+--
+-- Canonical source: scripts/district-opportunity-actuals-view.sql
+
+DROP MATERIALIZED VIEW IF EXISTS district_opportunity_actuals;
+
+CREATE MATERIALIZED VIEW district_opportunity_actuals AS
+WITH stage_weights AS (
+  SELECT unnest(ARRAY[0, 1, 2, 3, 4, 5]) AS prefix,
+         unnest(ARRAY[0.05, 0.10, 0.25, 0.50, 0.75, 0.90]) AS weight
+),
+opp_subscriptions AS (
+  SELECT
+    opportunity_id,
+    COALESCE(SUM(net_total), 0) AS sub_revenue,
+    COUNT(*) AS sub_count
+  FROM subscriptions
+  GROUP BY opportunity_id
+),
+categorized_opps AS (
+  SELECT
+    o.*,
+    COALESCE(os.sub_revenue, 0) AS sub_revenue,
+    COALESCE(os.sub_count, 0)   AS sub_count,
+    CASE
+      WHEN LOWER(o.contract_type) LIKE '%renewal%' THEN 'renewal'
+      WHEN LOWER(o.contract_type) LIKE '%winback%' OR LOWER(o.contract_type) LIKE '%win back%' THEN 'winback'
+      WHEN LOWER(o.contract_type) LIKE '%expansion%' THEN 'expansion'
+      ELSE 'new_business'
+    END AS category,
+    CASE
+      WHEN o.stage ~ '^\d' THEN (regexp_match(o.stage, '^(\d+)'))[1]::int
+      WHEN LOWER(o.stage) IN ('closed won', 'active', 'position purchased',
+        'requisition received', 'return position pending') THEN 6
+      WHEN LOWER(o.stage) = 'closed lost' THEN -1
+      ELSE NULL
+    END AS stage_prefix
+  FROM opportunities o
+  LEFT JOIN opp_subscriptions os ON os.opportunity_id = o.id
+  WHERE o.district_lea_id IS NOT NULL
+)
+SELECT
+  co.district_lea_id,
+  co.school_yr,
+  co.sales_rep_email,
+  co.category,
+  COALESCE(SUM(co.net_booking_amount) FILTER (WHERE co.stage_prefix >= 6), 0) AS bookings,
+  COALESCE(SUM(co.net_booking_amount) FILTER (WHERE co.stage_prefix BETWEEN 0 AND 5), 0) AS open_pipeline,
+  COALESCE(SUM(co.net_booking_amount * sw.weight) FILTER (WHERE co.stage_prefix BETWEEN 0 AND 5), 0) AS weighted_pipeline,
+  COALESCE(SUM(co.total_revenue), 0)     + COALESCE(SUM(co.sub_revenue), 0) AS total_revenue,
+  COALESCE(SUM(co.completed_revenue), 0) + COALESCE(SUM(co.sub_revenue), 0) AS completed_revenue,
+  COALESCE(SUM(co.scheduled_revenue), 0) AS scheduled_revenue,
+  COALESCE(SUM(co.total_take), 0) AS total_take,
+  COALESCE(SUM(co.completed_take), 0) AS completed_take,
+  COALESCE(SUM(co.scheduled_take), 0) AS scheduled_take,
+  CASE WHEN SUM(co.total_revenue) > 0
+    THEN SUM(co.total_take) / SUM(co.total_revenue)
+    ELSE NULL
+  END AS avg_take_rate,
+  COALESCE(SUM(co.invoiced), 0) AS invoiced,
+  COALESCE(SUM(co.credited), 0) AS credited,
+  COUNT(*)::int AS opp_count,
+  COALESCE(SUM(co.sub_count), 0)::int AS subscription_count
+FROM categorized_opps co
+LEFT JOIN stage_weights sw ON sw.prefix = co.stage_prefix
+GROUP BY co.district_lea_id, co.school_yr, co.sales_rep_email, co.category;
+
+CREATE INDEX idx_doa_district           ON district_opportunity_actuals (district_lea_id);
+CREATE INDEX idx_doa_school_yr          ON district_opportunity_actuals (school_yr);
+CREATE INDEX idx_doa_rep                ON district_opportunity_actuals (sales_rep_email);
+CREATE INDEX idx_doa_category           ON district_opportunity_actuals (category);
+CREATE INDEX idx_doa_district_yr        ON district_opportunity_actuals (district_lea_id, school_yr);
+CREATE INDEX idx_doa_district_yr_rep    ON district_opportunity_actuals (district_lea_id, school_yr, sales_rep_email);
+CREATE UNIQUE INDEX idx_doa_unique      ON district_opportunity_actuals (district_lea_id, school_yr, sales_rep_email, category);
+
+ANALYZE district_opportunity_actuals;

--- a/scripts/district-opportunity-actuals-view.sql
+++ b/scripts/district-opportunity-actuals-view.sql
@@ -2,6 +2,15 @@
 -- Materialized view: district_opportunity_actuals
 -- Aggregates opportunities by district, school year, sales rep, and category.
 -- Refreshed after each scheduler sync cycle (hourly).
+--
+-- Subscription handling: Elevate K12 contracts (acquired post-merger) live in
+-- the opportunities table but their session-derived revenue columns are zero
+-- because EK12 uses subscriptions, not sessions. The opp_subscriptions CTE
+-- pre-aggregates subscription net_total per opportunity (signed sums so
+-- credits offset positives), and that revenue is added into total_revenue
+-- and completed_revenue at the final SELECT level. Take is intentionally
+-- left untouched — we don't have an educator-cost / take rate concept for
+-- subscriptions, so adding sub revenue to take would be invented data.
 
 DROP MATERIALIZED VIEW IF EXISTS district_opportunity_actuals;
 
@@ -10,21 +19,45 @@ WITH stage_weights AS (
   SELECT unnest(ARRAY[0, 1, 2, 3, 4, 5]) AS prefix,
          unnest(ARRAY[0.05, 0.10, 0.25, 0.50, 0.75, 0.90]) AS weight
 ),
+opp_subscriptions AS (
+  -- Pre-aggregate subscriptions per opportunity. Done in a separate CTE so
+  -- the LEFT JOIN below contributes one row per opportunity (avoiding the
+  -- row multiplication that would happen if we joined the raw subscriptions
+  -- table directly into categorized_opps).
+  SELECT
+    opportunity_id,
+    COALESCE(SUM(net_total), 0) AS sub_revenue,
+    COUNT(*) AS sub_count
+  FROM subscriptions
+  GROUP BY opportunity_id
+),
 categorized_opps AS (
   SELECT
     o.*,
+    COALESCE(os.sub_revenue, 0) AS sub_revenue,
+    COALESCE(os.sub_count, 0)   AS sub_count,
     CASE
       WHEN LOWER(o.contract_type) LIKE '%renewal%' THEN 'renewal'
       WHEN LOWER(o.contract_type) LIKE '%winback%' OR LOWER(o.contract_type) LIKE '%win back%' THEN 'winback'
       WHEN LOWER(o.contract_type) LIKE '%expansion%' THEN 'expansion'
       ELSE 'new_business'
     END AS category,
-    -- Extract numeric stage prefix (first character(s) before space or dash)
+    -- Stage prefix bucket (matches the logic in refresh_fullmind_financials).
+    -- Numeric prefix 0-5 → open pipeline
+    -- Numeric prefix 6+ → closed-won
+    -- Text "Closed Won" / "Active" / "Position Purchased" / etc → closed-won (6)
+    -- Text "Closed Lost" → -1 (excluded from both bookings and pipeline)
+    -- LMS doesn't actually emit numeric 6+ stages; closed-won is text-only,
+    -- so the text branch is required for any closed-won bookings to show up.
     CASE
       WHEN o.stage ~ '^\d' THEN (regexp_match(o.stage, '^(\d+)'))[1]::int
+      WHEN LOWER(o.stage) IN ('closed won', 'active', 'position purchased',
+        'requisition received', 'return position pending') THEN 6
+      WHEN LOWER(o.stage) = 'closed lost' THEN -1
       ELSE NULL
     END AS stage_prefix
   FROM opportunities o
+  LEFT JOIN opp_subscriptions os ON os.opportunity_id = o.id
   WHERE o.district_lea_id IS NOT NULL
 )
 SELECT
@@ -38,15 +71,19 @@ SELECT
   COALESCE(SUM(co.net_booking_amount) FILTER (WHERE co.stage_prefix BETWEEN 0 AND 5), 0) AS open_pipeline,
   -- Weighted pipeline
   COALESCE(SUM(co.net_booking_amount * sw.weight) FILTER (WHERE co.stage_prefix BETWEEN 0 AND 5), 0) AS weighted_pipeline,
-  -- Revenue
-  COALESCE(SUM(co.total_revenue), 0) AS total_revenue,
-  COALESCE(SUM(co.completed_revenue), 0) AS completed_revenue,
+  -- Revenue: Fullmind session-derived totals + Elevate K12 subscription revenue
+  -- (sub_revenue is signed so credits/cancellations offset positives)
+  COALESCE(SUM(co.total_revenue), 0)     + COALESCE(SUM(co.sub_revenue), 0) AS total_revenue,
+  COALESCE(SUM(co.completed_revenue), 0) + COALESCE(SUM(co.sub_revenue), 0) AS completed_revenue,
   COALESCE(SUM(co.scheduled_revenue), 0) AS scheduled_revenue,
-  -- Take
+  -- Take (unchanged — no take rate concept for subscriptions)
   COALESCE(SUM(co.total_take), 0) AS total_take,
   COALESCE(SUM(co.completed_take), 0) AS completed_take,
   COALESCE(SUM(co.scheduled_take), 0) AS scheduled_take,
-  -- Take rate (per-row, do NOT SUM across rows)
+  -- Take rate computed against session-only revenue base (the raw column,
+  -- not the output column that now includes sub_revenue). Keeps the rate
+  -- meaningful as a session-margin metric instead of getting diluted to 0
+  -- by EK12 subscription revenue.
   CASE WHEN SUM(co.total_revenue) > 0
     THEN SUM(co.total_take) / SUM(co.total_revenue)
     ELSE NULL
@@ -54,8 +91,9 @@ SELECT
   -- Financial
   COALESCE(SUM(co.invoiced), 0) AS invoiced,
   COALESCE(SUM(co.credited), 0) AS credited,
-  -- Count
-  COUNT(*)::int AS opp_count
+  -- Counts
+  COUNT(*)::int AS opp_count,
+  COALESCE(SUM(co.sub_count), 0)::int AS subscription_count
 FROM categorized_opps co
 LEFT JOIN stage_weights sw ON sw.prefix = co.stage_prefix
 GROUP BY co.district_lea_id, co.school_yr, co.sales_rep_email, co.category;


### PR DESCRIPTION
## Summary

Two related fixes to the `district_opportunity_actuals` materialized view (read by the leaderboard via `getRepActuals` and several other dashboards via `getDistrictActuals` / `getPlanDistrictActuals`):

1. **EK12 subscription revenue** now flows into rep totals (the leaderboard's `revenue` input was $0 for EK12 reps despite $13.8M of contracted subscription revenue from #109).
2. **Text-stage closed-won opportunities** now contribute to `bookings` (the matview's `bookings` column has been $0 since it was created — for *all* reps, not just EK12 — because the LMS uses text labels like "Closed Won" instead of numeric stage prefixes, and the parser only handled numeric).

## Background

After [#109](https://github.com/SierraArcega/territory-plan/pull/109) ingested EK12 subscriptions into `district_financials`, the district detail panel rendered correctly. But the leaderboard reads from a different source (`district_opportunity_actuals`), which had two gaps:

### Gap 1 — subscription revenue not in matview

The matview aggregated only from the `opportunities` table. EK12 opportunities have $0 in their session-derived revenue columns (no sessions to compute from — that's the same root cause that #109 fixed for the district panel). So EK12 reps showed $0 revenue and $0 take on the leaderboard.

**Fix:** new `opp_subscriptions` CTE pre-aggregates `net_total` per opportunity (signed sums so credits offset positives), `LEFT JOIN`ed into `categorized_opps`. `sub_revenue` is added to `total_revenue` and `completed_revenue` at the GROUP BY level.

Take is intentionally untouched — we don't have a take rate concept for subscriptions, so adding sub revenue to take would be invented data. `avg_take_rate` is computed against the session-only revenue base (the raw column reference, not the new output column) so it stays meaningful as a session-margin metric.

### Gap 2 — stage parser missed text-stage closed-won

While diagnosing Gap 1, I noticed EK12 reps showed $0 bookings in addition to $0 revenue. Investigation revealed:

```
Stage values on district-mapped opportunities:
  Closed Won            665 opps  $63.3M  ❌ NULL stage_prefix → excluded
  Closed Lost           319 opps  $15.9M  ❌ NULL stage_prefix → excluded (correct)
  0 - Meeting Booked    137 opps  $11.9M  ✅ pipeline
  2 - Presentation       72 opps   $5.8M  ✅ pipeline
  1 - Discovery          65 opps   $9.0M  ✅ pipeline
  Active                 17 opps   $1.5M  ❌ NULL → excluded
  Position Purchased     19 opps   $1.7M  ❌ NULL → excluded
  Requisition Received   22 opps   $2.3M  ❌ NULL → excluded
  ... (and several more text stages)

Numeric stages with prefix 6+ (closed-won):  ZERO opportunities exist
```

**The LMS does not use numeric prefixes for closed-won.** Closed-won is the text label "Closed Won" (with operational variants like "Active" / "Position Purchased" / "Requisition Received" / "Return Position Pending"). The matview's parser only handled numeric prefixes, so **every closed-won opportunity returned `NULL stage_prefix` and was excluded from both `bookings` and `open_pipeline`**. The matview's `bookings` column has been $0 across the board since it was created.

The `refresh_fullmind_financials()` SQL function for `district_financials` already had the text-stage handling, which is why the district detail panel's "Closed Won" metric showed reasonable numbers. The matview was never updated to match.

**Fix:** extend the matview's `stage_prefix` expression with the same `WHEN LOWER(o.stage) IN ('closed won', 'active', ...) THEN 6` branches that `refresh_fullmind_financials()` has had all along. Surfaces ~$68.8M of previously-invisible closed-won bookings.

## Verified results

After applying this branch's migration to the database:

```
Top 10 reps by total_revenue (school_yr=2025-26):
  email                                 revenue       take      pipeline    bookings   subs
  anurag.baranwal@fullmindlearning.com  $8,804,631    $0        $470,059   $9,900,319  562
  monica.sherwood@fullmindlearning.com  $2,562,500    $1,090K   $20,000    $4,885,760    0
  kris.tedesco@fullmindlearning.com     $2,207,490    $1,894K   $316,977   $5,865,362    0
  mike.odonnell@fullmindlearning.com    $2,143,047    $1,549K   $288,041   $2,199,793    0
  joy.panko@fullmindlearning.com        $1,722,029    $705K     $0         $7,040,653    0
  jenn.russart@fullmindlearning.com     $1,560,073    $0        $997,000   $1,578,920   74
  liz.winnen@fullmindlearning.com       $1,383,540    $0        $0         $1,980,902  161
  lauren.kleist@fullmindlearning.com    $1,290,046    $0        $15,500    $1,491,088   63
  phil.dugliss@fullmindlearning.com     $736,441      $0        $15,000    $858,847     84
  rachel.reynoso@fullmindlearning.com   $661,330      $547K     $65,168    $880,560      0

Total bookings across the matview:  $68,783,490  (was $0 before)
FY26 bookings only:                  $44,212,526  (235 matview rows)
```

**All 6 EK12 reps now show both revenue AND bookings.** Native Fullmind reps with text-stage closed-won opportunities (kris, joy, monica, mike, rachel, etc.) also gained their previously-invisible bookings.

**Heads up — Anurag will dominate the leaderboard.** $8.8M revenue + $9.9M bookings + 562 EK12 subs is roughly 3.4× the next rep. This is correct (his EK12 contracts are real), but expect the leaderboard ordering to shift visibly.

## Asymmetry to be aware of

EK12 reps' `take` is $0 because we don't have an "educator cost" / take rate for subscriptions. If your active leaderboard initiative weights `take` highly, EK12-heavy reps will look weak on that dimension despite strong revenue. This is the same asymmetry from #109; you may want to revisit the active initiative's `takeWeight` after this lands.

## Pre-existing migration history note

PR #109 left `20260411_drop_calendar_connections` in a stuck state on the deploy database (the table no longer existed when the migration tried to drop it). This branch resolves it via `prisma migrate resolve --applied 20260411_drop_calendar_connections` so the new migration in this PR could apply, and so subsequent `migrate deploy` runs work cleanly. Resolved from `feat/leaderboard-include-elevate-revenue`, no app data touched — only the `_prisma_migrations` metadata table.

## Test plan

- [x] Schema unchanged (no Prisma model edits) — `prisma validate` passes by definition
- [x] `prisma migrate deploy` applied this branch's migration cleanly
- [x] `npx vitest run` — 1325 tests pass (2 unrelated test files fail to load due to pre-existing missing `@tanstack/react-virtual` dep)
- [x] Diagnostic queries confirm EK12 reps show revenue + bookings
- [x] Sanity check on non-EK12 reps' revenue (unchanged) ✓
- [x] Sanity check on total_bookings ($68.8M, exactly matches the previously "missing" amount)
- [ ] Browser verification — open the leaderboard page after this deploys, confirm Anurag/EK12 reps rise in ranking and that bookings show on dashboards that read `getDistrictActuals`
- [ ] Spot-check the goals dashboard if you use it — bookings number should now be non-zero for any rep with closed-won contracts

🤖 Generated with [Claude Code](https://claude.com/claude-code)