### PR TITLE
fix(map): eliminate layout shift in Districts dropdown

### DIFF
--- a/Docs/superpowers/specs/2026-04-13-districts-dropdown-layout-shift-design.md
+++ b/Docs/superpowers/specs/2026-04-13-districts-dropdown-layout-shift-design.md
@@ -1,0 +1,33 @@
+# Districts Dropdown Layout Shift Fix
+
+**Date:** 2026-04-13
+**Branch:** fix/districts-dropdown-flash
+
+## Problem
+
+When opening the Districts filter dropdown, the Sales Executive and Tags sections pop in ~100-200ms after the dropdown renders, causing a visible layout shift. This happens because the data is fetched inside `DistrictsDropdown` via `useEffect`, and the sections are conditionally rendered with `{owners.length > 0 && ...}`.
+
+## Solution: Pre-fetch at SearchBar Level
+
+Move the `/api/sales-executives` and `/api/tags` fetch calls up to the SearchBar component so data is ready before the dropdown opens. Always render the Sales Executive and Tags sections regardless of data state.
+
+### Changes
+
+**SearchBar/index.tsx:**
+- Add `useEffect` with fetch calls for `/api/sales-executives` and `/api/tags`
+- Store results in local state (`owners`, `tags`)
+- Pass as props to `DistrictsDropdown`
+
+**DistrictsDropdown.tsx:**
+- Accept `owners` and `tags` as props
+- Remove internal `useEffect` fetch calls and local state for owners/tags
+- Remove `{owners.length > 0 && ...}` conditional — always render FilterMultiSelect for Sales Executive
+- Remove `{tags.length > 0 && ...}` conditional — always render FilterMultiSelect for Tags
+
+### Scope
+
+Two files. No changes to FilterMultiSelect, FullmindContent, store, or filter logic.
+
+### Edge case
+
+Empty API response → FilterMultiSelect renders with empty options list showing "No matches." Preferred over hiding the section.

