### PR TITLE
fix(scheduler): reject invalid ncesId mappings to unblock sync

### DIFF
--- a/scheduler/sync/queries.py
+++ b/scheduler/sync/queries.py
@@ -109,15 +109,31 @@ def fetch_district_mappings(client, account_ids):
         ["id", "ncesId", "name", "state", "hasParent", "asDistrict"],
     )
     mapping = {}
+    rejected = 0
     for hit in hits:
         src = hit["_source"]
         account_id = str(src["id"])
         nces_id = src.get("ncesId")
+        # NCES district LEAIDs are exactly 7 digits. Anything else (e.g. a
+        # 12-digit school-level NCES ID) would blow up the VARCHAR(7) constraint
+        # on opportunities.district_lea_id — reject here so the opp falls
+        # through to unmatched instead of poisoning the whole batch.
+        if nces_id is not None and (len(nces_id) != 7 or not nces_id.isdigit()):
+            logger.warning(
+                "Rejecting district mapping: account_id=%s ncesId=%r len=%d "
+                "asDistrict=%s name=%r — expected 7-digit LEAID",
+                account_id, nces_id, len(nces_id),
+                src.get("asDistrict"), src.get("name"),
+            )
+            nces_id = None
+            rejected += 1
         mapping[account_id] = {
             "nces_id": nces_id,
             "leaid": nces_id,  # ncesId and leaid are the same
             "name": src.get("name"),
             "type": "district",
         }
+    if rejected:
+        logger.warning(f"Rejected {rejected} district mappings with invalid ncesId")
     logger.info(f"Resolved {len(mapping)} district mappings")
     return mapping

--- a/scheduler/tests/test_queries.py
+++ b/scheduler/tests/test_queries.py
@@ -46,3 +46,21 @@ def test_fetch_district_mappings():
         assert "12345" in result
         assert result["12345"]["leaid"] == "0100001"
         assert result["12345"]["nces_id"] == "0100001"
+
+
+def test_fetch_district_mappings_rejects_non_seven_digit_ncesid():
+    with patch("sync.queries.scroll_all") as mock_scroll:
+        mock_scroll.return_value = [
+            {"_source": {"id": 1, "ncesId": "0100001", "name": "Good District"}},
+            {"_source": {"id": 2, "ncesId": "010000100123", "name": "School Row"}},
+            {"_source": {"id": 3, "ncesId": "abc1234", "name": "Non-numeric"}},
+            {"_source": {"id": 4, "ncesId": None, "name": "Null ncesId"}},
+        ]
+        result = fetch_district_mappings(MagicMock(), [1, 2, 3, 4])
+
+        assert result["1"]["leaid"] == "0100001"
+        assert result["2"]["leaid"] is None
+        assert result["2"]["nces_id"] is None
+        assert result["3"]["leaid"] is None
+        assert result["3"]["nces_id"] is None
+        assert result["4"]["leaid"] is None


### PR DESCRIPTION
## Summary
- Hotfix for the repeating `value too long for type character varying(7)` scheduler alerts
- `clj-prod-districts` has ~30 records with malformed `ncesId` values (trailing whitespace, account IDs in the ncesId field, 6-digit codes, stray punctuation). When an hourly batch happens to touch one of these, the VARCHAR(7) constraint on `opportunities.district_lea_id` rejects the row, aborts the whole transaction, and `last_synced_at` never advances — so the scheduler loops on the same broken batch until upstream data changes
- Fix validates `ncesId` is a 7-digit string in `fetch_district_mappings`; invalid rows get logged with `account_id`, offending value, length, and district name, then fall through to `unmatched_opportunities` via the existing null-district path

## Context
- Two manual local sync runs (yesterday + this morning) with this code rejected 32 and 21 bad records respectively, and both completed successfully — so the fix is proven against prod data
- Full rejection list lives in local `/tmp/manual-sync*.log` — worth sending to whoever owns the districts index for upstream cleanup (most of the whitespace cases are real, valid districts we're currently missing revenue data for, which a follow-up `.strip()` normalization can recover safely)
- The 4-consecutive-failures alerts on 2026-04-14 at 04:22 UTC and 16:33 UTC were both manifestations of this same root cause

## Test plan
- [x] `python3 -m pytest scheduler/tests/test_queries.py -v` — 4/4 pass including new `test_fetch_district_mappings_rejects_non_seven_digit_ncesid`
- [x] Manual sync run against prod OpenSearch + Supabase succeeded twice (376 opps yesterday, 189 opps today)
- [ ] After merge + Railway redeploy: confirm next hourly cycle advances `last_synced_at` and no new Slack alerts fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)