### PR TITLE
feat(cron): daily leaderboard Slack post via Vercel Cron

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,3 +50,8 @@ ENCRYPTION_KEY=
 #   openssl rand -hex 32
 # Set in Vercel (production + preview) and pass as `Authorization: Bearer <secret>` from scheduled agents.
 LEADERBOARD_IMAGE_SECRET=
+
+# Slack channel (name or ID) for the daily leaderboard cron post.
+# If omitted, defaults to "test-automations". Strip the leading #.
+# The bot (identified by SLACK_BOT_TOKEN) must be a member of this channel.
+SLACK_LEADERBOARD_CHANNEL=test-automations

--- a/src/app/api/cron/leaderboard-slack-post/route.tsx
+++ b/src/app/api/cron/leaderboard-slack-post/route.tsx
@@ -1,0 +1,158 @@
+import { ImageResponse } from "next/og";
+import { NextRequest, NextResponse } from "next/server";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  fetchLeaderboardData,
+  NoActiveInitiativeError,
+} from "@/features/leaderboard/lib/fetch-leaderboard";
+import { LeaderboardImageLayout } from "@/features/leaderboard/lib/image-layout";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+const FONTS_DIR = join(process.cwd(), "src/features/leaderboard/lib/fonts");
+
+const fontRegular = readFile(join(FONTS_DIR, "PlusJakartaSans-Regular.ttf"));
+const fontSemiBold = readFile(join(FONTS_DIR, "PlusJakartaSans-SemiBold.ttf"));
+
+async function renderLeaderboardPng(): Promise<Buffer> {
+  const [regular, semiBold] = await Promise.all([fontRegular, fontSemiBold]);
+  const payload = await fetchLeaderboardData();
+  const height = 150 + 46 + payload.entries.length * 44 + 50 + 20;
+
+  const response = new ImageResponse(
+    <LeaderboardImageLayout payload={payload} />,
+    {
+      width: 1200,
+      height,
+      fonts: [
+        { name: "Plus Jakarta Sans", data: regular, weight: 400, style: "normal" },
+        { name: "Plus Jakarta Sans", data: semiBold, weight: 600, style: "normal" },
+      ],
+    },
+  );
+
+  return Buffer.from(await response.arrayBuffer());
+}
+
+async function resolveChannelId(token: string, channel: string): Promise<string> {
+  if (/^[CDGM][A-Z0-9]{8,}$/.test(channel)) return channel;
+
+  const name = channel.replace(/^#/, "");
+  let cursor: string | undefined;
+  do {
+    const url = new URL("https://slack.com/api/conversations.list");
+    url.searchParams.set("types", "public_channel,private_channel");
+    url.searchParams.set("limit", "200");
+    if (cursor) url.searchParams.set("cursor", cursor);
+
+    const res = await fetch(url.toString(), {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const data = await res.json();
+    if (!data.ok) throw new Error(`Slack conversations.list failed: ${data.error}`);
+
+    const match = data.channels.find((c: { id: string; name: string }) => c.name === name);
+    if (match) return match.id;
+
+    cursor = data.response_metadata?.next_cursor || undefined;
+  } while (cursor);
+
+  throw new Error(`Slack channel not found: ${name} (bot must be a member)`);
+}
+
+async function uploadImageToSlack(
+  token: string,
+  channelId: string,
+  pngBytes: Buffer,
+  filename: string,
+  comment: string,
+): Promise<void> {
+  const getUrlRes = await fetch("https://slack.com/api/files.getUploadURLExternal", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      filename,
+      length: pngBytes.byteLength.toString(),
+    }),
+  });
+  const getUrlData = await getUrlRes.json();
+  if (!getUrlData.ok) throw new Error(`Slack getUploadURLExternal failed: ${getUrlData.error}`);
+
+  const { upload_url, file_id } = getUrlData;
+
+  const uploadRes = await fetch(upload_url, {
+    method: "POST",
+    body: new Uint8Array(pngBytes),
+  });
+  if (!uploadRes.ok) {
+    throw new Error(`Slack upload POST failed: ${uploadRes.status} ${uploadRes.statusText}`);
+  }
+
+  const completeRes = await fetch("https://slack.com/api/files.completeUploadExternal", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      files: [{ id: file_id, title: filename }],
+      channel_id: channelId,
+      initial_comment: comment,
+    }),
+  });
+  const completeData = await completeRes.json();
+  if (!completeData.ok) {
+    throw new Error(`Slack completeUploadExternal failed: ${completeData.error}`);
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const secret = searchParams.get("secret");
+  const authHeader = request.headers.get("authorization");
+  const cronSecret = process.env.CRON_SECRET;
+
+  if (cronSecret && authHeader !== `Bearer ${cronSecret}` && secret !== cronSecret) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const token = process.env.SLACK_BOT_TOKEN;
+  if (!token) {
+    return NextResponse.json({ error: "SLACK_BOT_TOKEN not configured" }, { status: 500 });
+  }
+
+  const channel = process.env.SLACK_LEADERBOARD_CHANNEL || "test-automations";
+
+  try {
+    const channelId = await resolveChannelId(token, channel);
+    const pngBytes = await renderLeaderboardPng();
+    const today = new Date().toISOString().split("T")[0];
+
+    await uploadImageToSlack(
+      token,
+      channelId,
+      pngBytes,
+      `leaderboard-${today}.png`,
+      "Daily Fullmind sales leaderboard",
+    );
+
+    return NextResponse.json({
+      ok: true,
+      bytes: pngBytes.byteLength,
+      channel,
+    });
+  } catch (error) {
+    console.error("leaderboard-slack-post failed", error);
+    if (error instanceof NoActiveInitiativeError) {
+      return NextResponse.json({ ok: false, reason: "no-active-initiative" }, { status: 200 });
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,10 @@
     {
       "path": "/api/cron/vacancy-hygiene?secret=${CRON_SECRET}",
       "schedule": "0 6 * * *"
+    },
+    {
+      "path": "/api/cron/leaderboard-slack-post?secret=${CRON_SECRET}",
+      "schedule": "0 13 * * 1-5"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Replaces the broken remote-Claude-agent approach (blocked by Vercel System Mitigations) with a Vercel Cron that runs server-side and uploads the leaderboard PNG to Slack directly.

- New route: `GET /api/cron/leaderboard-slack-post?secret=${CRON_SECRET}`
- Renders the same Satori PNG as `/api/leaderboard-image` (shared `fetchLeaderboardData()` + `LeaderboardImageLayout`)
- Uploads via Slack's `files.uploadV2` three-step flow (raw fetch, no new deps)
- Channel resolved by name via `conversations.list` (default: `test-automations`)
- Schedule: `0 13 * * 1-5` (weekdays 8am America/Chicago)

## Config required before merge

- `SLACK_BOT_TOKEN` — already set in Vercel (existing bot)
- `CRON_SECRET` — already set in Vercel (used by existing crons)
- `SLACK_LEADERBOARD_CHANNEL` — optional, defaults to `test-automations`. To switch to `#mapomatic5000` later, set this in Vercel to `mapomatic5000` (no hash).

## Test plan

- [ ] Vercel preview build succeeds
- [ ] Typecheck passes (`npx tsc --noEmit`) — ✅ verified locally
- [ ] After merge: manually hit `https://plan.fullmindlearning.com/api/cron/leaderboard-slack-post?secret=$CRON_SECRET` — should return `{ok:true, bytes:N, channel:"test-automations"}` and post the PNG to #test-automations
- [ ] Wait for the first scheduled run (next weekday 8am CT) to confirm Vercel Cron picks up the new entry

## Related

Disabled the now-unneeded Claude Code remote trigger `trig_01EGMm3BQxfJadRA8CRW4SW4` ("Daily leaderboard post to Slack (test)"). Can be deleted via https://claude.ai/code/scheduled once this is verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)