### PR TITLE
perf(map): eliminate tab switching lag in results panel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,26 @@ TanStack Query. Vitest for testing.
 - Never use Tailwind grays — use plum-derived neutrals (#F7F5FA, #EFEDF5)
 - Icons: Lucide only, `currentColor`, semantic sizing
 
+### Performance
+This is a daily-use tool for sales reps. It must feel smooth — no user action
+should cause a dramatic slowdown. Apply these rules to every new feature:
+
+- **Paginate lists** — never render more than 50 items at once. Use "Show more"
+  or scroll-based loading. Show a filter hint banner at 200+ results.
+- **Stable query keys** — TanStack Query keys must use serialized primitives
+  (strings, numbers), never raw objects. Object spreads create new references
+  that trigger phantom refetches.
+- **Batch store mutations** — when a user action requires multiple Zustand
+  `set()` calls, combine them into a single `set()` to avoid cascading re-renders.
+- **Isolate subscriptions** — components should subscribe to the narrowest
+  store slice they need (e.g., `s.layerFilters.vacancies` not `s.layerFilters`).
+  Broad subscriptions cause unrelated state changes to trigger re-renders.
+- **Conditional rendering over conditional fetching** — prefer mounting/unmounting
+  components (which own their own queries) over running all queries and gating
+  with `enabled` flags. TanStack Query caches survive unmounts via `gcTime`.
+- **Clean up on unmount** — useEffect hooks that write to shared state (store,
+  context) must return a cleanup function to prevent stale data.
+
 ### Testing
 - Vitest + Testing Library + jsdom
 - Tests co-located in `__tests__/` directories next to source

--- a/Docs/superpowers/plans/2026-04-13-tab-switching-perf.md
+++ b/Docs/superpowers/plans/2026-04-13-tab-switching-perf.md
@@ -1,0 +1,661 @@
+# Tab Switching Performance Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate lag when switching between layer tabs (Districts, Contacts, Vacancies, Activities, Plans) on the Maps tab.
+
+**Architecture:** Stabilize TanStack Query keys to prevent phantom refetches, batch multiple store mutations into a single React render, and isolate each tab's data subscriptions so switching tabs is a lightweight conditional swap instead of a full re-evaluation of all overlay queries.
+
+**Tech Stack:** React 19, Zustand, TanStack Query, TypeScript, Vitest
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `src/features/map/lib/queries.ts` | Modify | Fix query keys for all 4 overlay hooks |
+| `src/features/map/lib/store.ts` | Modify | Add `switchToLayer` action, add `overlayGeoJSON` slice |
+| `src/features/map/lib/__tests__/store.overlays.test.ts` | Modify | Add tests for `switchToLayer` |
+| `src/features/map/components/SearchBar/index.tsx` | Modify | Use `switchToLayer` instead of `toggleLayer` + `openResultsPanel` |
+| `src/features/map/components/SearchResults/ContactsTabContainer.tsx` | Create | Isolated container owning contacts query |
+| `src/features/map/components/SearchResults/VacanciesTabContainer.tsx` | Create | Isolated container owning vacancies query |
+| `src/features/map/components/SearchResults/ActivitiesTabContainer.tsx` | Create | Isolated container owning activities query |
+| `src/features/map/components/SearchResults/PlansTabContainer.tsx` | Create | Isolated container owning plans query |
+| `src/features/map/components/SearchResults/index.tsx` | Modify | Remove per-layer queries, delegate to tab containers |
+
+---
+
+### Task 1: Stabilize Query Keys
+
+**Files:**
+- Modify: `src/features/map/lib/queries.ts:240-346`
+
+- [ ] **Step 1: Fix `useMapContacts` query key**
+
+In `src/features/map/lib/queries.ts`, replace the query key at line 241:
+
+```ts
+// Before
+queryKey: ["mapContacts", qBounds, filters, geoStates],
+
+// After
+queryKey: ["mapContacts", queryString],
+```
+
+- [ ] **Step 2: Fix `useMapVacancies` query key**
+
+In `src/features/map/lib/queries.ts`, replace the query key at line 274:
+
+```ts
+// Before
+queryKey: ["mapVacancies", qBounds, filters, dateRange, geoStates],
+
+// After
+queryKey: ["mapVacancies", queryString],
+```
+
+- [ ] **Step 3: Fix `useMapActivities` query key**
+
+In `src/features/map/lib/queries.ts`, replace the query key at line 310:
+
+```ts
+// Before
+queryKey: ["mapActivities", qBounds, filters, dateRange, geoStates],
+
+// After
+queryKey: ["mapActivities", queryString],
+```
+
+- [ ] **Step 4: Fix `useMapPlans` query key**
+
+In `src/features/map/lib/queries.ts`, replace the query key at line 338. Plans doesn't use `buildOverlayParams`, so use the locally built `queryString`:
+
+```ts
+// Before
+queryKey: ["mapPlans", filters],
+
+// After
+queryKey: ["mapPlans", queryString],
+```
+
+- [ ] **Step 5: Verify no regressions**
+
+Run: `npm test -- --run`
+Expected: All existing tests pass. The query key change is internal to TanStack Query — no consumer API changes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/map/lib/queries.ts
+git commit -m "perf(map): stabilize overlay query keys to prevent phantom refetches"
+```
+
+---
+
+### Task 2: Add `switchToLayer` Store Action
+
+**Files:**
+- Modify: `src/features/map/lib/store.ts:437-446` (action types), `src/features/map/lib/store.ts:1141-1176` (action implementations)
+- Modify: `src/features/map/lib/__tests__/store.overlays.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/features/map/lib/__tests__/store.overlays.test.ts`:
+
+```ts
+describe("switchToLayer", () => {
+  it("activates the layer, sets the results tab, and opens the results panel", () => {
+    useMapV2Store.getState().switchToLayer("vacancies");
+    const s = useMapV2Store.getState();
+    expect(s.activeLayers.has("vacancies")).toBe(true);
+    expect(s.activeResultsTab).toBe("vacancies");
+    expect(s.searchResultsVisible).toBe(true);
+  });
+
+  it("does not remove the districts layer", () => {
+    useMapV2Store.getState().switchToLayer("vacancies");
+    const s = useMapV2Store.getState();
+    expect(s.activeLayers.has("districts")).toBe(true);
+  });
+
+  it("preserves other active layers", () => {
+    useMapV2Store.getState().toggleLayer("contacts");
+    useMapV2Store.getState().switchToLayer("vacancies");
+    const s = useMapV2Store.getState();
+    expect(s.activeLayers.has("contacts")).toBe(true);
+    expect(s.activeLayers.has("vacancies")).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- --run src/features/map/lib/__tests__/store.overlays.test.ts`
+Expected: FAIL — `switchToLayer` is not a function.
+
+- [ ] **Step 3: Add the type declaration**
+
+In `src/features/map/lib/store.ts`, in the `MapV2Actions` interface (around line 437), add after `toggleLayer`:
+
+```ts
+  switchToLayer: (layer: OverlayLayerType) => void;
+```
+
+- [ ] **Step 4: Add the implementation**
+
+In `src/features/map/lib/store.ts`, after the `toggleLayer` implementation (after line 1152), add:
+
+```ts
+  switchToLayer: (layer) =>
+    set((s) => {
+      const next = new Set(s.activeLayers);
+      next.add(layer);
+      return {
+        activeLayers: next,
+        activeResultsTab: layer,
+        searchResultsVisible: true,
+      };
+    }),
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm test -- --run src/features/map/lib/__tests__/store.overlays.test.ts`
+Expected: All tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/map/lib/store.ts src/features/map/lib/__tests__/store.overlays.test.ts
+git commit -m "feat(map): add switchToLayer action for batched tab switching"
+```
+
+---
+
+### Task 3: Wire `switchToLayer` into SearchBar
+
+**Files:**
+- Modify: `src/features/map/components/SearchBar/index.tsx:215-233`
+
+- [ ] **Step 1: Subscribe to `switchToLayer` instead of separate actions**
+
+In `src/features/map/components/SearchBar/index.tsx`, add a new store subscription (near line 127):
+
+```ts
+const switchToLayer = useMapV2Store((s) => s.switchToLayer);
+```
+
+- [ ] **Step 2: Replace `handleEntityChevronClick`**
+
+Replace the `handleEntityChevronClick` callback (lines 221-233) with:
+
+```ts
+  const handleEntityChevronClick = useCallback((layerName: string, layerType: OverlayLayerType) => {
+    const store = useMapV2Store.getState();
+    if (!store.activeLayers.has(layerType)) {
+      switchToLayer(layerType);
+      setOpenDropdown((prev) => (prev === layerName ? null : layerName));
+    } else {
+      setOpenDropdown((prev) => {
+        const isOpening = prev !== layerName;
+        if (isOpening) {
+          useMapV2Store.getState().openResultsPanel(layerType as LayerType);
+        }
+        return isOpening ? layerName : null;
+      });
+    }
+  }, [switchToLayer]);
+```
+
+This uses `switchToLayer` (single mutation) when the layer isn't active, and falls back to `openResultsPanel` when the layer is already active (no toggle needed).
+
+- [ ] **Step 3: Verify no regressions**
+
+Run: `npm test -- --run`
+Expected: All tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/features/map/components/SearchBar/index.tsx
+git commit -m "perf(map): use switchToLayer for batched tab switching in SearchBar"
+```
+
+---
+
+### Task 4: Add `overlayGeoJSON` Store Slice
+
+**Files:**
+- Modify: `src/features/map/lib/store.ts`
+
+This slice allows tab containers to report their query data up to the shell for cross-filtering.
+
+- [ ] **Step 1: Add state type and initial state**
+
+In the `MapV2State` interface (around line 283, after `dateRange`), add:
+
+```ts
+  overlayGeoJSON: {
+    contacts: FeatureCollection<Point> | null;
+    vacancies: FeatureCollection<Point> | null;
+    activities: FeatureCollection<Point> | null;
+    plans: FeatureCollection<Geometry> | null;
+  };
+```
+
+Add imports at the top of the file if not already present:
+
+```ts
+import type { FeatureCollection, Point, Geometry } from "geojson";
+```
+
+In the initial state (around line 593, after `mapBounds: null`), add:
+
+```ts
+  overlayGeoJSON: {
+    contacts: null,
+    vacancies: null,
+    activities: null,
+    plans: null,
+  },
+```
+
+- [ ] **Step 2: Add action type**
+
+In `MapV2Actions` (around line 440, after `setMapBounds`), add:
+
+```ts
+  setOverlayGeoJSON: (layer: keyof MapV2State["overlayGeoJSON"], data: FeatureCollection | null) => void;
+```
+
+- [ ] **Step 3: Add action implementation**
+
+After `setMapBounds` implementation (around line 1170), add:
+
+```ts
+  setOverlayGeoJSON: (layer, data) =>
+    set((s) => ({
+      overlayGeoJSON: { ...s.overlayGeoJSON, [layer]: data },
+    })),
+```
+
+- [ ] **Step 4: Verify no regressions**
+
+Run: `npm test -- --run`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/map/lib/store.ts
+git commit -m "feat(map): add overlayGeoJSON store slice for tab container data flow"
+```
+
+---
+
+### Task 5: Create Tab Containers
+
+**Files:**
+- Create: `src/features/map/components/SearchResults/ContactsTabContainer.tsx`
+- Create: `src/features/map/components/SearchResults/VacanciesTabContainer.tsx`
+- Create: `src/features/map/components/SearchResults/ActivitiesTabContainer.tsx`
+- Create: `src/features/map/components/SearchResults/PlansTabContainer.tsx`
+
+Each container owns its query hook, reports raw GeoJSON to the store, and renders the existing presentation component with filtered data.
+
+- [ ] **Step 1: Create `ContactsTabContainer.tsx`**
+
+```tsx
+"use client";
+
+import { useEffect } from "react";
+import { useMapV2Store } from "@/features/map/lib/store";
+import { useMapContacts } from "@/features/map/lib/queries";
+import ContactsTab from "./ContactsTab";
+import type { FeatureCollection, Point } from "geojson";
+
+interface ContactsTabContainerProps {
+  filteredData: FeatureCollection<Point> | undefined;
+  geoStates: string[] | undefined;
+}
+
+export default function ContactsTabContainer({ filteredData, geoStates }: ContactsTabContainerProps) {
+  const filters = useMapV2Store((s) => s.layerFilters.contacts);
+  const mapBounds = useMapV2Store((s) => s.mapBounds);
+  const setOverlayGeoJSON = useMapV2Store((s) => s.setOverlayGeoJSON);
+
+  const { data, isLoading } = useMapContacts(mapBounds, filters, true, geoStates);
+
+  // Report raw GeoJSON to store for cross-filtering
+  useEffect(() => {
+    setOverlayGeoJSON("contacts", data ?? null);
+  }, [data, setOverlayGeoJSON]);
+
+  return <ContactsTab data={filteredData} isLoading={isLoading} />;
+}
+```
+
+- [ ] **Step 2: Create `VacanciesTabContainer.tsx`**
+
+```tsx
+"use client";
+
+import { useEffect } from "react";
+import { useMapV2Store } from "@/features/map/lib/store";
+import { useMapVacancies } from "@/features/map/lib/queries";
+import VacanciesTab from "./VacanciesTab";
+import type { FeatureCollection, Point } from "geojson";
+
+interface VacanciesTabContainerProps {
+  filteredData: FeatureCollection<Point> | undefined;
+  geoStates: string[] | undefined;
+}
+
+export default function VacanciesTabContainer({ filteredData, geoStates }: VacanciesTabContainerProps) {
+  const filters = useMapV2Store((s) => s.layerFilters.vacancies);
+  const dateRange = useMapV2Store((s) => s.dateRange.vacancies);
+  const mapBounds = useMapV2Store((s) => s.mapBounds);
+  const setOverlayGeoJSON = useMapV2Store((s) => s.setOverlayGeoJSON);
+
+  const { data, isLoading } = useMapVacancies(mapBounds, filters, dateRange, true, geoStates);
+
+  useEffect(() => {
+    setOverlayGeoJSON("vacancies", data ?? null);
+  }, [data, setOverlayGeoJSON]);
+
+  return <VacanciesTab data={filteredData} isLoading={isLoading} />;
+}
+```
+
+- [ ] **Step 3: Create `ActivitiesTabContainer.tsx`**
+
+```tsx
+"use client";
+
+import { useEffect } from "react";
+import { useMapV2Store } from "@/features/map/lib/store";
+import { useMapActivities } from "@/features/map/lib/queries";
+import ActivitiesTab from "./ActivitiesTab";
+import type { FeatureCollection, Point } from "geojson";
+
+interface ActivitiesTabContainerProps {
+  filteredData: FeatureCollection<Point> | undefined;
+  geoStates: string[] | undefined;
+}
+
+export default function ActivitiesTabContainer({ filteredData, geoStates }: ActivitiesTabContainerProps) {
+  const filters = useMapV2Store((s) => s.layerFilters.activities);
+  const dateRange = useMapV2Store((s) => s.dateRange.activities);
+  const mapBounds = useMapV2Store((s) => s.mapBounds);
+  const setOverlayGeoJSON = useMapV2Store((s) => s.setOverlayGeoJSON);
+
+  const { data, isLoading } = useMapActivities(mapBounds, filters, dateRange, true, geoStates);
+
+  useEffect(() => {
+    setOverlayGeoJSON("activities", data ?? null);
+  }, [data, setOverlayGeoJSON]);
+
+  return <ActivitiesTab data={filteredData} isLoading={isLoading} />;
+}
+```
+
+- [ ] **Step 4: Create `PlansTabContainer.tsx`**
+
+```tsx
+"use client";
+
+import { useEffect } from "react";
+import { useMapV2Store } from "@/features/map/lib/store";
+import { useMapPlans } from "@/features/map/lib/queries";
+import PlansTab from "./PlansTab";
+import type { FeatureCollection, Geometry } from "geojson";
+
+interface PlansTabContainerProps {
+  geoStates: string[] | undefined;
+}
+
+export default function PlansTabContainer({ geoStates }: PlansTabContainerProps) {
+  const filters = useMapV2Store((s) => s.layerFilters.plans);
+  const setOverlayGeoJSON = useMapV2Store((s) => s.setOverlayGeoJSON);
+
+  const { data, isLoading } = useMapPlans(filters, true);
+
+  useEffect(() => {
+    setOverlayGeoJSON("plans", data ?? null);
+  }, [data, setOverlayGeoJSON]);
+
+  // PlansTab receives raw data (not cross-filtered) — plans are the cross-filter source
+  return <PlansTab data={data} isLoading={isLoading} />;
+}
+```
+
+- [ ] **Step 5: Verify no regressions**
+
+Run: `npm test -- --run`
+Expected: All tests pass. Containers are not yet wired in.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/map/components/SearchResults/ContactsTabContainer.tsx \
+  src/features/map/components/SearchResults/VacanciesTabContainer.tsx \
+  src/features/map/components/SearchResults/ActivitiesTabContainer.tsx \
+  src/features/map/components/SearchResults/PlansTabContainer.tsx
+git commit -m "feat(map): add isolated tab container components"
+```
+
+---
+
+### Task 6: Slim Down SearchResults
+
+**Files:**
+- Modify: `src/features/map/components/SearchResults/index.tsx`
+
+This is the integration task — wire tab containers in, remove redundant subscriptions and queries.
+
+- [ ] **Step 1: Add container imports**
+
+At the top of `src/features/map/components/SearchResults/index.tsx`, add:
+
+```ts
+import ContactsTabContainer from "./ContactsTabContainer";
+import VacanciesTabContainer from "./VacanciesTabContainer";
+import ActivitiesTabContainer from "./ActivitiesTabContainer";
+import PlansTabContainer from "./PlansTabContainer";
+```
+
+- [ ] **Step 2: Remove redundant store subscriptions**
+
+Remove these lines from the `SearchResults` component (around lines 89-91):
+
+```ts
+// REMOVE these — tab containers own their own subscriptions
+const layerFilters = useMapV2Store((s) => s.layerFilters);
+const dateRange = useMapV2Store((s) => s.dateRange);
+const mapBounds = useMapV2Store((s) => s.mapBounds);
+```
+
+Replace with a subscription to the overlayGeoJSON slice:
+
+```ts
+const overlayGeoJSON = useMapV2Store((s) => s.overlayGeoJSON);
+```
+
+- [ ] **Step 3: Remove redundant query hooks**
+
+Remove the overlay query hook calls (around lines 116-139):
+
+```ts
+// REMOVE — moved into tab containers
+const contactsQuery = useMapContacts(...);
+const vacanciesQuery = useMapVacancies(...);
+const activitiesQuery = useMapActivities(...);
+const plansQuery = useMapPlans(...);
+```
+
+Also remove their imports from the top of the file.
+
+- [ ] **Step 4: Update useCrossFilter to read from store**
+
+Replace the `useCrossFilter` call (around lines 142-152):
+
+```ts
+// Before
+const {
+  overlayDerivedLeaids,
+  filteredContacts,
+  filteredVacancies,
+  filteredActivities,
+} = useCrossFilter({
+  plansGeoJSON: plansQuery.data,
+  contactsGeoJSON: contactsQuery.data,
+  vacanciesGeoJSON: vacanciesQuery.data,
+  activitiesGeoJSON: activitiesQuery.data,
+});
+
+// After
+const {
+  overlayDerivedLeaids,
+  filteredContacts,
+  filteredVacancies,
+  filteredActivities,
+} = useCrossFilter({
+  plansGeoJSON: overlayGeoJSON.plans,
+  contactsGeoJSON: overlayGeoJSON.contacts,
+  vacanciesGeoJSON: overlayGeoJSON.vacancies,
+  activitiesGeoJSON: overlayGeoJSON.activities,
+});
+```
+
+- [ ] **Step 5: Update tabCounts to use overlayGeoJSON**
+
+Update the `tabCounts` computation (around lines 483-505) to use `overlayGeoJSON` instead of query results:
+
+```ts
+const tabCounts = useMemo((): Partial<Record<LayerType, number>> => {
+  const counts: Partial<Record<LayerType, number>> = {};
+  counts.districts = total;
+  if (activeLayers.has("plans") && overlayGeoJSON.plans) {
+    const planIds = new Set<string>();
+    for (const f of overlayGeoJSON.plans.features) {
+      const pid = f.properties?.planId;
+      if (pid) planIds.add(pid);
+    }
+    counts.plans = planIds.size;
+  }
+  if (activeLayers.has("contacts") && filteredContacts) {
+    counts.contacts = filteredContacts.features.length;
+  }
+  if (activeLayers.has("vacancies") && filteredVacancies) {
+    counts.vacancies = filteredVacancies.features.length;
+  }
+  if (activeLayers.has("activities") && filteredActivities) {
+    counts.activities = filteredActivities.features.length;
+  }
+  return counts;
+}, [total, activeLayers, overlayGeoJSON.plans, filteredContacts, filteredVacancies, filteredActivities]);
+```
+
+- [ ] **Step 6: Replace inline tab rendering with containers**
+
+Replace the overlay tab rendering block (around lines 835-854):
+
+```tsx
+{/* Before */}
+{showingOverlayTab && activeResultsTab === "plans" && (
+  activeLayers.has("plans")
+    ? <PlansTab data={plansQuery.data} isLoading={plansQuery.isLoading} />
+    : <LayerOffPrompt layer="Plans" />
+)}
+{showingOverlayTab && activeResultsTab === "contacts" && (
+  activeLayers.has("contacts")
+    ? <ContactsTab data={filteredContacts} isLoading={contactsQuery.isLoading} />
+    : <LayerOffPrompt layer="Contacts" />
+)}
+{showingOverlayTab && activeResultsTab === "vacancies" && (
+  activeLayers.has("vacancies")
+    ? <VacanciesTab data={filteredVacancies} isLoading={vacanciesQuery.isLoading} />
+    : <LayerOffPrompt layer="Vacancies" />
+)}
+{showingOverlayTab && activeResultsTab === "activities" && (
+  activeLayers.has("activities")
+    ? <ActivitiesTab data={filteredActivities} isLoading={activitiesQuery.isLoading} />
+    : <LayerOffPrompt layer="Activities" />
+)}
+
+{/* After */}
+{showingOverlayTab && activeResultsTab === "plans" && (
+  activeLayers.has("plans")
+    ? <PlansTabContainer geoStates={geoStates} />
+    : <LayerOffPrompt layer="Plans" />
+)}
+{showingOverlayTab && activeResultsTab === "contacts" && (
+  activeLayers.has("contacts")
+    ? <ContactsTabContainer filteredData={filteredContacts} geoStates={geoStates} />
+    : <LayerOffPrompt layer="Contacts" />
+)}
+{showingOverlayTab && activeResultsTab === "vacancies" && (
+  activeLayers.has("vacancies")
+    ? <VacanciesTabContainer filteredData={filteredVacancies} geoStates={geoStates} />
+    : <LayerOffPrompt layer="Vacancies" />
+)}
+{showingOverlayTab && activeResultsTab === "activities" && (
+  activeLayers.has("activities")
+    ? <ActivitiesTabContainer filteredData={filteredActivities} geoStates={geoStates} />
+    : <LayerOffPrompt layer="Activities" />
+)}
+```
+
+- [ ] **Step 7: Clean up unused imports**
+
+Remove now-unused imports from `index.tsx`:
+- `useMapContacts`, `useMapVacancies`, `useMapActivities`, `useMapPlans` (moved to containers)
+- `ContactsTab`, `VacanciesTab`, `ActivitiesTab`, `PlansTab` (rendered by containers)
+
+Keep imports for: `useCrossFilter`, `ResultsTabStrip`, `LayerOffPrompt`, `DistrictExploreModal`, and all the container imports added in Step 1.
+
+- [ ] **Step 8: Verify no regressions**
+
+Run: `npm test -- --run`
+Expected: All tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/features/map/components/SearchResults/index.tsx
+git commit -m "perf(map): isolate tab rendering in SearchResults for fast tab switching"
+```
+
+---
+
+### Task 7: Manual Smoke Test
+
+- [ ] **Step 1: Run the dev server**
+
+Run: `npm run dev`
+
+- [ ] **Step 2: Verify tab switching is snappy**
+
+On the Maps tab:
+1. Click Vacancies → should activate layer and show results panel
+2. Click Contacts → should switch immediately, no visible lag
+3. Click Districts → should switch immediately
+4. Click Activities → should switch immediately
+5. Click back to Vacancies → should switch immediately with cached data
+6. Rapidly click between all tabs — should feel instant
+
+- [ ] **Step 3: Verify cross-filtering still works**
+
+1. Apply a vacancy filter (e.g., category = SPED)
+2. Switch to Districts tab — should show districts filtered by vacancy overlay
+3. Switch back to Vacancies — filter should still be applied
+
+- [ ] **Step 4: Verify map layers still render**
+
+1. Activate Vacancies layer — pins should appear on the map
+2. Activate Contacts layer — contact pins should appear
+3. Pan/zoom — new data should load for visible layers
+4. Deactivate a layer — pins should disappear
+
+- [ ] **Step 5: Final commit if any adjustments were needed**

--- a/Docs/superpowers/specs/2026-04-13-tab-switching-perf-spec.md
+++ b/Docs/superpowers/specs/2026-04-13-tab-switching-perf-spec.md
@@ -1,0 +1,127 @@
+# Tab Switching Performance Fix
+
+**Date:** 2026-04-13  
+**Problem:** Significant lag when switching between layer tabs (Districts, Contacts, Vacancies, Activities, Plans) on the Maps tab. Each tab switch triggers multiple store mutations, re-evaluates all overlay query hooks, and re-renders the entire SearchResults tree.
+
+## Root Causes
+
+1. **Multiple sequential store mutations per tab switch.** `handleEntityChevronClick` calls `toggleLayer()` then `openResultsPanel()` — two separate `set()` calls, two React re-renders.
+
+2. **Unstable query keys.** `useMapVacancies`, `useMapContacts`, and `useMapActivities` include raw filter/dateRange objects in their query keys. Every `setLayerFilter` call creates new object references via spread, triggering TanStack Query key comparison failures and unnecessary refetches — even when filter values haven't changed.
+
+3. **Monolithic SearchResults component.** `SearchResults/index.tsx` subscribes to `layerFilters`, `dateRange`, `mapBounds`, and `activeLayers` at the top level and runs all overlay query hooks on every render. Changing any layer's state re-evaluates hooks for every layer.
+
+## Solution: Approach B — Isolate Tab Rendering
+
+### Change 1: Stable Query Keys
+
+**Files:** `src/features/map/lib/queries.ts`
+
+Replace object references in query keys with the already-computed `queryString`:
+
+```ts
+// Before
+queryKey: ["mapVacancies", qBounds, filters, dateRange, geoStates]
+
+// After
+queryKey: ["mapVacancies", queryString]
+```
+
+Apply to all three overlay query hooks: `useMapVacancies`, `useMapContacts`, `useMapActivities`. The `buildOverlayParams` function already serializes filter values into a deterministic URL string — two identical filter states produce identical strings.
+
+### Change 2: Batched Store Action
+
+**Files:** `src/features/map/lib/store.ts`, `src/features/map/components/SearchBar/index.tsx`
+
+Add a new `switchToLayer` action that combines `toggleLayer` + `openResultsPanel` into a single `set()`:
+
+```ts
+switchToLayer: (layer) =>
+  set((s) => {
+    const next = new Set(s.activeLayers);
+    next.add(layer);
+    return {
+      activeLayers: next,
+      activeResultsTab: layer,
+      searchResultsVisible: true,
+    };
+  }),
+```
+
+Update `handleEntityChevronClick` in `SearchBar/index.tsx` to call `switchToLayer` instead of `toggleLayer` + `openResultsPanel` separately. Note: `switchToLayer` only activates (adds to set) — it is used for opening a layer tab. The existing `toggleLayer` action is preserved for deactivating layers via the toggle button.
+
+### Change 3: Isolated Tab Containers
+
+**New files in `src/features/map/components/SearchResults/`:**
+- `ContactsTabContainer.tsx`
+- `VacanciesTabContainer.tsx`
+- `ActivitiesTabContainer.tsx`
+- `PlansTabContainer.tsx`
+
+Each container:
+- Subscribes to only its own store slice (e.g., `layerFilters.vacancies`, `dateRange.vacancies`)
+- Calls its own query hook (e.g., `useMapVacancies`)
+- Reports raw GeoJSON to the store via `setOverlayGeoJSON(layer, data)`
+- Receives filtered GeoJSON as a prop from the shell (after cross-filter)
+- Renders the existing presentation component (e.g., `<VacanciesTab>`)
+
+### Change 4: Slim SearchResults Shell
+
+**File:** `src/features/map/components/SearchResults/index.tsx`
+
+Remove from SearchResults:
+- `layerFilters` subscription
+- `dateRange` subscription
+- Individual overlay query hooks (`contactsQuery`, `vacanciesQuery`, `activitiesQuery`, `plansQuery`)
+
+Keep in SearchResults:
+- `activeResultsTab` (tab switching)
+- `activeLayers` (show `<LayerOffPrompt>` vs container)
+- `searchResultsVisible` (panel open/close)
+- `useCrossFilter` (needs all overlay data — see Change 5)
+- Districts logic (no overlay query, stays inline)
+- `tabCounts` computation
+
+Conditionally render tab containers based on `activeResultsTab`.
+
+### Change 5: Overlay GeoJSON Store Slice + Cross-Filter
+
+**File:** `src/features/map/lib/store.ts`
+
+Add new state and action:
+```ts
+// State
+overlayGeoJSON: {
+  contacts: FeatureCollection | null;
+  vacancies: FeatureCollection | null;
+  activities: FeatureCollection | null;
+  plans: FeatureCollection | null;
+}
+
+// Action
+setOverlayGeoJSON: (layer, data) => set(...)
+```
+
+**File:** `src/features/map/lib/useCrossFilter.ts` — no changes needed.
+
+Cross-filter stays in the SearchResults shell. It reads `overlayGeoJSON` from the store (populated by tab containers) and produces `filteredContacts`, `filteredVacancies`, `filteredActivities`, and `overlayDerivedLeaids`. Filtered data is passed down to tab containers as props.
+
+**Data flow:**
+1. Tab container fetches data via query hook
+2. Tab container writes raw GeoJSON to store: `setOverlayGeoJSON("vacancies", data)`
+3. SearchResults shell reads `overlayGeoJSON` from store, runs `useCrossFilter`
+4. Shell passes filtered data down: `<VacanciesTabContainer filteredData={filteredVacancies} />`
+
+## What Does NOT Change
+
+- Dropdown components (VacanciesDropdown, ContactsDropdown, etc.)
+- Map layer rendering pipeline (`layers.ts`, MapLibre sources/layers)
+- `useCrossFilter.ts` logic
+- Existing presentation tab components (`VacanciesTab`, `ContactsTab`, etc.)
+- `toggleLayer` action (still used for deactivating layers via toggle)
+
+## Expected Result
+
+- Tab switching: 1 store update → 1 re-render of the shell → conditional swap of mounted container. No cascade through all query hooks.
+- Filter changes on one layer: only that layer's container re-renders and refetches.
+- Query deduplication: identical filter states produce identical query keys — no phantom refetches.

--- a/src/features/map/components/SearchBar/index.tsx
+++ b/src/features/map/components/SearchBar/index.tsx
@@ -125,6 +125,7 @@ export default function SearchBar() {
   // Overlay layers
   const activeLayers = useMapV2Store((s) => s.activeLayers);
   const toggleLayer = useMapV2Store((s) => s.toggleLayer);
+  const switchToLayer = useMapV2Store((s) => s.switchToLayer);
   const contactFilters = useMapV2Store((s) => s.layerFilters.contacts);
   const vacancyFilters = useMapV2Store((s) => s.layerFilters.vacancies);
   const activityFilters = useMapV2Store((s) => s.layerFilters.activities);
@@ -221,16 +222,18 @@ export default function SearchBar() {
   const handleEntityChevronClick = useCallback((layerName: string, layerType: OverlayLayerType) => {
     const store = useMapV2Store.getState();
     if (!store.activeLayers.has(layerType)) {
-      toggleLayer(layerType);
+      switchToLayer(layerType);
+      setOpenDropdown((prev) => (prev === layerName ? null : layerName));
+    } else {
+      setOpenDropdown((prev) => {
+        const isOpening = prev !== layerName;
+        if (isOpening) {
+          useMapV2Store.getState().openResultsPanel(layerType as LayerType);
+        }
+        return isOpening ? layerName : null;
+      });
     }
-    setOpenDropdown((prev) => {
-      const isOpening = prev !== layerName;
-      if (isOpening) {
-        useMapV2Store.getState().openResultsPanel(layerType as LayerType);
-      }
-      return isOpening ? layerName : null;
-    });
-  }, [toggleLayer]);
+  }, [switchToLayer]);
 
   const activeFilterCount = searchFilters.length;
 

--- a/src/features/map/components/SearchResults/ActivitiesTab.tsx
+++ b/src/features/map/components/SearchResults/ActivitiesTab.tsx
@@ -1,7 +1,10 @@
 "use client";
 
+import { useState } from "react";
 import type { FeatureCollection, Point, Feature } from "geojson";
 import ActivityCard from "./ActivityCard";
+
+const PAGE_SIZE = 50;
 
 interface ActivitiesTabProps {
   data: FeatureCollection<Point> | undefined;
@@ -32,6 +35,7 @@ function SkeletonCards() {
 
 export default function ActivitiesTab({ data, isLoading }: ActivitiesTabProps) {
   const features = data?.features ?? [];
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
 
   if (isLoading) return <SkeletonCards />;
 
@@ -46,14 +50,36 @@ export default function ActivitiesTab({ data, isLoading }: ActivitiesTabProps) {
     );
   }
 
+  const visibleFeatures = features.slice(0, visibleCount);
+  const hasMore = visibleCount < features.length;
+
   return (
     <div className="flex-1 overflow-y-auto p-3 space-y-2">
-      {features.map((feature, i) => (
+      {features.length > 200 && (
+        <div className="flex items-center gap-2 rounded-lg bg-[#C4E7E6]/30 px-3 py-2">
+          <svg className="w-3.5 h-3.5 text-[#6EA3BE] shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
+          </svg>
+          <p className="text-[11px] text-[#544A78]">
+            <span className="font-semibold">{features.length.toLocaleString()} results</span>
+            {" \u2014 try adding filters to narrow down"}
+          </p>
+        </div>
+      )}
+      {visibleFeatures.map((feature, i) => (
         <ActivityCard
           key={feature.properties?.id ?? feature.id ?? i}
           feature={feature as Feature<Point>}
         />
       ))}
+      {hasMore && (
+        <button
+          onClick={() => setVisibleCount((c) => c + PAGE_SIZE)}
+          className="w-full py-2 rounded-lg text-xs font-medium text-[#544A78] bg-[#F7F5FA] hover:bg-[#EFEDF5] transition-colors"
+        >
+          Show more ({features.length - visibleCount} remaining)
+        </button>
+      )}
     </div>
   );
 }

--- a/src/features/map/components/SearchResults/ActivitiesTabContainer.tsx
+++ b/src/features/map/components/SearchResults/ActivitiesTabContainer.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect } from "react";
+import { useMapV2Store } from "@/features/map/lib/store";
+import { useMapActivities } from "@/features/map/lib/queries";
+import ActivitiesTab from "./ActivitiesTab";
+import type { FeatureCollection, Point } from "geojson";
+
+interface ActivitiesTabContainerProps {
+  filteredData: FeatureCollection<Point> | undefined;
+  geoStates: string[] | undefined;
+}
+
+export default function ActivitiesTabContainer({ filteredData, geoStates }: ActivitiesTabContainerProps) {
+  const filters = useMapV2Store((s) => s.layerFilters.activities);
+  const dateRange = useMapV2Store((s) => s.dateRange.activities);
+  const mapBounds = useMapV2Store((s) => s.mapBounds);
+  const setOverlayGeoJSON = useMapV2Store((s) => s.setOverlayGeoJSON);
+
+  const { data, isLoading } = useMapActivities(mapBounds, filters, dateRange, true, geoStates);
+
+  useEffect(() => {
+    setOverlayGeoJSON("activities", data ?? null);
+  }, [data, setOverlayGeoJSON]);
+
+  return <ActivitiesTab data={filteredData} isLoading={isLoading} />;
+}

--- a/src/features/map/components/SearchResults/ActivitiesTabContainer.tsx
+++ b/src/features/map/components/SearchResults/ActivitiesTabContainer.tsx
@@ -19,8 +19,10 @@ export default function ActivitiesTabContainer({ filteredData, geoStates }: Acti
 
   const { data, isLoading } = useMapActivities(mapBounds, filters, dateRange, true, geoStates);
 
+  // Report raw GeoJSON to store for cross-filtering; clear on unmount
   useEffect(() => {
     setOverlayGeoJSON("activities", data ?? null);
+    return () => setOverlayGeoJSON("activities", null);
   }, [data, setOverlayGeoJSON]);
 
   return <ActivitiesTab data={filteredData} isLoading={isLoading} />;

--- a/src/features/map/components/SearchResults/ContactsTab.tsx
+++ b/src/features/map/components/SearchResults/ContactsTab.tsx
@@ -1,7 +1,10 @@
 "use client";
 
+import { useState } from "react";
 import type { FeatureCollection, Point, Feature } from "geojson";
 import ContactCard from "./ContactCard";
+
+const PAGE_SIZE = 50;
 
 interface ContactsTabProps {
   data: FeatureCollection<Point> | undefined;
@@ -29,6 +32,7 @@ function SkeletonCards() {
 
 export default function ContactsTab({ data, isLoading }: ContactsTabProps) {
   const features = data?.features ?? [];
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
 
   if (isLoading) return <SkeletonCards />;
 
@@ -43,14 +47,36 @@ export default function ContactsTab({ data, isLoading }: ContactsTabProps) {
     );
   }
 
+  const visibleFeatures = features.slice(0, visibleCount);
+  const hasMore = visibleCount < features.length;
+
   return (
     <div className="flex-1 overflow-y-auto p-3 space-y-2">
-      {features.map((feature, i) => (
+      {features.length > 200 && (
+        <div className="flex items-center gap-2 rounded-lg bg-[#C4E7E6]/30 px-3 py-2">
+          <svg className="w-3.5 h-3.5 text-[#6EA3BE] shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
+          </svg>
+          <p className="text-[11px] text-[#544A78]">
+            <span className="font-semibold">{features.length.toLocaleString()} results</span>
+            {" \u2014 try adding filters to narrow down"}
+          </p>
+        </div>
+      )}
+      {visibleFeatures.map((feature, i) => (
         <ContactCard
           key={feature.properties?.id ?? feature.id ?? i}
           feature={feature as Feature<Point>}
         />
       ))}
+      {hasMore && (
+        <button
+          onClick={() => setVisibleCount((c) => c + PAGE_SIZE)}
+          className="w-full py-2 rounded-lg text-xs font-medium text-[#544A78] bg-[#F7F5FA] hover:bg-[#EFEDF5] transition-colors"
+        >
+          Show more ({features.length - visibleCount} remaining)
+        </button>
+      )}
     </div>
   );
 }

--- a/src/features/map/components/SearchResults/ContactsTabContainer.tsx
+++ b/src/features/map/components/SearchResults/ContactsTabContainer.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect } from "react";
+import { useMapV2Store } from "@/features/map/lib/store";
+import { useMapContacts } from "@/features/map/lib/queries";
+import ContactsTab from "./ContactsTab";
+import type { FeatureCollection, Point } from "geojson";
+
+interface ContactsTabContainerProps {
+  filteredData: FeatureCollection<Point> | undefined;
+  geoStates: string[] | undefined;
+}
+
+export default function ContactsTabContainer({ filteredData, geoStates }: ContactsTabContainerProps) {
+  const filters = useMapV2Store((s) => s.layerFilters.contacts);
+  const mapBounds = useMapV2Store((s) => s.mapBounds);
+  const setOverlayGeoJSON = useMapV2Store((s) => s.setOverlayGeoJSON);
+
+  const { data, isLoading } = useMapContacts(mapBounds, filters, true, geoStates);
+
+  // Report raw GeoJSON to store for cross-filtering
+  useEffect(() => {
+    setOverlayGeoJSON("contacts", data ?? null);
+  }, [data, setOverlayGeoJSON]);
+
+  return <ContactsTab data={filteredData} isLoading={isLoading} />;
+}

--- a/src/features/map/components/SearchResults/ContactsTabContainer.tsx
+++ b/src/features/map/components/SearchResults/ContactsTabContainer.tsx
@@ -18,9 +18,10 @@ export default function ContactsTabContainer({ filteredData, geoStates }: Contac
 
   const { data, isLoading } = useMapContacts(mapBounds, filters, true, geoStates);
 
-  // Report raw GeoJSON to store for cross-filtering
+  // Report raw GeoJSON to store for cross-filtering; clear on unmount
   useEffect(() => {
     setOverlayGeoJSON("contacts", data ?? null);
+    return () => setOverlayGeoJSON("contacts", null);
   }, [data, setOverlayGeoJSON]);
 
   return <ContactsTab data={filteredData} isLoading={isLoading} />;

--- a/src/features/map/components/SearchResults/PlansTabContainer.tsx
+++ b/src/features/map/components/SearchResults/PlansTabContainer.tsx
@@ -6,18 +6,16 @@ import { useMapPlans } from "@/features/map/lib/queries";
 import PlansTab from "./PlansTab";
 import type { FeatureCollection, Geometry } from "geojson";
 
-interface PlansTabContainerProps {
-  geoStates: string[] | undefined;
-}
-
-export default function PlansTabContainer({ geoStates }: PlansTabContainerProps) {
+export default function PlansTabContainer() {
   const filters = useMapV2Store((s) => s.layerFilters.plans);
   const setOverlayGeoJSON = useMapV2Store((s) => s.setOverlayGeoJSON);
 
   const { data, isLoading } = useMapPlans(filters, true);
 
+  // Report raw GeoJSON to store for cross-filtering; clear on unmount
   useEffect(() => {
     setOverlayGeoJSON("plans", data ?? null);
+    return () => setOverlayGeoJSON("plans", null);
   }, [data, setOverlayGeoJSON]);
 
   // PlansTab receives raw data (not cross-filtered) — plans are the cross-filter source

--- a/src/features/map/components/SearchResults/PlansTabContainer.tsx
+++ b/src/features/map/components/SearchResults/PlansTabContainer.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect } from "react";
+import { useMapV2Store } from "@/features/map/lib/store";
+import { useMapPlans } from "@/features/map/lib/queries";
+import PlansTab from "./PlansTab";
+import type { FeatureCollection, Geometry } from "geojson";
+
+interface PlansTabContainerProps {
+  geoStates: string[] | undefined;
+}
+
+export default function PlansTabContainer({ geoStates }: PlansTabContainerProps) {
+  const filters = useMapV2Store((s) => s.layerFilters.plans);
+  const setOverlayGeoJSON = useMapV2Store((s) => s.setOverlayGeoJSON);
+
+  const { data, isLoading } = useMapPlans(filters, true);
+
+  useEffect(() => {
+    setOverlayGeoJSON("plans", data ?? null);
+  }, [data, setOverlayGeoJSON]);
+
+  // PlansTab receives raw data (not cross-filtered) — plans are the cross-filter source
+  return <PlansTab data={data} isLoading={isLoading} />;
+}

--- a/src/features/map/components/SearchResults/VacanciesTab.tsx
+++ b/src/features/map/components/SearchResults/VacanciesTab.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import type { FeatureCollection, Point, Feature } from "geojson";
 import { useMapV2Store } from "@/features/map/lib/store";
 import VacancyCard from "./VacancyCard";
+
+const PAGE_SIZE = 50;
 
 interface VacanciesTabProps {
   data: FeatureCollection<Point> | undefined;
@@ -36,6 +38,7 @@ export default function VacanciesTab({ data, isLoading }: VacanciesTabProps) {
   const pinnedVacancyIds = useMapV2Store((s) => s.pinnedVacancyIds);
   const setPinnedVacancyIds = useMapV2Store((s) => s.setPinnedVacancyIds);
   const setExploreModalLeaid = useMapV2Store((s) => s.setExploreModalLeaid);
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
 
   const allFeatures = data?.features ?? [];
 
@@ -44,6 +47,9 @@ export default function VacanciesTab({ data, isLoading }: VacanciesTabProps) {
     const pinned = new Set(pinnedVacancyIds);
     return allFeatures.filter((f) => pinned.has(String(f.properties?.id)));
   }, [allFeatures, pinnedVacancyIds]);
+
+  const visibleFeatures = features.slice(0, visibleCount);
+  const hasMore = visibleCount < features.length;
 
   if (isLoading) return <SkeletonCards />;
 
@@ -60,6 +66,17 @@ export default function VacanciesTab({ data, isLoading }: VacanciesTabProps) {
 
   return (
     <div className="flex-1 overflow-y-auto p-3 space-y-2">
+      {features.length > 200 && (
+        <div className="flex items-center gap-2 rounded-lg bg-[#C4E7E6]/30 px-3 py-2">
+          <svg className="w-3.5 h-3.5 text-[#6EA3BE] shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
+          </svg>
+          <p className="text-[11px] text-[#544A78]">
+            <span className="font-semibold">{features.length.toLocaleString()} results</span>
+            {" \u2014 try adding filters to narrow down"}
+          </p>
+        </div>
+      )}
       {pinnedVacancyIds && (
         <div className="flex items-center justify-between rounded-lg bg-[#F7F5FA] px-3 py-2 mb-1">
           <p className="text-xs text-[#403770]">
@@ -74,7 +91,7 @@ export default function VacanciesTab({ data, isLoading }: VacanciesTabProps) {
           </button>
         </div>
       )}
-      {features.map((feature, i) => (
+      {visibleFeatures.map((feature, i) => (
         <VacancyCard
           key={feature.properties?.id ?? feature.id ?? i}
           feature={feature as Feature<Point>}
@@ -87,6 +104,14 @@ export default function VacanciesTab({ data, isLoading }: VacanciesTabProps) {
           }
         />
       ))}
+      {hasMore && (
+        <button
+          onClick={() => setVisibleCount((c) => c + PAGE_SIZE)}
+          className="w-full py-2 rounded-lg text-xs font-medium text-[#544A78] bg-[#F7F5FA] hover:bg-[#EFEDF5] transition-colors"
+        >
+          Show more ({features.length - visibleCount} remaining)
+        </button>
+      )}
     </div>
   );
 }

--- a/src/features/map/components/SearchResults/VacanciesTabContainer.tsx
+++ b/src/features/map/components/SearchResults/VacanciesTabContainer.tsx
@@ -19,8 +19,10 @@ export default function VacanciesTabContainer({ filteredData, geoStates }: Vacan
 
   const { data, isLoading } = useMapVacancies(mapBounds, filters, dateRange, true, geoStates);
 
+  // Report raw GeoJSON to store for cross-filtering; clear on unmount
   useEffect(() => {
     setOverlayGeoJSON("vacancies", data ?? null);
+    return () => setOverlayGeoJSON("vacancies", null);
   }, [data, setOverlayGeoJSON]);
 
   return <VacanciesTab data={filteredData} isLoading={isLoading} />;

--- a/src/features/map/components/SearchResults/VacanciesTabContainer.tsx
+++ b/src/features/map/components/SearchResults/VacanciesTabContainer.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect } from "react";
+import { useMapV2Store } from "@/features/map/lib/store";
+import { useMapVacancies } from "@/features/map/lib/queries";
+import VacanciesTab from "./VacanciesTab";
+import type { FeatureCollection, Point } from "geojson";
+
+interface VacanciesTabContainerProps {
+  filteredData: FeatureCollection<Point> | undefined;
+  geoStates: string[] | undefined;
+}
+
+export default function VacanciesTabContainer({ filteredData, geoStates }: VacanciesTabContainerProps) {
+  const filters = useMapV2Store((s) => s.layerFilters.vacancies);
+  const dateRange = useMapV2Store((s) => s.dateRange.vacancies);
+  const mapBounds = useMapV2Store((s) => s.mapBounds);
+  const setOverlayGeoJSON = useMapV2Store((s) => s.setOverlayGeoJSON);
+
+  const { data, isLoading } = useMapVacancies(mapBounds, filters, dateRange, true, geoStates);
+
+  useEffect(() => {
+    setOverlayGeoJSON("vacancies", data ?? null);
+  }, [data, setOverlayGeoJSON]);
+
+  return <VacanciesTab data={filteredData} isLoading={isLoading} />;
+}

--- a/src/features/map/components/SearchResults/__tests__/SearchResults.test.tsx
+++ b/src/features/map/components/SearchResults/__tests__/SearchResults.test.tsx
@@ -24,9 +24,7 @@ const mockStoreState = {
   setSearchBounds: vi.fn(),
   setSearchSort: vi.fn(),
   activeLayers: new Set(["districts"]),
-  layerFilters: { contacts: {}, vacancies: {}, activities: {}, plans: {} },
-  dateRange: { vacancies: { start: null, end: null, preset: null }, activities: { start: null, end: null, preset: null } },
-  mapBounds: null,
+  overlayGeoJSON: { contacts: null, vacancies: null, activities: null, plans: null },
   activeResultsTab: "districts" as string,
   openResultsPanel: vi.fn(),
   selectedFiscalYear: "fy26",
@@ -58,12 +56,10 @@ vi.mock("@/features/shared/lib/queries", () => ({
   useProfile: () => ({ data: { id: "user-1" } }),
 }));
 
-vi.mock("@/features/map/lib/queries", () => ({
-  useMapContacts: () => ({ data: [] }),
-  useMapVacancies: () => ({ data: [] }),
-  useMapActivities: () => ({ data: [] }),
-  useMapPlans: () => ({ data: [] }),
-}));
+vi.mock("../ContactsTabContainer", () => ({ default: () => <div data-testid="contacts-tab-container" /> }));
+vi.mock("../VacanciesTabContainer", () => ({ default: () => <div data-testid="vacancies-tab-container" /> }));
+vi.mock("../ActivitiesTabContainer", () => ({ default: () => <div data-testid="activities-tab-container" /> }));
+vi.mock("../PlansTabContainer", () => ({ default: () => <div data-testid="plans-tab-container" /> }));
 
 vi.mock("@/features/map/lib/useCrossFilter", () => ({
   useCrossFilter: () => ({ contactLeaids: new Set(), vacancyLeaids: new Set(), activityLeaids: new Set(), planLeaids: new Set() }),

--- a/src/features/map/components/SearchResults/index.tsx
+++ b/src/features/map/components/SearchResults/index.tsx
@@ -7,12 +7,10 @@ import { useMapV2Store } from "@/features/map/lib/store";
 import { mapV2Ref } from "@/features/map/lib/ref";
 import { useTerritoryPlans, useAddDistrictsToPlan, useCreateTerritoryPlan } from "@/features/plans/lib/queries";
 import { useProfile } from "@/features/shared/lib/queries";
-import {
-  useMapContacts,
-  useMapVacancies,
-  useMapActivities,
-  useMapPlans,
-} from "@/features/map/lib/queries";
+import ContactsTabContainer from "./ContactsTabContainer";
+import VacanciesTabContainer from "./VacanciesTabContainer";
+import ActivitiesTabContainer from "./ActivitiesTabContainer";
+import PlansTabContainer from "./PlansTabContainer";
 import type { LayerType } from "@/features/map/lib/layers";
 import { getFinancial } from "@/features/shared/lib/financial-helpers";
 import type { DistrictFinancial } from "@/features/shared/types/api-types";
@@ -20,10 +18,6 @@ import { useCrossFilter } from "@/features/map/lib/useCrossFilter";
 import DistrictSearchCard from "./DistrictSearchCard";
 import DistrictExploreModal from "./DistrictExploreModal";
 import ResultsTabStrip from "./ResultsTabStrip";
-import PlansTab from "./PlansTab";
-import ContactsTab from "./ContactsTab";
-import VacanciesTab from "./VacanciesTab";
-import ActivitiesTab from "./ActivitiesTab";
 
 interface SearchResultDistrict {
   leaid: string;
@@ -86,9 +80,7 @@ export default function SearchResults() {
 
   const activeLayers = useMapV2Store((s) => s.activeLayers);
   const activeResultsTab = useMapV2Store((s) => s.activeResultsTab);
-  const layerFilters = useMapV2Store((s) => s.layerFilters);
-  const dateRange = useMapV2Store((s) => s.dateRange);
-  const mapBounds = useMapV2Store((s) => s.mapBounds);
+  const overlayGeoJSON = useMapV2Store((s) => s.overlayGeoJSON);
 
   const { data: plans } = useTerritoryPlans();
   const { data: profile } = useProfile();
@@ -112,43 +104,17 @@ export default function SearchResults() {
     return undefined;
   }, [searchFilters]);
 
-  // Overlay query hooks — enabled when layer is active
-  const contactsQuery = useMapContacts(
-    mapBounds,
-    layerFilters.contacts,
-    activeLayers.has("contacts"),
-    geoStates,
-  );
-  const vacanciesQuery = useMapVacancies(
-    mapBounds,
-    layerFilters.vacancies,
-    dateRange.vacancies,
-    activeLayers.has("vacancies"),
-    geoStates,
-  );
-  const activitiesQuery = useMapActivities(
-    mapBounds,
-    layerFilters.activities,
-    dateRange.activities,
-    activeLayers.has("activities"),
-    geoStates,
-  );
-  const plansQuery = useMapPlans(
-    layerFilters.plans,
-    activeLayers.has("plans"),
-  );
-
-  // Cross-filter — single source of truth
+  // Cross-filter — single source of truth (reads from store, populated by tab containers)
   const {
     overlayDerivedLeaids,
     filteredContacts,
     filteredVacancies,
     filteredActivities,
   } = useCrossFilter({
-    plansGeoJSON: plansQuery.data,
-    contactsGeoJSON: contactsQuery.data,
-    vacanciesGeoJSON: vacanciesQuery.data,
-    activitiesGeoJSON: activitiesQuery.data,
+    plansGeoJSON: overlayGeoJSON.plans,
+    contactsGeoJSON: overlayGeoJSON.contacts,
+    vacanciesGeoJSON: overlayGeoJSON.vacancies,
+    activitiesGeoJSON: overlayGeoJSON.activities,
   });
 
   const [districts, setDistricts] = useState<SearchResultDistrict[]>([]);
@@ -483,10 +449,9 @@ export default function SearchResults() {
   const tabCounts = useMemo((): Partial<Record<LayerType, number>> => {
     const counts: Partial<Record<LayerType, number>> = {};
     counts.districts = total;
-    if (activeLayers.has("plans") && plansQuery.data) {
-      // Deduplicate by planId
+    if (activeLayers.has("plans") && overlayGeoJSON.plans) {
       const planIds = new Set<string>();
-      for (const f of plansQuery.data.features) {
+      for (const f of overlayGeoJSON.plans.features) {
         const pid = f.properties?.planId;
         if (pid) planIds.add(pid);
       }
@@ -502,7 +467,7 @@ export default function SearchResults() {
       counts.activities = filteredActivities.features.length;
     }
     return counts;
-  }, [total, activeLayers, plansQuery.data, filteredContacts, filteredVacancies, filteredActivities]);
+  }, [total, activeLayers, overlayGeoJSON.plans, filteredContacts, filteredVacancies, filteredActivities]);
 
   const showingOverlayTab = activeResultsTab !== "districts";
   const hasDistrictResults = isSearchActive || overlayDerivedLeaids != null || selectedDistrictLeaids.size > 0;
@@ -831,25 +796,25 @@ export default function SearchResults() {
         </div>
       )}
 
-      {/* Overlay tab content */}
+      {/* Overlay tab content — each container owns its own store subscriptions & queries */}
       {showingOverlayTab && activeResultsTab === "plans" && (
         activeLayers.has("plans")
-          ? <PlansTab data={plansQuery.data} isLoading={plansQuery.isLoading} />
+          ? <PlansTabContainer geoStates={geoStates} />
           : <LayerOffPrompt layer="Plans" />
       )}
       {showingOverlayTab && activeResultsTab === "contacts" && (
         activeLayers.has("contacts")
-          ? <ContactsTab data={filteredContacts} isLoading={contactsQuery.isLoading} />
+          ? <ContactsTabContainer filteredData={filteredContacts} geoStates={geoStates} />
           : <LayerOffPrompt layer="Contacts" />
       )}
       {showingOverlayTab && activeResultsTab === "vacancies" && (
         activeLayers.has("vacancies")
-          ? <VacanciesTab data={filteredVacancies} isLoading={vacanciesQuery.isLoading} />
+          ? <VacanciesTabContainer filteredData={filteredVacancies} geoStates={geoStates} />
           : <LayerOffPrompt layer="Vacancies" />
       )}
       {showingOverlayTab && activeResultsTab === "activities" && (
         activeLayers.has("activities")
-          ? <ActivitiesTab data={filteredActivities} isLoading={activitiesQuery.isLoading} />
+          ? <ActivitiesTabContainer filteredData={filteredActivities} geoStates={geoStates} />
           : <LayerOffPrompt layer="Activities" />
       )}
 

--- a/src/features/map/components/SearchResults/index.tsx
+++ b/src/features/map/components/SearchResults/index.tsx
@@ -799,7 +799,7 @@ export default function SearchResults() {
       {/* Overlay tab content — each container owns its own store subscriptions & queries */}
       {showingOverlayTab && activeResultsTab === "plans" && (
         activeLayers.has("plans")
-          ? <PlansTabContainer geoStates={geoStates} />
+          ? <PlansTabContainer />
           : <LayerOffPrompt layer="Plans" />
       )}
       {showingOverlayTab && activeResultsTab === "contacts" && (

--- a/src/features/map/lib/__tests__/store.overlays.test.ts
+++ b/src/features/map/lib/__tests__/store.overlays.test.ts
@@ -132,6 +132,30 @@ describe("setDateRange", () => {
   });
 });
 
+describe("switchToLayer", () => {
+  it("activates the layer, sets the results tab, and opens the results panel", () => {
+    useMapV2Store.getState().switchToLayer("vacancies");
+    const s = useMapV2Store.getState();
+    expect(s.activeLayers.has("vacancies")).toBe(true);
+    expect(s.activeResultsTab).toBe("vacancies");
+    expect(s.searchResultsVisible).toBe(true);
+  });
+
+  it("does not remove the districts layer", () => {
+    useMapV2Store.getState().switchToLayer("vacancies");
+    const s = useMapV2Store.getState();
+    expect(s.activeLayers.has("districts")).toBe(true);
+  });
+
+  it("preserves other active layers", () => {
+    useMapV2Store.getState().toggleLayer("contacts");
+    useMapV2Store.getState().switchToLayer("vacancies");
+    const s = useMapV2Store.getState();
+    expect(s.activeLayers.has("contacts")).toBe(true);
+    expect(s.activeLayers.has("vacancies")).toBe(true);
+  });
+});
+
 describe("geographyFilters", () => {
   it("defaults to empty states and null zipRadius", () => {
     const s = useMapV2Store.getState();

--- a/src/features/map/lib/queries.ts
+++ b/src/features/map/lib/queries.ts
@@ -238,7 +238,7 @@ export function useMapContacts(
   });
 
   return useQuery({
-    queryKey: ["mapContacts", qBounds, filters, geoStates],
+    queryKey: ["mapContacts", queryString],
     queryFn: () =>
       fetchJson<FeatureCollection<Point>>(`${API_BASE}/map/contacts${queryString}`),
     enabled: enabled && qBounds !== null,
@@ -271,7 +271,7 @@ export function useMapVacancies(
   );
 
   return useQuery({
-    queryKey: ["mapVacancies", qBounds, filters, dateRange, geoStates],
+    queryKey: ["mapVacancies", queryString],
     queryFn: () =>
       fetchJson<FeatureCollection<Point>>(`${API_BASE}/map/vacancies${queryString}`),
     enabled: enabled && qBounds !== null,
@@ -307,7 +307,7 @@ export function useMapActivities(
   );
 
   return useQuery({
-    queryKey: ["mapActivities", qBounds, filters, dateRange, geoStates],
+    queryKey: ["mapActivities", queryString],
     queryFn: () =>
       fetchJson<FeatureCollection<Point>>(`${API_BASE}/map/activities${queryString}`),
     enabled: enabled && qBounds !== null,
@@ -335,7 +335,7 @@ export function useMapPlans(
   const queryString = qs ? `?${qs}` : "";
 
   return useQuery({
-    queryKey: ["mapPlans", filters],
+    queryKey: ["mapPlans", queryString],
     queryFn: () =>
       fetchJson<FeatureCollection<Geometry>>(`${API_BASE}/map/plans${queryString}`),
     enabled,

--- a/src/features/map/lib/store.ts
+++ b/src/features/map/lib/store.ts
@@ -435,6 +435,7 @@ interface MapV2Actions {
 
   // Overlay layers (map planning overlays)
   toggleLayer: (layer: OverlayLayerType) => void;
+  switchToLayer: (layer: OverlayLayerType) => void;
   setLayerFilter: <K extends keyof LayerFilters>(layer: K, filter: Partial<LayerFilters[K]>) => void;
   setDateRange: (layer: "vacancies" | "activities", range: Partial<DateRange>) => void;
   setMapBounds: (bounds: [number, number, number, number] | null) => void;
@@ -1149,6 +1150,17 @@ export const useMapV2Store = create<MapV2State & MapV2Actions>()((set, get) => (
         next.add(layer);
       }
       return { activeLayers: next };
+    }),
+
+  switchToLayer: (layer) =>
+    set((s) => {
+      const next = new Set(s.activeLayers);
+      next.add(layer);
+      return {
+        activeLayers: next,
+        activeResultsTab: layer,
+        searchResultsVisible: true,
+      };
     }),
 
   setLayerFilter: (layer, filter) =>

--- a/src/features/map/lib/store.ts
+++ b/src/features/map/lib/store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import type { FeatureCollection, Point, Geometry } from "geojson";
 import type { VendorId, SignalId, LocaleId, LayerType, ColorDimension } from "@/features/map/lib/layers";
 import type { AccountTypeValue } from "@/features/shared/types/account-types";
 import { DEFAULT_VENDOR_PALETTE, DEFAULT_SIGNAL_PALETTE, DEFAULT_CATEGORY_COLORS, DEFAULT_CATEGORY_OPACITIES, deriveVendorCategoryColors, deriveSignalCategoryColors, getVendorPalette, getSignalPalette } from "@/features/map/lib/palettes";
@@ -282,6 +283,12 @@ interface MapV2State {
   layerFilters: LayerFilters;
   dateRange: Record<"vacancies" | "activities", DateRange>;
   mapBounds: [number, number, number, number] | null; // [west, south, east, north]
+  overlayGeoJSON: {
+    contacts: FeatureCollection<Point> | null;
+    vacancies: FeatureCollection<Point> | null;
+    activities: FeatureCollection<Point> | null;
+    plans: FeatureCollection<Geometry> | null;
+  };
 
   // Unified layer control
   colorBy: ColorDimension;
@@ -439,6 +446,7 @@ interface MapV2Actions {
   setLayerFilter: <K extends keyof LayerFilters>(layer: K, filter: Partial<LayerFilters[K]>) => void;
   setDateRange: (layer: "vacancies" | "activities", range: Partial<DateRange>) => void;
   setMapBounds: (bounds: [number, number, number, number] | null) => void;
+  setOverlayGeoJSON: (layer: keyof MapV2State["overlayGeoJSON"], data: FeatureCollection | null) => void;
 
   // Unified layer control
   setColorBy: (dimension: ColorDimension) => void;
@@ -592,6 +600,12 @@ export const useMapV2Store = create<MapV2State & MapV2Actions>()((set, get) => (
     activities: { start: null, end: null, preset: null },
   },
   mapBounds: null,
+  overlayGeoJSON: {
+    contacts: null,
+    vacancies: null,
+    activities: null,
+    plans: null,
+  },
 
   // Unified layer control
   colorBy: "engagement" as ColorDimension,
@@ -1180,6 +1194,11 @@ export const useMapV2Store = create<MapV2State & MapV2Actions>()((set, get) => (
     })),
 
   setMapBounds: (bounds) => set({ mapBounds: bounds }),
+
+  setOverlayGeoJSON: (layer, data) =>
+    set((s) => ({
+      overlayGeoJSON: { ...s.overlayGeoJSON, [layer]: data },
+    })),
 
   // Unified layer control
   setColorBy: (dimension) => set({ colorBy: dimension }),


### PR DESCRIPTION
## Summary

- **Stable query keys** — overlay query hooks now key on serialized URL strings instead of raw objects, preventing phantom refetches when filter state creates new object references
- **Batched store mutations** — new `switchToLayer` action combines layer activation + tab switch + panel open into a single Zustand `set()` call (1 render instead of 2-3)
- **Isolated tab containers** — each overlay tab (Contacts, Vacancies, Activities, Plans) owns its own store subscriptions and query hooks in a dedicated container component. SearchResults is now a thin shell that runs cross-filtering and conditionally swaps the active tab
- **Paginated card lists** — tabs render 50 items initially with "Show more" progressive loading, preventing DOM thrashing from hundreds of cards mounting at once
- **Filter hint banner** — soft Robin's Egg banner appears at 200+ results recommending users narrow with filters
- **Performance conventions in CLAUDE.md** — codified list pagination, stable query keys, batched mutations, isolated subscriptions, and cleanup-on-unmount as project-wide rules

## Test plan

- [ ] Switch rapidly between Districts, Contacts, Vacancies, Activities, Plans tabs — should feel instant
- [ ] Apply vacancy filters, switch to Districts tab — cross-filtered districts should display
- [ ] Switch back to Vacancies — filter should persist, data loads from cache
- [ ] Activate/deactivate overlay layers — map pins appear/disappear correctly
- [ ] Pan/zoom map with layers active — new data loads for visible area
- [ ] Verify "Show more" button appears and works when >50 results
- [ ] Verify filter hint banner appears when >200 results
- [ ] Run `npm test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)