### PR TITLE
feat(leaderboard): filter zero-rev reps + fancier Slack copy

### DIFF
--- a/src/app/api/cron/leaderboard-slack-post/route.tsx
+++ b/src/app/api/cron/leaderboard-slack-post/route.tsx
@@ -19,7 +19,8 @@ const fontSemiBold = readFile(join(FONTS_DIR, "PlusJakartaSans-SemiBold.ttf"));
 
 async function renderLeaderboardPng(): Promise<Buffer> {
   const [regular, semiBold] = await Promise.all([fontRegular, fontSemiBold]);
-  const payload = await fetchLeaderboardData();
+  const raw = await fetchLeaderboardData();
+  const payload = { ...raw, entries: raw.entries.filter((e) => e.revenueCurrentFY > 0) };
   const height = 150 + 46 + payload.entries.length * 44 + 50 + 20;
 
   const response = new ImageResponse(
@@ -134,12 +135,24 @@ export async function GET(request: NextRequest) {
     const pngBytes = await renderLeaderboardPng();
     const today = new Date().toISOString().split("T")[0];
 
+    const comment = [
+      "🏆 *Fullmind Sales Leaderboard*",
+      "",
+      "Good morning, Sales Team! 🌅 Let's get after it today 💪🚀",
+      "",
+      "*Metric definitions*",
+      "• *Revenue* — Sum of Subscriptions + Sessions",
+      "• *Min Purchases* — Contracted floor per contract, summed across distinct contracts",
+      "• *Pipeline* — Sum of Open Opportunities (stages 0–5)",
+      "• *Targeted* — Sum of Plan District Targets minus Pipeline (untapped target)",
+    ].join("\n");
+
     await uploadImageToSlack(
       token,
       channelId,
       pngBytes,
       `leaderboard-${today}.png`,
-      "Daily Fullmind sales leaderboard",
+      comment,
     );
 
     return NextResponse.json({

--- a/src/app/api/leaderboard-image/route.tsx
+++ b/src/app/api/leaderboard-image/route.tsx
@@ -39,7 +39,8 @@ export async function GET(request: NextRequest) {
   const [regular, semiBold] = await Promise.all([fontRegular, fontSemiBold]);
 
   try {
-    const payload = await fetchLeaderboardData();
+    const raw = await fetchLeaderboardData();
+    const payload = { ...raw, entries: raw.entries.filter((e) => e.revenueCurrentFY > 0) };
     // next/og defaults height to 630 when omitted, clipping the table.
     // Compute height: header band ~150 + column headers 46 + rows × 44 + footer 50 + buffer.
     const height = 150 + 46 + payload.entries.length * 44 + 50 + 20;


### PR DESCRIPTION
## Summary

Polish pass on the daily leaderboard Slack post:

- **Filter zero-revenue reps** from the rendered PNG so the image isn't padded with people who haven't booked anything in the current fiscal year. Applies to both `/api/leaderboard-image` (used by the UI and any callers) and `/api/cron/leaderboard-slack-post` (the daily Slack cron). Team totals still reflect the whole team — the footer row may exceed the sum of visible rows on purpose.
- **Fancier Slack post body** — adds a greeting, emoji, and inline metric definitions so anyone in the channel knows what the columns mean without having to ask. Definitions live in the Slack message body (not the image) to keep the PNG focused on data.

## Test plan

- [x] Typecheck passes (`npx tsc --noEmit`)
- [x] Verified locally (multiple previews posted to #test-automations)
- [ ] Vercel preview build succeeds
- [ ] After merge: flip `SLACK_LEADERBOARD_CHANNEL` in Vercel from `test-automations` → the revenue feed channel (`C01VD0DF3TQ`), redeploy, and trigger a one-off run to confirm production posts the new copy to the new channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)