--- a/src/features/map/components/SearchBar/DistrictsDropdown.tsx
+++ b/src/features/map/components/SearchBar/DistrictsDropdown.tsx
@@ -53,6 +53,8 @@ const COMPETITOR_VENDORS = [
 
 interface DistrictsDropdownProps {
   onClose: () => void;
+  owners: { id: string; name: string }[];
+  tags: Array<{ id: string; name: string }>;
 }
 
 type SectionKey = "attributes" | "fullmind" | "competitors" | "finance" | "demographics" | "academics";
@@ -66,7 +68,7 @@ const SECTIONS: { key: SectionKey; label: string }[] = [
   { key: "academics", label: "Academics" },
 ];
 
-export default function DistrictsDropdown({ onClose }: DistrictsDropdownProps) {
+export default function DistrictsDropdown({ onClose, owners, tags }: DistrictsDropdownProps) {
   const searchFilters = useMapV2Store((s) => s.searchFilters);
   const addSearchFilter = useMapV2Store((s) => s.addSearchFilter);
   const updateSearchFilter = useMapV2Store((s) => s.updateSearchFilter);
@@ -76,21 +78,6 @@ export default function DistrictsDropdown({ onClose }: DistrictsDropdownProps) {
 
   // Collapsible section state — start with first section open
   const [openSections, setOpenSections] = useState<Set<SectionKey>>(new Set(["fullmind"]));
-
-  // Fullmind data
-  const [owners, setOwners] = useState<{ id: string; name: string }[]>([]);
-  const [tags, setTags] = useState<Array<{ id: string; name: string }>>([]);
-
-  useEffect(() => {
-    fetch("/api/sales-executives")
-      .then((r) => (r.ok ? r.json() : []))
-      .then((data) => setOwners((data || []).map((d: { id: string; fullName: string | null; email: string }) => ({ id: d.id, name: d.fullName || d.email }))))
-      .catch(() => {});
-    fetch("/api/tags")
-      .then((r) => (r.ok ? r.json() : []))
-      .then((data) => setTags(Array.isArray(data) ? data : []))
-      .catch(() => {});
-  }, []);
 
   // Close on outside click
   useEffect(() => {
@@ -328,30 +315,26 @@ function FullmindContent({
         onSelect={(opt) => addFilter(opt.column, opt.op, opt.value)}
       />
 
-      {owners.length > 0 && (
-        <FilterMultiSelect
-          label="Sales Executive"
-          column="salesExecutive"
-          options={owners.map((o) => ({ value: o.id, label: o.name }))}
-          onApply={(col, vals) => {
-            const names = vals.map((v) => owners.find((o) => o.id === v)?.name ?? v);
-            addFilter(col, "in", vals, names.join(", "));
-          }}
-        />
-      )}
+      <FilterMultiSelect
+        label="Sales Executive"
+        column="salesExecutive"
+        options={owners.map((o) => ({ value: o.id, label: o.name }))}
+        onApply={(col, vals) => {
+          const names = vals.map((v) => owners.find((o) => o.id === v)?.name ?? v);
+          addFilter(col, "in", vals, names.join(", "));
+        }}
+      />
 
       <FinancialRangeFilter label="Pipeline" column="open_pipeline" defaultFy={defaultFy} min={0} max={500000} step={5000} formatValue={(v) => `$${formatCompact(v)}`} onApply={handleFinancialRangeApply} />
       <FinancialRangeFilter label="Bookings" column="closed_won_bookings" defaultFy={defaultFy} min={0} max={500000} step={5000} formatValue={(v) => `$${formatCompact(v)}`} onApply={handleFinancialRangeApply} />
       <FinancialRangeFilter label="Invoicing" column="invoicing" defaultFy={defaultFy} min={0} max={500000} step={5000} formatValue={(v) => `$${formatCompact(v)}`} onApply={handleFinancialRangeApply} />
 
-      {tags.length > 0 && (
-        <FilterMultiSelect
-          label="Tags"
-          column="tags"
-          options={tags.map((t) => ({ value: t.name, label: t.name }))}
-          onApply={(col, vals) => addFilter(col, "eq", vals)}
-        />
-      )}
+      <FilterMultiSelect
+        label="Tags"
+        column="tags"
+        options={tags.map((t) => ({ value: t.name, label: t.name }))}
+        onApply={(col, vals) => addFilter(col, "eq", vals)}
+      />
     </>
   );
 }

--- a/src/features/map/components/SearchBar/controls/FilterMultiSelect.tsx
+++ b/src/features/map/components/SearchBar/controls/FilterMultiSelect.tsx
@@ -52,10 +52,6 @@ export default function FilterMultiSelect({ label, column, options, onApply, loa
     enabled: !!virtualize,
   });
 
-  // Auto-focus search on mount
-  useEffect(() => {
-    requestAnimationFrame(() => searchRef.current?.focus());
-  }, []);
 
   // Apply the current selection to the store immediately — remove the existing filter
   // for this column (if any) then add a new one if the selection is non-empty.

--- a/src/features/map/components/SearchBar/index.tsx
+++ b/src/features/map/components/SearchBar/index.tsx
@@ -13,6 +13,25 @@ import {
 } from "@/features/map/lib/filter-utils";
 import { useGeographyPrefetch } from "@/features/map/lib/queries";
 
+// Pre-fetched dropdown data — loaded once at SearchBar mount so Districts dropdown opens instantly
+function useDropdownData() {
+  const [owners, setOwners] = useState<{ id: string; name: string }[]>([]);
+  const [tags, setTags] = useState<Array<{ id: string; name: string }>>([]);
+
+  useEffect(() => {
+    fetch("/api/sales-executives")
+      .then((r) => (r.ok ? r.json() : []))
+      .then((data) => setOwners((data || []).map((d: { id: string; fullName: string | null; email: string }) => ({ id: d.id, name: d.fullName || d.email }))))
+      .catch(() => {});
+    fetch("/api/tags")
+      .then((r) => (r.ok ? r.json() : []))
+      .then((data) => setTags(Array.isArray(data) ? data : []))
+      .catch(() => {});
+  }, []);
+
+  return { owners, tags };
+}
+
 interface DistrictSuggestion {
   leaid: string;
   name: string;
@@ -111,6 +130,7 @@ function countByDomain(filters: ExploreFilter[], domain: string): number {
 
 export default function SearchBar() {
   useGeographyPrefetch();
+  const { owners, tags } = useDropdownData();
   const searchFilters = useMapV2Store((s) => s.searchFilters);
   const selectedFiscalYear = useMapV2Store((s) => s.selectedFiscalYear);
   const setSelectedFiscalYear = useMapV2Store((s) => s.setSelectedFiscalYear);
@@ -479,7 +499,7 @@ export default function SearchBar() {
       {openDropdown && (
         <div className="absolute top-full left-0 z-50 px-3 pt-2">
           {openDropdown === "geography" && <GeographyDropdown onClose={() => setOpenDropdown(null)} />}
-          {openDropdown === "districts" && <DistrictsDropdown onClose={() => setOpenDropdown(null)} />}
+          {openDropdown === "districts" && <DistrictsDropdown onClose={() => setOpenDropdown(null)} owners={owners} tags={tags} />}
           {openDropdown === "contacts" && <ContactsDropdown onClose={() => setOpenDropdown(null)} />}
           {openDropdown === "vacancies" && <VacanciesDropdown onClose={() => setOpenDropdown(null)} />}
           {openDropdown === "activities" && <ActivitiesDropdown onClose={() => setOpenDropdown(null)} />}


### PR DESCRIPTION
## Summary
- Pre-fetch sales executives and tags at the SearchBar level so data is ready before the Districts dropdown opens, eliminating the visible pop-in of the Sales Executive and Tags sections
- Remove conditional guards (`owners.length > 0`) that hid sections until API responses arrived, causing layout shift
- Remove auto-focus in FilterMultiSelect that was scrolling the dropdown to the bottom on open

## Test plan
- [ ] Open Districts dropdown — Sales Executive and Tags sections should appear immediately without layout shift
- [ ] Dropdown should open scrolled to the top, not the bottom
- [ ] Sales Executive filter still works (search, select, deselect)
- [ ] Tags filter still works
- [ ] Close and reopen dropdown — no re-fetch, data persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)