### PR TITLE
feat: Principal target role + per-school Clay enrichment + school-level CSV export

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,25 @@ should cause a dramatic slowdown. Apply these rules to every new feature:
 - **Clean up on unmount** — useEffect hooks that write to shared state (store,
   context) must return a cleanup function to prevent stale data.
 
+### UX Defaults
+This is a single-user-first tool. Every interaction should feel personalized and
+require the fewest clicks possible. Apply these rules to all forms, filters, and
+creation flows:
+
+- **Default owner to current user** — any form with an owner, assignee, or rep
+  field must default to `profile.id` (via `useProfile()`), not "Unassigned" or
+  empty. Editing an existing record should preserve the saved owner.
+- **Create-and-add in one step** — when a user creates a new entity (plan, task,
+  activity) in a context where items are already selected (districts, contacts),
+  the creation flow must automatically associate those items. Never require a
+  second click to add what was already selected.
+- **Filter bars default to current user** — Rep/Owner filter dropdowns should
+  default to the current user's ID on mount, not "all". Use a ref guard to set
+  the default once without overwriting user-chosen filters.
+- **Show loading state, don't hide UI** — filters or dropdowns whose options
+  load asynchronously must render a disabled placeholder during loading, not
+  disappear. Disappearing UI causes layout shift and confusion.
+
 ### Testing
 - Vitest + Testing Library + jsdom
 - Tests co-located in `__tests__/` directories next to source

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,23 @@ creation flows:
 - Vitest + Testing Library + jsdom
 - Tests co-located in `__tests__/` directories next to source
 
+### External Webhooks (Clay, etc.)
+When touching any flow that asks a third party to POST back to us (Clay
+`CLAY_WEBHOOK_URL` callbacks, future webhook integrations), the callback URL is
+built from `NEXT_PUBLIC_SITE_URL`, which defaults to production
+(`https://plan.fullmindlearning.com`). That means **end-to-end verification on
+localhost requires a tunnel** — otherwise the third party POSTs back to prod and
+your local code never runs.
+
+- Start a tunnel: `ngrok http 3005` (ngrok is already authed on dev machines).
+- Put the public URL in `.env.local` as `NEXT_PUBLIC_SITE_URL=<tunnel-url>` and
+  restart `npm run dev` so the API routes pick it up.
+- After testing, remove the override from `.env.local` so subsequent runs
+  don't keep pointing Clay at a dead tunnel.
+- If you modify webhook request/response shape, also update the corresponding
+  Clay table's input columns / HTTP callback payload — app-side code alone
+  won't fix a mismatch on Clay's side.
+
 ## Large Files — Read Selectively
 - `src/features/map/lib/store.ts` (~1400 lines) — Zustand store, grep for specific slices
 - `src/features/map/lib/layers.ts` (688 lines) — MapLibre layer configs

--- a/Docs/superpowers/plans/2026-04-16-leaderboard-tier-removal-dynamic-fy.md
+++ b/Docs/superpowers/plans/2026-04-16-leaderboard-tier-removal-dynamic-fy.md
@@ -1,0 +1,895 @@
+# Leaderboard: Remove Tier Badges + Dynamic FY Checkboxes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove tier badge UI from all leaderboard views and replace FY dropdowns with dynamic, relative-label checkboxes (Previous/Current/Next) backed by prior-FY data from the API.
+
+**Architecture:** Three-layer change — (1) API adds prior-FY pipeline/targeted data to the response, (2) types updated to carry the new fields, (3) frontend components stripped of tier badges and FY dropdowns replaced with checkbox groups. The API already dynamically computes fiscal years from the current date, so the frontend labels auto-roll each year.
+
+**Tech Stack:** Next.js App Router, React 19, TypeScript, Prisma, TanStack Query, Tailwind 4, Vitest
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `src/app/api/leaderboard/route.ts` | Modify | Add prior-FY pipeline/targeted data to response |
+| `src/features/leaderboard/lib/types.ts` | Modify | Add `pipelinePriorFY`, `targetedPriorFY` to `LeaderboardEntry` |
+| `src/features/leaderboard/lib/queries.ts` | Modify | Add `priorFY` to `LeaderboardFiscalYears`, prior-FY fields to `teamTotals` |
+| `src/features/leaderboard/components/RevenueOverviewTab.tsx` | Modify | Replace FYSelect with FYCheckboxGroup + toast |
+| `src/features/leaderboard/components/LeaderboardHomeWidget.tsx` | Modify | Remove TierBadge, use neutral styling |
+| `src/features/leaderboard/components/LeaderboardModal.tsx` | Modify | Remove tier grouping, flat ranked list |
+| `src/features/leaderboard/components/LeaderboardDetailView.tsx` | Modify | Remove tier column |
+
+---
+
+### Task 1: Add Prior-FY Data to API Response
+
+**Files:**
+- Modify: `src/app/api/leaderboard/route.ts`
+
+- [ ] **Step 1: Add `pipelinePriorFY` to per-user actuals extraction**
+
+In the `repActuals` mapping (around line 76-84), add prior-FY pipeline alongside existing fields:
+
+```typescript
+return {
+  userId: score.userId,
+  pipeline: yearActuals.get(pipelineSchoolYr)?.openPipeline ?? 0,
+  pipelineCurrentFY: yearActuals.get(defaultSchoolYr)?.openPipeline ?? 0,
+  pipelineNextFY: yearActuals.get(nextFYSchoolYr)?.openPipeline ?? 0,
+  pipelinePriorFY: yearActuals.get(priorSchoolYr)?.openPipeline ?? 0,
+  take: yearActuals.get(takeSchoolYr)?.totalTake ?? 0,
+  revenue: yearActuals.get(revenueSchoolYr)?.totalRevenue ?? 0,
+  priorYearRevenue: yearActuals.get(priorSchoolYr)?.totalRevenue ?? 0,
+};
+```
+
+Also update the catch fallback (around line 86) to include `pipelinePriorFY: 0`.
+
+- [ ] **Step 2: Add prior-FY targeted districts query**
+
+Add `priorFYInt` alongside existing `currentFYInt` and `nextFYInt` (around line 173):
+
+```typescript
+const priorFYInt = currentFY - 1;
+```
+
+Expand the `Promise.all` (around line 183-198) to include a third query:
+
+```typescript
+const [targetedPriorFYDistricts, targetedCurrentFYDistricts, targetedNextFYDistricts] = await Promise.all([
+  prisma.territoryPlanDistrict.findMany({
+    where: { plan: { ...ownerFilter, fiscalYear: priorFYInt } },
+    select: {
+      renewalTarget: true, winbackTarget: true, expansionTarget: true, newBusinessTarget: true,
+      plan: { select: { ownerId: true, userId: true } },
+    },
+  }),
+  prisma.territoryPlanDistrict.findMany({
+    where: { plan: { ...ownerFilter, fiscalYear: currentFYInt } },
+    select: {
+      renewalTarget: true, winbackTarget: true, expansionTarget: true, newBusinessTarget: true,
+      plan: { select: { ownerId: true, userId: true } },
+    },
+  }),
+  prisma.territoryPlanDistrict.findMany({
+    where: { plan: { ...ownerFilter, fiscalYear: nextFYInt } },
+    select: {
+      renewalTarget: true, winbackTarget: true, expansionTarget: true, newBusinessTarget: true,
+      plan: { select: { ownerId: true, userId: true } },
+    },
+  }),
+]);
+```
+
+Add after the existing `sumTargets` calls (around line 211-212):
+
+```typescript
+const targetedPriorFYByUser = sumTargets(targetedPriorFYDistricts);
+```
+
+- [ ] **Step 3: Wire prior-FY fields into entry response and team totals**
+
+In the entry return object (around line 277-296), add:
+
+```typescript
+pipelinePriorFY: actuals.pipelinePriorFY,
+targetedPriorFY: targetedPriorFYByUser.get(score.userId) ?? 0,
+```
+
+In `sumActuals` calls for `teamTotals` (around line 315-332), add:
+
+```typescript
+pipelinePriorFY: sumActuals(repActuals, "pipelinePriorFY"),
+unassignedPipelinePriorFY: sumActuals(adminActuals, "pipelinePriorFY"),
+targetedPriorFY: sumTargetedMap(targetedPriorFYByUser, userIds),
+unassignedTargetedPriorFY: sumTargetedMap(targetedPriorFYByUser, adminUserIds),
+```
+
+Update `sumActuals` type parameter (around line 302-305) to include `"pipelinePriorFY"`:
+
+```typescript
+const sumActuals = (
+  pool: typeof repActuals,
+  key: "revenue" | "priorYearRevenue" | "pipelineCurrentFY" | "pipelineNextFY" | "pipelinePriorFY",
+): number => pool.reduce((acc, a) => acc + (a[key] ?? 0), 0);
+```
+
+In the `fiscalYears` response object (around line 352-355), add `priorFY`:
+
+```typescript
+fiscalYears: {
+  priorFY: priorSchoolYr,
+  currentFY: defaultSchoolYr,
+  nextFY: nextFYSchoolYr,
+},
+```
+
+- [ ] **Step 4: Verify API compiles**
+
+Run: `npx tsc --noEmit --pretty 2>&1 | grep -i "leaderboard/route" | head -20`
+Expected: No errors from `route.ts` (there may be pre-existing errors in other files).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/api/leaderboard/route.ts
+git commit -m "feat(leaderboard): add prior-FY pipeline and targeted data to API response"
+```
+
+---
+
+### Task 2: Update TypeScript Types and Query Interfaces
+
+**Files:**
+- Modify: `src/features/leaderboard/lib/types.ts`
+- Modify: `src/features/leaderboard/lib/queries.ts`
+
+- [ ] **Step 1: Add prior-FY fields to LeaderboardEntry**
+
+In `src/features/leaderboard/lib/types.ts`, add two fields to the `LeaderboardEntry` interface (after line 52, alongside existing `pipelineNextFY`):
+
+```typescript
+export interface LeaderboardEntry {
+  userId: string;
+  fullName: string;
+  avatarUrl: string | null;
+  totalPoints: number;
+  tier: TierRank;
+  rank: number;
+  take: number;
+  pipeline: number;
+  pipelinePriorFY: number;
+  pipelineCurrentFY: number;
+  pipelineNextFY: number;
+  revenue: number;
+  priorYearRevenue: number;
+  revenueTargeted: number;
+  targetedPriorFY: number;
+  targetedCurrentFY: number;
+  targetedNextFY: number;
+  combinedScore: number;
+  initiativeScore: number;
+  pointBreakdown: PointBreakdownItem[];
+}
+```
+
+- [ ] **Step 2: Add priorFY to LeaderboardFiscalYears and teamTotals**
+
+In `src/features/leaderboard/lib/queries.ts`, update:
+
+```typescript
+export interface LeaderboardFiscalYears {
+  priorFY: string;
+  currentFY: string;
+  nextFY: string;
+}
+```
+
+Add prior-FY fields to the `teamTotals` type (around line 22-37):
+
+```typescript
+teamTotals?: {
+  revenue: number;
+  priorYearRevenue: number;
+  unassignedRevenue: number;
+  unassignedPriorYearRevenue: number;
+
+  pipelinePriorFY: number;
+  pipelineCurrentFY: number;
+  pipelineNextFY: number;
+  unassignedPipelinePriorFY: number;
+  unassignedPipelineCurrentFY: number;
+  unassignedPipelineNextFY: number;
+
+  targetedPriorFY: number;
+  targetedCurrentFY: number;
+  targetedNextFY: number;
+  unassignedTargetedPriorFY: number;
+  unassignedTargetedCurrentFY: number;
+  unassignedTargetedNextFY: number;
+};
+```
+
+- [ ] **Step 3: Verify types compile**
+
+Run: `npx tsc --noEmit --pretty 2>&1 | grep -i "leaderboard" | head -20`
+Expected: No new errors from leaderboard files.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/features/leaderboard/lib/types.ts src/features/leaderboard/lib/queries.ts
+git commit -m "feat(leaderboard): add prior-FY fields to entry and query types"
+```
+
+---
+
+### Task 3: Replace FY Dropdowns with Checkbox Groups
+
+**Files:**
+- Modify: `src/features/leaderboard/components/RevenueOverviewTab.tsx`
+
+- [ ] **Step 1: Replace FYSelection type and helper functions**
+
+Replace the entire top section of the file (lines 1-31) with:
+
+```typescript
+"use client";
+
+import { useState, useMemo, useCallback } from "react";
+import { Check } from "lucide-react";
+import RevenuePodium from "./RevenuePodium";
+import RevenueTable from "./RevenueTable";
+import type { RevenueSortColumn, RevenueTableTotals } from "./RevenueTable";
+import { useLeaderboard } from "../lib/queries";
+import type { LeaderboardEntry } from "../lib/types";
+
+interface FYChecked {
+  prior: boolean;
+  current: boolean;
+  next: boolean;
+}
+
+const DEFAULT_FY_CHECKED: FYChecked = { prior: false, current: true, next: true };
+
+/** Convert school year "2025-26" to display "FY26" */
+function formatFYLabel(schoolYr: string): string {
+  const parts = schoolYr.split("-");
+  return `FY${parts[1] ?? schoolYr}`;
+}
+
+/** Sum the checked FY values for pipeline */
+function getPipelineValue(entry: LeaderboardEntry, checked: FYChecked): number {
+  let sum = 0;
+  if (checked.prior) sum += entry.pipelinePriorFY;
+  if (checked.current) sum += entry.pipelineCurrentFY;
+  if (checked.next) sum += entry.pipelineNextFY;
+  return sum;
+}
+
+/** Sum the checked FY values for targeted */
+function getTargetedValue(entry: LeaderboardEntry, checked: FYChecked): number {
+  let sum = 0;
+  if (checked.prior) sum += entry.targetedPriorFY;
+  if (checked.current) sum += entry.targetedCurrentFY;
+  if (checked.next) sum += entry.targetedNextFY;
+  return sum;
+}
+
+/** Count how many FYs are checked */
+function checkedCount(fy: FYChecked): number {
+  return (fy.prior ? 1 : 0) + (fy.current ? 1 : 0) + (fy.next ? 1 : 0);
+}
+```
+
+- [ ] **Step 2: Update component state and projections**
+
+Replace the component function (from `export default function RevenueOverviewTab()` through the end of the file) with:
+
+```typescript
+export default function RevenueOverviewTab() {
+  const [pipelineFY, setPipelineFY] = useState<FYChecked>({ ...DEFAULT_FY_CHECKED });
+  const [targetedFY, setTargetedFY] = useState<FYChecked>({ ...DEFAULT_FY_CHECKED });
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
+  const [sortColumn, setSortColumn] = useState<RevenueSortColumn>("revenue");
+  const [sortDirection, setSortDirection] = useState<"asc" | "desc">("desc");
+
+  const { data: leaderboard, isLoading } = useLeaderboard();
+
+  const showToast = useCallback((msg: string) => {
+    setToastMessage(msg);
+    setTimeout(() => setToastMessage(null), 2000);
+  }, []);
+
+  const handleToggle = useCallback(
+    (
+      current: FYChecked,
+      setter: (fy: FYChecked) => void,
+      key: keyof FYChecked
+    ) => {
+      if (current[key] && checkedCount(current) === 1) {
+        showToast("At least one fiscal year must be selected");
+        return;
+      }
+      setter({ ...current, [key]: !current[key] });
+    },
+    [showToast]
+  );
+
+  // Project entries with computed pipeline/targeted values based on FY selection
+  const projectedEntries = useMemo(() => {
+    return (leaderboard?.entries ?? []).map((entry) => ({
+      ...entry,
+      pipeline: getPipelineValue(entry, pipelineFY),
+      revenueTargeted: getTargetedValue(entry, targetedFY),
+    }));
+  }, [leaderboard?.entries, pipelineFY, targetedFY]);
+
+  const projectedTotals = useMemo<RevenueTableTotals | undefined>(() => {
+    const t = leaderboard?.teamTotals;
+    if (!t) return undefined;
+
+    const sumFY = (
+      prior: number,
+      current: number,
+      next: number,
+      checked: FYChecked
+    ): number => {
+      let sum = 0;
+      if (checked.prior) sum += prior;
+      if (checked.current) sum += current;
+      if (checked.next) sum += next;
+      return sum;
+    };
+
+    return {
+      revenue: t.revenue,
+      priorYearRevenue: t.priorYearRevenue,
+      pipeline: sumFY(t.pipelinePriorFY, t.pipelineCurrentFY, t.pipelineNextFY, pipelineFY),
+      revenueTargeted: sumFY(t.targetedPriorFY, t.targetedCurrentFY, t.targetedNextFY, targetedFY),
+      unassignedRevenue: t.unassignedRevenue,
+      unassignedPriorYearRevenue: t.unassignedPriorYearRevenue,
+      unassignedPipeline: sumFY(
+        t.unassignedPipelinePriorFY,
+        t.unassignedPipelineCurrentFY,
+        t.unassignedPipelineNextFY,
+        pipelineFY
+      ),
+      unassignedRevenueTargeted: sumFY(
+        t.unassignedTargetedPriorFY,
+        t.unassignedTargetedCurrentFY,
+        t.unassignedTargetedNextFY,
+        targetedFY
+      ),
+    };
+  }, [leaderboard?.teamTotals, pipelineFY, targetedFY]);
+
+  const sortedEntries = useMemo(() => {
+    return [...projectedEntries].sort((a, b) => {
+      const aVal = a[sortColumn];
+      const bVal = b[sortColumn];
+      return sortDirection === "desc" ? bVal - aVal : aVal - bVal;
+    });
+  }, [projectedEntries, sortColumn, sortDirection]);
+
+  const handleSort = (column: RevenueSortColumn) => {
+    if (column === sortColumn) {
+      setSortDirection((prev) => (prev === "desc" ? "asc" : "desc"));
+    } else {
+      setSortColumn(column);
+      setSortDirection("desc");
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="w-6 h-6 border-2 border-[#403770] border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  const fy = leaderboard?.fiscalYears;
+
+  const fyOptions: { key: keyof FYChecked; label: string; fyLabel: string }[] = fy
+    ? [
+        { key: "prior", label: "Previous", fyLabel: formatFYLabel(fy.priorFY) },
+        { key: "current", label: "Current", fyLabel: formatFYLabel(fy.currentFY) },
+        { key: "next", label: "Next", fyLabel: formatFYLabel(fy.nextFY) },
+      ]
+    : [];
+
+  return (
+    <div className="relative">
+      {/* Toast */}
+      {toastMessage && (
+        <div className="absolute top-1 left-1/2 -translate-x-1/2 z-10 px-3 py-1.5 bg-[#403770] text-white text-xs font-medium rounded-lg shadow-lg animate-fade-in">
+          {toastMessage}
+        </div>
+      )}
+
+      {/* FY checkbox selectors */}
+      {fy && (
+        <div className="flex flex-col gap-2 px-4 py-2.5 bg-[#F7F5FA] border-b border-[#EFEDF5]">
+          <FYCheckboxGroup
+            label="Pipeline"
+            options={fyOptions}
+            checked={pipelineFY}
+            onToggle={(key) => handleToggle(pipelineFY, setPipelineFY, key)}
+          />
+          <FYCheckboxGroup
+            label="Targeted"
+            options={fyOptions}
+            checked={targetedFY}
+            onToggle={(key) => handleToggle(targetedFY, setTargetedFY, key)}
+          />
+        </div>
+      )}
+
+      <RevenuePodium entries={sortedEntries} />
+      <RevenueTable
+        entries={sortedEntries}
+        sortColumn={sortColumn}
+        sortDirection={sortDirection}
+        onSort={handleSort}
+        teamTotals={projectedTotals}
+      />
+    </div>
+  );
+}
+
+function FYCheckboxGroup({
+  label,
+  options,
+  checked,
+  onToggle,
+}: {
+  label: string;
+  options: { key: keyof FYChecked; label: string; fyLabel: string }[];
+  checked: FYChecked;
+  onToggle: (key: keyof FYChecked) => void;
+}) {
+  return (
+    <div className="flex items-center gap-3">
+      <span className="text-[11px] font-semibold uppercase tracking-wider text-[#8A849A] w-16">
+        {label}:
+      </span>
+      <div className="flex items-center gap-2.5">
+        {options.map((opt) => {
+          const isChecked = checked[opt.key];
+          return (
+            <button
+              key={opt.key}
+              type="button"
+              onClick={() => onToggle(opt.key)}
+              className="flex items-center gap-1.5 group"
+            >
+              <div
+                className={`w-3.5 h-3.5 rounded-sm border flex items-center justify-center transition-colors ${
+                  isChecked
+                    ? "bg-[#403770] border-[#403770]"
+                    : "bg-white border-[#D4CFE2] group-hover:border-[#403770]"
+                }`}
+              >
+                {isChecked && <Check className="w-2.5 h-2.5 text-white" strokeWidth={3} />}
+              </div>
+              <span className="text-xs font-medium text-[#403770]">
+                {opt.label}
+              </span>
+              <span className="text-[10px] text-[#8A80A8]">
+                ({opt.fyLabel})
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Verify component compiles**
+
+Run: `npx tsc --noEmit --pretty 2>&1 | grep -i "RevenueOverviewTab" | head -10`
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/features/leaderboard/components/RevenueOverviewTab.tsx
+git commit -m "feat(leaderboard): replace FY dropdowns with dynamic checkbox groups"
+```
+
+---
+
+### Task 4: Remove Tier Badge from LeaderboardHomeWidget
+
+**Files:**
+- Modify: `src/features/leaderboard/components/LeaderboardHomeWidget.tsx`
+
+- [ ] **Step 1: Remove tier imports and use neutral styling**
+
+Replace imports (lines 5-7):
+
+```typescript
+// Remove these:
+// import TierBadge from "./TierBadge";
+// import { parseTierRank, TIER_COLORS } from "../lib/types";
+```
+
+Remove tier color logic (lines 42-44):
+
+```typescript
+// Remove these:
+// const tierRank = data.tier ?? "freshman";
+// const { tier } = parseTierRank(tierRank);
+// const colors = TIER_COLORS[tier];
+```
+
+Replace the style prop on the container div (around line 71-75) — swap `colors.bg` and `colors.glow` for static neutral values:
+
+```typescript
+style={{
+  backgroundColor: "#F7F5FA",
+  boxShadow: isHovered ? "0 0 20px rgba(138,128,168,0.3)" : "0 0 0 transparent",
+  transform: rankChanged ? "scale(1.02)" : "scale(1)",
+}}
+```
+
+Update the shimmer overlay gradient (around line 82):
+
+```typescript
+background: `linear-gradient(90deg, transparent, rgba(138,128,168,0.3), transparent)`,
+```
+
+- [ ] **Step 2: Replace tier badge row with rank-only display**
+
+Replace the "Top row: tier badge + rank" section (lines 88-92):
+
+```tsx
+{/* Rank display */}
+<div className="flex items-center justify-between mb-2">
+  <span className="text-lg font-bold text-[#403770]">#{data.rank}</span>
+  <span className="text-xs font-medium text-[#8A80A8]">
+    {data.totalPoints} pts
+  </span>
+</div>
+```
+
+- [ ] **Step 3: Verify component compiles**
+
+Run: `npx tsc --noEmit --pretty 2>&1 | grep -i "LeaderboardHomeWidget" | head -10`
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/features/leaderboard/components/LeaderboardHomeWidget.tsx
+git commit -m "fix(leaderboard): remove tier badge from home widget, use neutral styling"
+```
+
+---
+
+### Task 5: Remove Tier Grouping from LeaderboardModal
+
+**Files:**
+- Modify: `src/features/leaderboard/components/LeaderboardModal.tsx`
+
+- [ ] **Step 1: Remove tier-related imports and helpers**
+
+Update the imports (lines 7-9). Remove `TierBadge` import and unused tier type imports:
+
+```typescript
+// Remove:
+// import TierBadge from "./TierBadge";
+// Remove from types import: parseTierRank, TIER_LABELS, TIERS, TIER_COLORS, TierName
+// Keep:
+import type { LeaderboardView, LeaderboardEntry } from "../lib/types";
+```
+
+Remove the `getTierForEntry` helper function (lines 115-117).
+
+Remove `tierThresholdMap` construction (lines 119-124).
+
+- [ ] **Step 2: Replace tier-grouped initiative list with flat ranked list**
+
+Replace the entire initiative content section (lines 272-481 — the `{[...TIERS].reverse().map((tierKey) => { ... })}` block) with a flat list:
+
+```tsx
+<div className="divide-y divide-[#E2DEEC]">
+  {rankedEntries.map((entry) => {
+    const isExpanded = expandedUser === entry.userId;
+    const isMe = myRank?.userId === entry.userId;
+
+    return (
+      <div key={entry.userId}>
+        {/* Main row */}
+        <button
+          onClick={() =>
+            setExpandedUser(isExpanded ? null : entry.userId)
+          }
+          className={`w-full flex items-center gap-3 px-6 py-3 transition-colors text-left ${
+            isMe
+              ? "bg-[#C4E7E6]/20 border-l-3 border-l-[#C4E7E6]"
+              : "hover:bg-[#FAFAFA]"
+          }`}
+        >
+          <span className="w-8 text-sm font-bold text-[#403770] text-right">
+            #{entry.displayRank}
+          </span>
+
+          {entry.avatarUrl ? (
+            <img
+              src={entry.avatarUrl}
+              alt={entry.fullName}
+              className="w-8 h-8 rounded-full object-cover"
+              referrerPolicy="no-referrer"
+            />
+          ) : (
+            <div className="w-8 h-8 rounded-full bg-[#F37167] flex items-center justify-center">
+              <span className="text-xs font-bold text-white">
+                {entry.fullName
+                  .split(" ")
+                  .map((n) => n[0])
+                  .join("")
+                  .slice(0, 2)}
+              </span>
+            </div>
+          )}
+
+          <span className="flex-1 text-sm font-medium text-[#403770] truncate">
+            {entry.fullName}
+            {isMe && (
+              <span className="ml-1.5 text-[10px] font-semibold text-[#6EA3BE]">You</span>
+            )}
+          </span>
+
+          <span className="w-20 text-right text-sm font-semibold text-[#403770]">
+            {getScore(entry)}
+          </span>
+
+          <ChevronDown
+            className={`w-4 h-4 text-[#A69DC0] transition-transform ${
+              isExpanded ? "rotate-180" : ""
+            }`}
+          />
+        </button>
+
+        {/* Expanded breakdown — same as before */}
+        {isExpanded && (
+          <div className="px-6 pb-3 pt-0">
+            <div className="ml-11 rounded-xl bg-[#F7F5FA] p-4">
+              {view === "initiative" ? (
+                <div className="space-y-2">
+                  {(entry.pointBreakdown ?? []).map((b) => {
+                    const isRevenue = b.action === "revenue_targeted";
+                    const revenueDollars = isRevenue ? b.count * 10000 : 0;
+
+                    return (
+                      <div
+                        key={b.action}
+                        className="flex items-center justify-between"
+                      >
+                        <div className="flex items-center gap-2">
+                          <div className="w-6 h-6 rounded-md bg-[#403770]/10 flex items-center justify-center">
+                            <Target className="w-3.5 h-3.5 text-[#403770]" />
+                          </div>
+                          <div>
+                            <span className="text-xs font-medium text-[#403770]">
+                              {b.label}
+                            </span>
+                            {isRevenue ? (
+                              <span className="text-[10px] text-[#8A80A8] ml-1.5">
+                                {formatCurrency(revenueDollars)} targeted ÷ $10K = {b.count} units x {b.pointValue} pts
+                              </span>
+                            ) : (
+                              <span className="text-[10px] text-[#8A80A8] ml-1.5">
+                                {b.count} x {b.pointValue} pts
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                        <span className="text-xs font-semibold text-[#403770]">
+                          {b.total} pts
+                        </span>
+                      </div>
+                    );
+                  })}
+                  <div className="pt-2 mt-1 border-t border-[#E2DEEC] flex items-center justify-between">
+                    <span className="text-xs font-semibold text-[#403770]">
+                      Total Initiative Points
+                    </span>
+                    <span className="text-sm font-bold text-[#403770]">
+                      {entry.totalPoints} pts
+                    </span>
+                  </div>
+                </div>
+              ) : (
+                <div className="grid grid-cols-2 gap-x-6 gap-y-2">
+                  <ScoreRow
+                    icon={Target}
+                    label="Initiative Points"
+                    value={`${entry.totalPoints} pts`}
+                    weight={weights.initiative}
+                    color="#403770"
+                  />
+                  <ScoreRow
+                    icon={TrendingUp}
+                    label={`Pipeline (${fyLabels.pipeline})`}
+                    value={formatCurrency(entry.pipeline)}
+                    weight={weights.pipeline}
+                    color="#6EA3BE"
+                  />
+                  <ScoreRow
+                    icon={DollarSign}
+                    label={`Take (${fyLabels.take})`}
+                    value={formatCurrency(entry.take)}
+                    weight={weights.take}
+                    color="#69B34A"
+                  />
+                  <ScoreRow
+                    icon={Trophy}
+                    label={`Revenue (${fyLabels.revenue})`}
+                    value={formatCurrency(entry.revenue)}
+                    weight={weights.revenue}
+                    color="#D4A843"
+                  />
+                  {weights.revenueTargeted > 0 && (
+                    <ScoreRow
+                      icon={Target}
+                      label={`Targeted (${fyLabels.revenueTargeted})`}
+                      value={formatCurrency(entry.revenueTargeted)}
+                      weight={weights.revenueTargeted}
+                      color="#F37167"
+                    />
+                  )}
+                  <div className="col-span-2 pt-2 mt-1 border-t border-[#E2DEEC]">
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs font-semibold text-[#403770]">
+                        Combined Score
+                      </span>
+                      <span className="text-sm font-bold text-[#403770]">
+                        {entry.combinedScore.toFixed(1)}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  })}
+</div>
+```
+
+- [ ] **Step 3: Verify component compiles**
+
+Run: `npx tsc --noEmit --pretty 2>&1 | grep -i "LeaderboardModal" | head -10`
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/features/leaderboard/components/LeaderboardModal.tsx
+git commit -m "fix(leaderboard): remove tier grouping from modal, flat ranked list"
+```
+
+---
+
+### Task 6: Remove Tier Column from LeaderboardDetailView
+
+**Files:**
+- Modify: `src/features/leaderboard/components/LeaderboardDetailView.tsx`
+
+- [ ] **Step 1: Remove tier imports**
+
+Update line 6 — remove tier-related imports:
+
+```typescript
+// Remove:
+// import { TIER_LABELS, TIER_COLORS, parseTierRank } from "../lib/types";
+// import TierBadge from "./TierBadge";
+// import type { TierName } from "../lib/types";
+```
+
+- [ ] **Step 2: Remove tier column header**
+
+Remove the `<th>` for "Tier" (lines 83-85):
+
+```tsx
+// Remove:
+// <th className="text-center px-4 py-3 text-xs font-semibold text-[#8A80A8] uppercase tracking-wide w-28">
+//   Tier
+// </th>
+```
+
+- [ ] **Step 3: Remove tier column cell and unused variables**
+
+Remove the tier parsing and colors (lines 102-103):
+
+```typescript
+// Remove:
+// const tierKey = parseTierRank(entry.tier).tier;
+// const colors = TIER_COLORS[tierKey];
+```
+
+Remove the `<td>` for TierBadge (lines 156-158):
+
+```tsx
+// Remove:
+// <td className="px-4 py-3 text-center">
+//   <TierBadge tierRank={entry.tier} size="sm" />
+// </td>
+```
+
+Update the `colSpan` in the expanded detail row (line 182) — decrease by 1 since the tier column is gone:
+
+```tsx
+<td colSpan={2 + data.metrics.length + 1} className="px-6 py-4">
+```
+
+- [ ] **Step 4: Verify component compiles**
+
+Run: `npx tsc --noEmit --pretty 2>&1 | grep -i "LeaderboardDetailView" | head -10`
+Expected: No errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/leaderboard/components/LeaderboardDetailView.tsx
+git commit -m "fix(leaderboard): remove tier column from detail view"
+```
+
+---
+
+### Task 7: Update Existing Test + Manual Verification
+
+**Files:**
+- Modify: `src/features/leaderboard/components/__tests__/RevenuePodium.test.tsx` (check if it references tier)
+- Modify: `src/features/leaderboard/components/__tests__/RevenueTable.test.tsx` (check if mock data needs prior-FY fields)
+
+- [ ] **Step 1: Update test mock data to include prior-FY fields**
+
+Check the existing test files. The mock `LeaderboardEntry` objects in tests need `pipelinePriorFY` and `targetedPriorFY` fields added. In each test file, find the mock entry objects and add:
+
+```typescript
+pipelinePriorFY: 0,
+targetedPriorFY: 0,
+```
+
+alongside the existing `pipelineCurrentFY`, `pipelineNextFY`, `targetedCurrentFY`, `targetedNextFY` fields.
+
+- [ ] **Step 2: Run all leaderboard tests**
+
+Run: `npx vitest run --reporter verbose src/features/leaderboard/ 2>&1`
+Expected: All tests pass.
+
+- [ ] **Step 3: Run type check on full project**
+
+Run: `npx tsc --noEmit --pretty 2>&1 | tail -5`
+Expected: No new errors introduced.
+
+- [ ] **Step 4: Commit test updates**
+
+```bash
+git add src/features/leaderboard/components/__tests__/
+git commit -m "test(leaderboard): update mock data with prior-FY fields"
+```
+
+- [ ] **Step 5: Manual verification checklist**
+
+Start dev server: `npm run dev`
+
+Verify in browser:
+1. **Leaderboard modal** — no tier badges, no tier dividers, flat ranked list
+2. **Revenue Overview tab** — checkbox groups instead of dropdowns, defaults to Current + Next checked
+3. **Uncheck last checkbox** — re-checks it + shows "At least one fiscal year must be selected" toast for ~2s
+4. **Previous checkbox** — checking it adds prior-FY data to pipeline/targeted columns
+5. **Profile sidebar widget** — no "Freshman" badge, shows rank and points only
+6. **Detail view** — no tier column in the table
+7. **FY labels** — show dynamic values from API (e.g., "Previous (FY25)", "Current (FY26)", "Next (FY27)")

--- a/Docs/superpowers/plans/2026-04-20-find-contacts-principals.md
+++ b/Docs/superpowers/plans/2026-04-20-find-contacts-principals.md
@@ -1,0 +1,1883 @@
+# Find Contacts — Principal Target Role + School-Level Export
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add "Principal" as a Target Role in the Find Contacts popover, fire Clay enrichment per-school (not per-district) when selected, link returned contacts to their school, and change CSV export to one row per contact with School Name / Level / Type columns.
+
+**Architecture:** No Prisma schema changes — `School`, `SchoolContact`, and `Contact` already exist. The bulk-enrich API route branches on `targetRole`: the existing per-district path is untouched, and a new per-school path fetches `School` rows filtered by `schoolLevel`, skips schools already linked to a principal via `SchoolContact`, and fires one Clay webhook per school with `ncessch` in the payload. The Clay webhook callback upserts a `SchoolContact` whenever `ncessch` is present. The plan-contacts GET endpoint starts including `schoolContacts[].school` so the client can render per-school export rows. Frontend surfaces an inline school-level subfilter (3 checkboxes) inside the existing popover; CSV export switches to one-row-per-contact with 3 new columns.
+
+**Tech Stack:** Next.js 16 App Router, React 19, TypeScript, Prisma/PostgreSQL, TanStack Query, Vitest + Testing Library, Tailwind 4, Lucide icons.
+
+**Spec:** `Docs/superpowers/specs/2026-04-20-find-contacts-principals-design.md`
+
+**Branch:** `feat/find-contacts-principals` (already created, spec committed, no implementation commits yet)
+
+---
+
+## File Structure
+
+### New Files
+| File | Responsibility |
+|------|---------------|
+| `src/features/shared/lib/schoolLabels.ts` | Shared `SCHOOL_LEVEL_LABELS` + new `SCHOOL_TYPE_LABELS` constants (CSV export needs both, tooltip already uses level labels) |
+| `src/features/shared/lib/__tests__/schoolLabels.test.ts` | Unit test for label constants |
+| `src/app/api/territory-plans/[id]/contacts/bulk-enrich/__tests__/route.test.ts` | API route tests — Principal branch, school-level filter, skip already-enriched, metadata |
+| `src/app/api/webhooks/clay/__tests__/route.test.ts` | Webhook test — `ncessch` payload creates both `Contact` and `SchoolContact` |
+| `src/features/plans/components/__tests__/ContactsActionBar.test.tsx` | Component test — Principal popover shows checkboxes, empty selection disables Start |
+
+### Modified Files
+| File | Changes |
+|------|---------|
+| `src/features/shared/types/contact-types.ts` | Add `"Principal"` to `TARGET_ROLES` |
+| `src/features/shared/types/api-types.ts` | Extend `Contact` with optional `schoolContacts` array |
+| `src/features/map/components/MapV2Tooltip.tsx` | Import `SCHOOL_LEVEL_LABELS` from shared module instead of defining locally |
+| `src/features/map/components/panels/district/SchoolsCard.tsx` | Import `SCHOOL_LEVEL_LABELS` from shared module |
+| `src/features/map/components/panels/district/tabs/SchoolsTab.tsx` | Import `SCHOOL_LEVEL_LABELS` from shared module |
+| `src/features/map/components/panels/district/CharterSchools.tsx` | Import `SCHOOL_LEVEL_LABELS` from shared module |
+| `src/app/api/territory-plans/[id]/contacts/route.ts` | Include `schoolContacts: { include: { school } }`; return selected school fields per contact |
+| `src/app/api/territory-plans/[id]/contacts/bulk-enrich/route.ts` | Accept `schoolLevels`; branch on `targetRole === "Principal"` with per-school fetch, skip, webhook fire |
+| `src/app/api/territory-plans/[id]/contacts/enrich-progress/route.ts` | When the active activity is a Principal enrichment, count schools-with-principal-contacts instead of districts-with-contacts |
+| `src/app/api/webhooks/clay/route.ts` | When payload includes `ncessch`, upsert `SchoolContact` after creating/updating `Contact` |
+| `src/features/plans/lib/queries.ts` | Extend `useBulkEnrich` to pass `schoolLevels` |
+| `src/features/plans/components/ContactsActionBar.tsx` | Render school-level subsection when `selectedRole === "Principal"`; disable Start if none checked; rewrite `handleExportCsv` to one-row-per-contact with 3 new columns |
+
+---
+
+## Task 1: Clay Workflow Audit (manual, non-blocking for merge)
+
+The Clay workflow currently expects per-district fields. Before the feature produces correct results, the user must open Clay and verify the workflow accepts per-school input. The code ships and merges independently of this — the feature just won't return principal contacts until Clay is ready.
+
+**Files:** none (manual task, log the outcome in the task PR description).
+
+- [ ] **Step 1: Open the Clay workspace behind `CLAY_WEBHOOK_URL`**
+
+Find the webhook URL in `.env.local` or Vercel project env vars under `CLAY_WEBHOOK_URL`. Open Clay → find the table that ingests that URL.
+
+- [ ] **Step 2: Verify input columns**
+
+The input table (the one Clay writes incoming `/contacts/bulk-enrich` payloads into) must accept these columns in addition to what it already has:
+- `ncessch` (string)
+- `school_name` (string)
+- `school_level` (int)
+- `school_type` (int)
+
+If any are missing, add them as text/number columns.
+
+- [ ] **Step 3: Verify the enrichment step targets schools, not districts**
+
+The "Find Person" / Apollo / ZoomInfo step that finds the contact must use `school_name` (and `street`/`city`/`zip` from the school if available) as the company input when `target_role === "Principal"`. If the step is hardcoded to `district_name`, add a conditional or a second branch keyed on `target_role`.
+
+- [ ] **Step 4: Verify the callback HTTP column includes `ncessch`**
+
+The Clay HTTP column that POSTs results back to `/api/webhooks/clay` must include `ncessch` in the payload. Without this, the app cannot create the `SchoolContact` link and principal contacts will look like district-level contacts.
+
+- [ ] **Step 5: Record audit result**
+
+In the PR description, note one of:
+- ✅ Clay workflow already supported per-school — no edits made.
+- ✅ Edited Clay workflow (list which of the 3 items above were changed).
+- ⚠️ Clay workflow not yet updated — merging code-only; will enable after workflow is ready.
+
+---
+
+## Task 2: Spot-Check School Data Coverage
+
+`School.schoolType` population rate is unknown. If it's mostly null, the CSV column will be mostly blank — that's fine, but we want to know before shipping.
+
+**Files:** none (one-off DB query, log result).
+
+- [ ] **Step 1: Run coverage query against the dev/prod database**
+
+```bash
+npx prisma studio
+# OR, using psql directly:
+psql "$DATABASE_URL" -c "
+  SELECT
+    COUNT(*) AS total,
+    COUNT(school_type) AS with_type,
+    COUNT(school_level) AS with_level,
+    ROUND(100.0 * COUNT(school_type) / COUNT(*), 1) AS pct_type,
+    ROUND(100.0 * COUNT(school_level) / COUNT(*), 1) AS pct_level
+  FROM schools
+  WHERE school_status = 1;
+"
+```
+
+Expected: a single row with `pct_level` and `pct_type` percentages.
+
+- [ ] **Step 2: Record the result**
+
+In the PR description, add a line like: `School.schoolLevel: 94% populated. School.schoolType: 62% populated.` If `schoolLevel` coverage is under ~85%, flag to the user — the school-level filter will silently exclude unlabeled schools.
+
+---
+
+## Task 3: Sync Local Branch
+
+**Files:** none.
+
+- [ ] **Step 1: Confirm you're on the feature branch**
+
+```bash
+git branch --show-current
+```
+
+Expected: `feat/find-contacts-principals`
+
+- [ ] **Step 2: Rebase onto latest main**
+
+```bash
+git fetch origin
+git rebase origin/main
+```
+
+Expected: clean rebase (spec file adds only, no conflicts). If conflicts appear, resolve in the spec file and continue.
+
+- [ ] **Step 3: Verify tests still pass on the current tree**
+
+```bash
+npm test -- --run
+```
+
+Expected: all tests pass. If anything fails unrelated to this work, stop and fix that first on a separate branch (see `project_local_dev_broken.md` / `project_compilation_warnings.md` memory entries).
+
+---
+
+## Task 4: Create Shared School Labels Module
+
+Spec §7 leaves the location of `SCHOOL_TYPE_LABELS` open. CSV export needs both label maps, and `SCHOOL_LEVEL_LABELS` is already duplicated across four map components. Create one shared source.
+
+**Files:**
+- Create: `src/features/shared/lib/schoolLabels.ts`
+- Test: `src/features/shared/lib/__tests__/schoolLabels.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/features/shared/lib/__tests__/schoolLabels.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { SCHOOL_LEVEL_LABELS, SCHOOL_TYPE_LABELS } from "../schoolLabels";
+
+describe("SCHOOL_LEVEL_LABELS", () => {
+  it("maps all 4 NCES school levels", () => {
+    expect(SCHOOL_LEVEL_LABELS[1]).toBe("Elementary");
+    expect(SCHOOL_LEVEL_LABELS[2]).toBe("Middle");
+    expect(SCHOOL_LEVEL_LABELS[3]).toBe("High");
+    expect(SCHOOL_LEVEL_LABELS[4]).toBe("Other");
+  });
+});
+
+describe("SCHOOL_TYPE_LABELS", () => {
+  it("maps all 4 NCES school types", () => {
+    expect(SCHOOL_TYPE_LABELS[1]).toBe("Regular");
+    expect(SCHOOL_TYPE_LABELS[2]).toBe("Special Education");
+    expect(SCHOOL_TYPE_LABELS[3]).toBe("Career & Technical");
+    expect(SCHOOL_TYPE_LABELS[4]).toBe("Alternative");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+npm test -- --run src/features/shared/lib/__tests__/schoolLabels.test.ts
+```
+
+Expected: FAIL (module does not exist).
+
+- [ ] **Step 3: Create the module**
+
+Create `src/features/shared/lib/schoolLabels.ts`:
+
+```ts
+// NCES school level codes (common core of data)
+export const SCHOOL_LEVEL_LABELS: Record<number, string> = {
+  1: "Elementary",
+  2: "Middle",
+  3: "High",
+  4: "Other",
+};
+
+// NCES school type codes (common core of data)
+// 1 = Regular, 2 = Special Education, 3 = Career & Technical, 4 = Alternative
+export const SCHOOL_TYPE_LABELS: Record<number, string> = {
+  1: "Regular",
+  2: "Special Education",
+  3: "Career & Technical",
+  4: "Alternative",
+};
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+npm test -- --run src/features/shared/lib/__tests__/schoolLabels.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Replace duplicated `SCHOOL_LEVEL_LABELS` in existing consumers**
+
+In each of these four files, delete the local `SCHOOL_LEVEL_LABELS` definition (a `Record<number, string>` with entries for 1–4) and add this import near the top:
+
+```ts
+import { SCHOOL_LEVEL_LABELS } from "@/features/shared/lib/schoolLabels";
+```
+
+Files to update:
+- `src/features/map/components/MapV2Tooltip.tsx` (current definition at line 32)
+- `src/features/map/components/panels/district/SchoolsCard.tsx`
+- `src/features/map/components/panels/district/tabs/SchoolsTab.tsx`
+- `src/features/map/components/panels/district/CharterSchools.tsx`
+
+- [ ] **Step 6: Typecheck the whole tree**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no new errors from the removal/import swap. (Pre-existing errors are tracked separately per `project_compilation_warnings.md`.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/features/shared/lib/schoolLabels.ts \
+        src/features/shared/lib/__tests__/schoolLabels.test.ts \
+        src/features/map/components/MapV2Tooltip.tsx \
+        src/features/map/components/panels/district/SchoolsCard.tsx \
+        src/features/map/components/panels/district/tabs/SchoolsTab.tsx \
+        src/features/map/components/panels/district/CharterSchools.tsx
+git commit -m "refactor: centralize SCHOOL_LEVEL_LABELS + add SCHOOL_TYPE_LABELS in shared module"
+```
+
+---
+
+## Task 5: Add "Principal" to TARGET_ROLES
+
+**Files:**
+- Modify: `src/features/shared/types/contact-types.ts:67-75`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/features/shared/lib/__tests__/schoolLabels.test.ts` (or create a colocated test — the target-roles file has no existing test, so a new file is cleaner). Create `src/features/shared/types/__tests__/contact-types.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { TARGET_ROLES } from "../contact-types";
+
+describe("TARGET_ROLES", () => {
+  it("includes Principal as the 8th role", () => {
+    expect(TARGET_ROLES).toContain("Principal");
+  });
+
+  it("preserves existing roles in order", () => {
+    expect(TARGET_ROLES.slice(0, 7)).toEqual([
+      "Superintendent",
+      "Assistant Superintendent",
+      "Chief Technology Officer",
+      "Chief Financial Officer",
+      "Curriculum Director",
+      "Special Education Director",
+      "HR Director",
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+npm test -- --run src/features/shared/types/__tests__/contact-types.test.ts
+```
+
+Expected: FAIL (`TARGET_ROLES` does not contain "Principal").
+
+- [ ] **Step 3: Add Principal to the constant**
+
+In `src/features/shared/types/contact-types.ts`, change the `TARGET_ROLES` block from:
+
+```ts
+export const TARGET_ROLES = [
+  "Superintendent",
+  "Assistant Superintendent",
+  "Chief Technology Officer",
+  "Chief Financial Officer",
+  "Curriculum Director",
+  "Special Education Director",
+  "HR Director",
+] as const;
+```
+
+to:
+
+```ts
+export const TARGET_ROLES = [
+  "Superintendent",
+  "Assistant Superintendent",
+  "Chief Technology Officer",
+  "Chief Financial Officer",
+  "Curriculum Director",
+  "Special Education Director",
+  "HR Director",
+  "Principal",
+] as const;
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+npm test -- --run src/features/shared/types/__tests__/contact-types.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/shared/types/contact-types.ts \
+        src/features/shared/types/__tests__/contact-types.test.ts
+git commit -m "feat(types): add Principal to TARGET_ROLES"
+```
+
+---
+
+## Task 6: Include `schoolContacts` in Plan Contacts API
+
+CSV export needs per-contact school data. Extend the plan contacts GET endpoint to pull the `SchoolContact` join and include a minimal school payload per contact.
+
+**Files:**
+- Modify: `src/app/api/territory-plans/[id]/contacts/route.ts`
+- Modify: `src/features/shared/types/api-types.ts:87-101`
+
+- [ ] **Step 1: Extend the `Contact` API type**
+
+In `src/features/shared/types/api-types.ts`, replace lines 87–101 with:
+
+```ts
+export interface ContactSchoolLink {
+  ncessch: string;
+  name: string;
+  schoolLevel: number | null;
+  schoolType: number | null;
+}
+
+export interface Contact {
+  id: number;
+  leaid: string;
+  salutation: string | null;
+  name: string;
+  title: string | null;
+  email: string | null;
+  phone: string | null;
+  isPrimary: boolean;
+  linkedinUrl: string | null;
+  persona: string | null;
+  seniorityLevel: string | null;
+  createdAt: string;
+  lastEnrichedAt: string | null;
+  /** Present when the contact is linked to one or more schools (e.g. principals). Empty array for district-level contacts. */
+  schoolContacts: ContactSchoolLink[];
+}
+```
+
+- [ ] **Step 2: Update the GET route to return `schoolContacts`**
+
+In `src/app/api/territory-plans/[id]/contacts/route.ts`, change the `prisma.contact.findMany` call at lines 47–55 to include the join, and update the mapping at lines 69–85 to project the school data:
+
+```ts
+    const contacts = await prisma.contact.findMany({
+      where: {
+        leaid: { in: leaids },
+      },
+      orderBy: [
+        { isPrimary: "desc" },
+        { name: "asc" },
+      ],
+      include: {
+        schoolContacts: {
+          include: {
+            school: {
+              select: {
+                ncessch: true,
+                schoolName: true,
+                schoolLevel: true,
+                schoolType: true,
+              },
+            },
+          },
+        },
+      },
+    });
+```
+
+Then change the `return NextResponse.json(...)` block (lines 69–85) to:
+
+```ts
+    return NextResponse.json(
+      dedupedContacts.map((c) => ({
+        id: c.id,
+        leaid: c.leaid,
+        salutation: c.salutation,
+        name: c.name,
+        title: c.title,
+        email: c.email,
+        phone: c.phone,
+        isPrimary: c.isPrimary,
+        linkedinUrl: c.linkedinUrl,
+        persona: c.persona,
+        seniorityLevel: c.seniorityLevel,
+        createdAt: c.createdAt.toISOString(),
+        lastEnrichedAt: c.lastEnrichedAt?.toISOString() ?? null,
+        schoolContacts: c.schoolContacts.map((sc) => ({
+          ncessch: sc.school.ncessch,
+          name: sc.school.schoolName,
+          schoolLevel: sc.school.schoolLevel,
+          schoolType: sc.school.schoolType,
+        })),
+      }))
+    );
+```
+
+- [ ] **Step 3: Typecheck**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no new errors. (If `ContactsActionBar.tsx` now complains about missing `schoolContacts` in constructed test/mock data, that's a real follow-up — handle it in Task 12.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/features/shared/types/api-types.ts \
+        src/app/api/territory-plans/[id]/contacts/route.ts
+git commit -m "feat(api): include schoolContacts in plan contacts endpoint"
+```
+
+---
+
+## Task 7: Extend `bulk-enrich` — Principal Branch
+
+Add `schoolLevels` to the request body, branch on `targetRole === "Principal"` to fire one Clay webhook per school.
+
+**Files:**
+- Modify: `src/app/api/territory-plans/[id]/contacts/bulk-enrich/route.ts`
+- Test: `src/app/api/territory-plans/[id]/contacts/bulk-enrich/__tests__/route.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/app/api/territory-plans/[id]/contacts/bulk-enrich/__tests__/route.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/supabase/server", () => ({
+  getUser: vi.fn().mockResolvedValue({ id: "user-1" }),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    territoryPlan: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    contact: {
+      groupBy: vi.fn(),
+    },
+    district: {
+      findMany: vi.fn(),
+    },
+    school: {
+      findMany: vi.fn(),
+    },
+    schoolContact: {
+      findMany: vi.fn(),
+    },
+    activity: {
+      create: vi.fn(),
+    },
+  },
+}));
+
+// Stub global fetch so we can assert Clay webhook calls without network I/O
+const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+vi.stubGlobal("fetch", mockFetch);
+
+import prisma from "@/lib/prisma";
+import { POST } from "../route";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockPrisma = vi.mocked(prisma) as any;
+
+function buildRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/territory-plans/plan-1/contacts/bulk-enrich", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.CLAY_WEBHOOK_URL = "https://clay.test/hook";
+  process.env.NEXT_PUBLIC_SITE_URL = "https://app.test";
+  mockPrisma.territoryPlan.findUnique.mockResolvedValue({
+    id: "plan-1",
+    enrichmentStartedAt: null,
+    enrichmentQueued: null,
+    districts: [
+      { districtLeaid: "0100001" },
+      { districtLeaid: "0100002" },
+    ],
+  });
+  mockPrisma.territoryPlan.update.mockResolvedValue({});
+  mockPrisma.activity.create.mockResolvedValue({ id: "activity-1" });
+});
+
+describe("POST /bulk-enrich — Principal", () => {
+  it("queues one webhook per eligible school at the requested levels", async () => {
+    mockPrisma.school.findMany.mockResolvedValue([
+      { ncessch: "010000100001", schoolName: "Alpha HS", schoolLevel: 3, schoolType: 1, leaid: "0100001", streetAddress: "1 A St", city: "A", stateAbbrev: "AL", zip: "10000", phone: null },
+      { ncessch: "010000100002", schoolName: "Beta HS",  schoolLevel: 3, schoolType: 4, leaid: "0100001", streetAddress: "2 B St", city: "B", stateAbbrev: "AL", zip: "10001", phone: null },
+      { ncessch: "010000200001", schoolName: "Gamma HS", schoolLevel: 3, schoolType: 1, leaid: "0100002", streetAddress: "3 C St", city: "C", stateAbbrev: "AL", zip: "10002", phone: null },
+    ]);
+    mockPrisma.schoolContact.findMany.mockResolvedValue([]); // none already enriched
+    mockPrisma.district.findMany.mockResolvedValue([
+      { leaid: "0100001", name: "Alpha SD", stateAbbrev: "AL", websiteUrl: "alpha.edu" },
+      { leaid: "0100002", name: "Beta SD",  stateAbbrev: "AL", websiteUrl: "beta.edu"  },
+    ]);
+
+    const res = await POST(buildRequest({ targetRole: "Principal", schoolLevels: [3] }), {
+      params: Promise.resolve({ id: "plan-1" }),
+    });
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.queued).toBe(3);
+
+    expect(mockPrisma.school.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          leaid: { in: ["0100001", "0100002"] },
+          schoolLevel: { in: [3] },
+          schoolStatus: 1,
+        }),
+      })
+    );
+
+    // Allow fire-and-forget to tick
+    await new Promise((r) => setTimeout(r, 20));
+    const webhookCalls = mockFetch.mock.calls.filter(([url]) => url === "https://clay.test/hook");
+    expect(webhookCalls).toHaveLength(3);
+    const firstPayload = JSON.parse(webhookCalls[0][1].body as string);
+    expect(firstPayload.ncessch).toBe("010000100001");
+    expect(firstPayload.target_role).toBe("Principal");
+    expect(firstPayload.school_level).toBe(3);
+  });
+
+  it("skips schools that already have a principal SchoolContact", async () => {
+    mockPrisma.school.findMany.mockResolvedValue([
+      { ncessch: "S1", schoolName: "One", schoolLevel: 3, schoolType: 1, leaid: "0100001", streetAddress: "", city: "", stateAbbrev: "AL", zip: "", phone: null },
+      { ncessch: "S2", schoolName: "Two", schoolLevel: 3, schoolType: 1, leaid: "0100001", streetAddress: "", city: "", stateAbbrev: "AL", zip: "", phone: null },
+    ]);
+    // S1 already has a principal contact
+    mockPrisma.schoolContact.findMany.mockResolvedValue([{ schoolId: "S1" }]);
+    mockPrisma.district.findMany.mockResolvedValue([
+      { leaid: "0100001", name: "Alpha SD", stateAbbrev: "AL", websiteUrl: null },
+    ]);
+
+    const res = await POST(buildRequest({ targetRole: "Principal", schoolLevels: [3] }), {
+      params: Promise.resolve({ id: "plan-1" }),
+    });
+    const data = await res.json();
+
+    expect(data.queued).toBe(1);
+    expect(data.skipped).toBe(1);
+  });
+
+  it("records targetRole, schoolLevels, schoolsQueued in Activity metadata", async () => {
+    mockPrisma.school.findMany.mockResolvedValue([
+      { ncessch: "S1", schoolName: "One", schoolLevel: 1, schoolType: 1, leaid: "0100001", streetAddress: "", city: "", stateAbbrev: "AL", zip: "", phone: null },
+    ]);
+    mockPrisma.schoolContact.findMany.mockResolvedValue([]);
+    mockPrisma.district.findMany.mockResolvedValue([
+      { leaid: "0100001", name: "Alpha SD", stateAbbrev: "AL", websiteUrl: null },
+    ]);
+
+    await POST(buildRequest({ targetRole: "Principal", schoolLevels: [1, 2] }), {
+      params: Promise.resolve({ id: "plan-1" }),
+    });
+
+    expect(mockPrisma.activity.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          metadata: expect.objectContaining({
+            targetRole: "Principal",
+            schoolLevels: [1, 2],
+            schoolsQueued: 1,
+          }),
+        }),
+      })
+    );
+  });
+
+  it("returns 400 when Principal is selected with empty schoolLevels", async () => {
+    const res = await POST(buildRequest({ targetRole: "Principal", schoolLevels: [] }), {
+      params: Promise.resolve({ id: "plan-1" }),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /bulk-enrich — non-Principal (regression)", () => {
+  it("Superintendent path still fires per-district webhooks", async () => {
+    mockPrisma.contact.groupBy.mockResolvedValue([]); // no districts already enriched
+    mockPrisma.district.findMany.mockResolvedValue([
+      { leaid: "0100001", name: "Alpha SD", stateAbbrev: "AL", cityLocation: "A", streetLocation: "1 A", zipLocation: "10000", websiteUrl: "alpha.edu" },
+      { leaid: "0100002", name: "Beta SD",  stateAbbrev: "AL", cityLocation: "B", streetLocation: "2 B", zipLocation: "10001", websiteUrl: "beta.edu" },
+    ]);
+
+    const res = await POST(buildRequest({ targetRole: "Superintendent" }), {
+      params: Promise.resolve({ id: "plan-1" }),
+    });
+    const data = await res.json();
+
+    expect(data.queued).toBe(2);
+    // School path should not have been consulted
+    expect(mockPrisma.school.findMany).not.toHaveBeenCalled();
+    expect(mockPrisma.schoolContact.findMany).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+npm test -- --run src/app/api/territory-plans/[id]/contacts/bulk-enrich/__tests__/route.test.ts
+```
+
+Expected: all four Principal tests fail (route doesn't handle `Principal` yet); the regression test may already pass — that's fine.
+
+- [ ] **Step 3: Implement the Principal branch in the route**
+
+Replace the entire contents of `src/app/api/territory-plans/[id]/contacts/bulk-enrich/route.ts` with:
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { getUser } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+const ENRICHMENT_TIMEOUT_MS = 10 * 60 * 1000;
+
+/**
+ * POST /api/territory-plans/[id]/contacts/bulk-enrich
+ *
+ * Trigger bulk Clay contact enrichment for a plan.
+ *   - Non-Principal roles: one webhook per district (skipping districts that already have contacts).
+ *   - Principal: one webhook per School at the requested schoolLevels (skipping schools already linked
+ *     to a principal via SchoolContact).
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const user = await getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const targetRole: string = body.targetRole ?? "Superintendent";
+    const schoolLevelsRaw: unknown = body.schoolLevels;
+
+    const isPrincipal = targetRole === "Principal";
+
+    let schoolLevels: number[] = [];
+    if (isPrincipal) {
+      if (!Array.isArray(schoolLevelsRaw) || schoolLevelsRaw.length === 0) {
+        return NextResponse.json(
+          { error: "schoolLevels is required and must be non-empty when targetRole is Principal" },
+          { status: 400 }
+        );
+      }
+      schoolLevels = schoolLevelsRaw
+        .map((n) => Number(n))
+        .filter((n) => Number.isInteger(n) && n >= 1 && n <= 4);
+      if (schoolLevels.length === 0) {
+        return NextResponse.json(
+          { error: "schoolLevels must contain integers 1–4" },
+          { status: 400 }
+        );
+      }
+    }
+
+    const plan = await prisma.territoryPlan.findUnique({
+      where: { id },
+      include: { districts: { select: { districtLeaid: true } } },
+    });
+
+    if (!plan) {
+      return NextResponse.json({ error: "Territory plan not found" }, { status: 404 });
+    }
+
+    const allLeaids = plan.districts.map((d) => d.districtLeaid);
+
+    if (allLeaids.length === 0) {
+      return NextResponse.json({ total: 0, skipped: 0, queued: 0 });
+    }
+
+    const clayWebhookUrl = process.env.CLAY_WEBHOOK_URL;
+    if (!clayWebhookUrl) {
+      return NextResponse.json(
+        { error: "Clay webhook not configured. Please add CLAY_WEBHOOK_URL to environment variables." },
+        { status: 500 }
+      );
+    }
+
+    const callbackUrl = `${process.env.NEXT_PUBLIC_SITE_URL || "https://plan.fullmindlearning.com"}/api/webhooks/clay`;
+
+    // ---------- Concurrency guard (shared) ----------
+    if (
+      plan.enrichmentStartedAt &&
+      plan.enrichmentQueued &&
+      Date.now() - plan.enrichmentStartedAt.getTime() < ENRICHMENT_TIMEOUT_MS
+    ) {
+      // For district mode, the existing check against contact groupBy is correct.
+      // For Principal mode, we conservatively refuse until the previous run times out.
+      if (isPrincipal) {
+        return NextResponse.json(
+          {
+            error: "Enrichment already in progress",
+            enriched: 0,
+            queued: plan.enrichmentQueued,
+          },
+          { status: 409 }
+        );
+      }
+      const enrichedCount = await prisma.contact.groupBy({
+        by: ["leaid"],
+        where: { leaid: { in: allLeaids } },
+      });
+      if (enrichedCount.length < plan.enrichmentQueued) {
+        return NextResponse.json(
+          {
+            error: "Enrichment already in progress",
+            enriched: enrichedCount.length,
+            queued: plan.enrichmentQueued,
+          },
+          { status: 409 }
+        );
+      }
+    }
+
+    // ============================================================
+    // Principal path — one webhook per school
+    // ============================================================
+    if (isPrincipal) {
+      const schools = await prisma.school.findMany({
+        where: {
+          leaid: { in: allLeaids },
+          schoolLevel: { in: schoolLevels },
+          schoolStatus: 1, // open schools only
+        },
+        select: {
+          ncessch: true,
+          schoolName: true,
+          schoolLevel: true,
+          schoolType: true,
+          leaid: true,
+          streetAddress: true,
+          city: true,
+          stateAbbrev: true,
+          zip: true,
+          phone: true,
+        },
+      });
+
+      if (schools.length === 0) {
+        return NextResponse.json({ total: 0, skipped: 0, queued: 0 });
+      }
+
+      // NOTE: the "already enriched as principal" heuristic matches title /principal/i.
+      // If match rate is poor in production, fall back to skipping schools with ANY SchoolContact.
+      const alreadyPrincipal = await prisma.schoolContact.findMany({
+        where: {
+          schoolId: { in: schools.map((s) => s.ncessch) },
+          contact: { title: { contains: "principal", mode: "insensitive" } },
+        },
+        select: { schoolId: true },
+      });
+      const alreadyPrincipalSet = new Set(alreadyPrincipal.map((r) => r.schoolId));
+      const toEnrich = schools.filter((s) => !alreadyPrincipalSet.has(s.ncessch));
+
+      const total = schools.length;
+      const skipped = alreadyPrincipalSet.size;
+      const queued = toEnrich.length;
+
+      if (queued === 0) {
+        return NextResponse.json({ total, skipped, queued: 0 });
+      }
+
+      const districtRows = await prisma.district.findMany({
+        where: { leaid: { in: Array.from(new Set(toEnrich.map((s) => s.leaid))) } },
+        select: {
+          leaid: true,
+          name: true,
+          stateAbbrev: true,
+          websiteUrl: true,
+        },
+      });
+      const districtByLeaid = new Map(districtRows.map((d) => [d.leaid, d]));
+
+      const activity = await prisma.activity.create({
+        data: {
+          type: "contact_enrichment",
+          title: `Bulk contact enrichment — Principal`,
+          status: "in_progress",
+          source: "system",
+          createdByUserId: user.id,
+          metadata: {
+            targetRole: "Principal",
+            schoolLevels,
+            schoolsQueued: queued,
+            districtCount: districtRows.length,
+            skipped,
+          },
+          plans: { create: { planId: id } },
+        },
+      });
+
+      await prisma.territoryPlan.update({
+        where: { id },
+        data: {
+          enrichmentStartedAt: new Date(),
+          enrichmentQueued: queued,
+          enrichmentActivityId: activity.id,
+        },
+      });
+
+      const batchSize = 10;
+      const fireBatches = async () => {
+        for (let i = 0; i < toEnrich.length; i += batchSize) {
+          const batch = toEnrich.slice(i, i + batchSize);
+          await Promise.all(
+            batch.map(async (school) => {
+              const district = districtByLeaid.get(school.leaid);
+              try {
+                await fetch(clayWebhookUrl, {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({
+                    ncessch: school.ncessch,
+                    school_name: school.schoolName,
+                    school_level: school.schoolLevel,
+                    school_type: school.schoolType,
+                    leaid: school.leaid,
+                    district_name: district?.name ?? null,
+                    state: school.stateAbbrev,
+                    city: school.city,
+                    street: school.streetAddress,
+                    zip: school.zip,
+                    website_url: district?.websiteUrl ?? null,
+                    target_role: "Principal",
+                    callback_url: callbackUrl,
+                  }),
+                });
+              } catch (error) {
+                console.error(`Clay webhook failed for school ${school.ncessch}:`, error);
+              }
+            })
+          );
+          if (i + batchSize < toEnrich.length) {
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+          }
+        }
+      };
+      fireBatches().catch((error) => {
+        console.error("Batch enrichment error (Principal):", error);
+      });
+
+      return NextResponse.json({ total, skipped, queued });
+    }
+
+    // ============================================================
+    // Existing per-district path (unchanged behavior)
+    // ============================================================
+    const districtsWithContacts = await prisma.contact.groupBy({
+      by: ["leaid"],
+      where: { leaid: { in: allLeaids } },
+    });
+    const enrichedLeaids = new Set(districtsWithContacts.map((d) => d.leaid));
+    const leaidsToEnrich = allLeaids.filter((l) => !enrichedLeaids.has(l));
+
+    const total = allLeaids.length;
+    const skipped = enrichedLeaids.size;
+    const queued = leaidsToEnrich.length;
+
+    if (queued === 0) {
+      return NextResponse.json({ total, skipped, queued: 0 });
+    }
+
+    const districts = await prisma.district.findMany({
+      where: { leaid: { in: leaidsToEnrich } },
+      select: {
+        leaid: true,
+        name: true,
+        stateAbbrev: true,
+        cityLocation: true,
+        streetLocation: true,
+        zipLocation: true,
+        websiteUrl: true,
+      },
+    });
+
+    const activity = await prisma.activity.create({
+      data: {
+        type: "contact_enrichment",
+        title: `Bulk contact enrichment — ${targetRole}`,
+        status: "in_progress",
+        source: "system",
+        createdByUserId: user.id,
+        metadata: { targetRole, queued, skipped },
+        plans: { create: { planId: id } },
+      },
+    });
+
+    await prisma.territoryPlan.update({
+      where: { id },
+      data: {
+        enrichmentStartedAt: new Date(),
+        enrichmentQueued: queued,
+        enrichmentActivityId: activity.id,
+      },
+    });
+
+    const batchSize = 10;
+    const fireBatches = async () => {
+      for (let i = 0; i < districts.length; i += batchSize) {
+        const batch = districts.slice(i, i + batchSize);
+        await Promise.all(
+          batch.map(async (district) => {
+            try {
+              await fetch(clayWebhookUrl, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                  leaid: district.leaid,
+                  district_name: district.name,
+                  state: district.stateAbbrev,
+                  city: district.cityLocation,
+                  street: district.streetLocation,
+                  state_full: district.stateAbbrev,
+                  zip: district.zipLocation,
+                  website_url: district.websiteUrl,
+                  target_role: targetRole,
+                  callback_url: callbackUrl,
+                }),
+              });
+            } catch (error) {
+              console.error(`Clay webhook failed for district ${district.leaid}:`, error);
+            }
+          })
+        );
+        if (i + batchSize < districts.length) {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+        }
+      }
+    };
+    fireBatches().catch((error) => {
+      console.error("Batch enrichment error:", error);
+    });
+
+    return NextResponse.json({ total, skipped, queued });
+  } catch (error) {
+    console.error("Error triggering bulk enrichment:", error);
+    return NextResponse.json(
+      { error: "Failed to trigger bulk enrichment" },
+      { status: 500 }
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+npm test -- --run src/app/api/territory-plans/[id]/contacts/bulk-enrich/__tests__/route.test.ts
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/api/territory-plans/[id]/contacts/bulk-enrich/
+git commit -m "feat(api): Principal branch in bulk-enrich (per-school Clay fan-out)"
+```
+
+---
+
+## Task 8: Update `enrich-progress` to Count Schools in Principal Mode
+
+When the active activity is a Principal enrichment, `enrichmentQueued` counts schools. The current progress route counts districts-with-contacts, which is wrong for principals. Branch on `activity.metadata.targetRole`.
+
+**Files:**
+- Modify: `src/app/api/territory-plans/[id]/contacts/enrich-progress/route.ts`
+
+- [ ] **Step 1: Extend the progress route**
+
+Replace the contents of `src/app/api/territory-plans/[id]/contacts/enrich-progress/route.ts` with:
+
+```ts
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { getUser } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/territory-plans/[id]/contacts/enrich-progress
+ *
+ * Returns enrichment progress. Branches on the active enrichment Activity's
+ * metadata.targetRole:
+ *   - "Principal": counts schools with a principal SchoolContact.
+ *   - anything else (or no active activity): counts districts with any contact.
+ *
+ * Also completes the Activity record when enrichment finishes or stalls.
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const user = await getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+    }
+
+    const plan = await prisma.territoryPlan.findUnique({
+      where: { id },
+      include: { districts: { select: { districtLeaid: true } } },
+    });
+
+    if (!plan) {
+      return NextResponse.json({ error: "Territory plan not found" }, { status: 404 });
+    }
+
+    const allLeaids = plan.districts.map((d) => d.districtLeaid);
+    const total = allLeaids.length;
+    const queued = plan.enrichmentQueued ?? 0;
+
+    if (queued === 0 || allLeaids.length === 0) {
+      return NextResponse.json({ total, enriched: 0, queued: 0 });
+    }
+
+    // Read the active activity's metadata to decide counting strategy
+    let targetRole: string | null = null;
+    let activityMeta: Record<string, unknown> = {};
+    if (plan.enrichmentActivityId) {
+      const activity = await prisma.activity.findUnique({
+        where: { id: plan.enrichmentActivityId },
+        select: { metadata: true },
+      });
+      activityMeta = (activity?.metadata as Record<string, unknown>) ?? {};
+      targetRole = typeof activityMeta.targetRole === "string" ? activityMeta.targetRole : null;
+    }
+
+    let enriched: number;
+    let skipped: number;
+
+    if (targetRole === "Principal") {
+      // Count distinct schools (in the plan's districts) that now have a principal SchoolContact.
+      const principalLinks = await prisma.schoolContact.findMany({
+        where: {
+          school: { leaid: { in: allLeaids } },
+          contact: { title: { contains: "principal", mode: "insensitive" } },
+        },
+        select: { schoolId: true },
+        distinct: ["schoolId"],
+      });
+      const schoolsWithPrincipal = principalLinks.length;
+      // `skipped` was recorded at fire time; subtract it so we only count newly enriched.
+      skipped = typeof activityMeta.skipped === "number" ? activityMeta.skipped : 0;
+      enriched = Math.max(0, schoolsWithPrincipal - skipped);
+    } else {
+      const districtsWithContacts = await prisma.contact.groupBy({
+        by: ["leaid"],
+        where: { leaid: { in: allLeaids } },
+      });
+      skipped = total - queued;
+      enriched = Math.max(0, districtsWithContacts.length - skipped);
+    }
+
+    const isComplete = enriched >= queued;
+    const isStalled =
+      plan.enrichmentStartedAt &&
+      Date.now() - plan.enrichmentStartedAt.getTime() > 10 * 60 * 1000;
+
+    if ((isComplete || isStalled) && plan.enrichmentActivityId) {
+      try {
+        await prisma.activity.update({
+          where: { id: plan.enrichmentActivityId },
+          data: {
+            status: "completed",
+            metadata: { ...activityMeta, queued, skipped, enriched },
+            ...(isStalled && !isComplete
+              ? {
+                  outcome: `Partial — enrichment stalled after ${enriched} of ${queued}`,
+                  outcomeType: "neutral",
+                }
+              : {}),
+          },
+        });
+
+        await prisma.territoryPlan.update({
+          where: { id },
+          data: {
+            enrichmentStartedAt: null,
+            enrichmentQueued: null,
+            enrichmentActivityId: null,
+          },
+        });
+      } catch (error) {
+        console.error("Failed to update enrichment activity:", error);
+      }
+    }
+
+    return NextResponse.json({ total, enriched, queued });
+  } catch (error) {
+    console.error("Error fetching enrichment progress:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch enrichment progress" },
+      { status: 500 }
+    );
+  }
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no new errors.
+
+- [ ] **Step 3: Run the existing test suite to confirm no regression**
+
+```bash
+npm test -- --run
+```
+
+Expected: all tests PASS (no new tests added here; we rely on the bulk-enrich tests plus manual smoke in Task 14).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/api/territory-plans/[id]/contacts/enrich-progress/route.ts
+git commit -m "feat(api): count schools-with-principal for Principal mode in enrich-progress"
+```
+
+---
+
+## Task 9: Clay Webhook — Create `SchoolContact` When `ncessch` Present
+
+**Files:**
+- Modify: `src/app/api/webhooks/clay/route.ts`
+- Test: `src/app/api/webhooks/clay/__tests__/route.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/app/api/webhooks/clay/__tests__/route.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    district: { findUnique: vi.fn() },
+    school: { findUnique: vi.fn() },
+    contact: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    schoolContact: {
+      upsert: vi.fn(),
+    },
+  },
+}));
+
+import prisma from "@/lib/prisma";
+import { POST } from "../route";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockPrisma = vi.mocked(prisma) as any;
+
+function buildRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/webhooks/clay", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.district.findUnique.mockResolvedValue({ leaid: "0100001" });
+  mockPrisma.contact.findFirst.mockResolvedValue(null);
+  mockPrisma.contact.create.mockResolvedValue({ id: 42 });
+  mockPrisma.schoolContact.upsert.mockResolvedValue({});
+});
+
+describe("POST /api/webhooks/clay", () => {
+  it("creates a SchoolContact when payload includes ncessch", async () => {
+    const res = await POST(buildRequest({
+      leaid: "0100001",
+      ncessch: "010000100001",
+      name: "Jane Principal",
+      title: "Principal",
+      email: "jane@alpha.edu",
+    }));
+
+    expect(res.status).toBe(200);
+    expect(mockPrisma.contact.create).toHaveBeenCalled();
+    expect(mockPrisma.schoolContact.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { schoolId_contactId: { schoolId: "010000100001", contactId: 42 } },
+        create: { schoolId: "010000100001", contactId: 42 },
+        update: {},
+      })
+    );
+  });
+
+  it("does NOT call schoolContact.upsert when payload has no ncessch", async () => {
+    const res = await POST(buildRequest({
+      leaid: "0100001",
+      name: "Super Intendent",
+      title: "Superintendent",
+      email: "super@alpha.edu",
+    }));
+
+    expect(res.status).toBe(200);
+    expect(mockPrisma.schoolContact.upsert).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+npm test -- --run src/app/api/webhooks/clay/__tests__/route.test.ts
+```
+
+Expected: the first test fails (`schoolContact.upsert` not called).
+
+- [ ] **Step 3: Pull `ncessch` off the payload type and upsert after contact creation**
+
+In `src/app/api/webhooks/clay/route.ts`:
+
+(a) Add `ncessch?: string;` to both `ClayContact` (line ~38) and `ClayWebhookPayload` (line ~57):
+
+```ts
+interface ClayContact {
+  // ... existing fields
+  ncessch?: string;
+}
+
+interface ClayWebhookPayload {
+  leaid: string;
+  ncessch?: string;
+  contacts?: ClayContact[];
+  // ... rest of existing fields
+}
+```
+
+(b) After the contact processing loop (i.e., after the `for (const contact of contacts) { ... }` block ends at line ~273 and before the final `console.log(...)` at line ~275), insert:
+
+```ts
+    // If payload is a per-school enrichment (ncessch present at root OR on any sub-contact),
+    // link each created/updated Contact to the School via SchoolContact.
+    const rootNcessch = payload.ncessch;
+    if (rootNcessch) {
+      for (const c of processedContacts) {
+        await prisma.schoolContact.upsert({
+          where: { schoolId_contactId: { schoolId: rootNcessch, contactId: c.id } },
+          create: { schoolId: rootNcessch, contactId: c.id },
+          update: {},
+        });
+      }
+    }
+```
+
+(c) To make `processedContacts` available, change each of the 4 spots in the contact loop that either `await prisma.contact.update(...)` or `await prisma.contact.create(...)` to capture the result. Introduce `const processedContacts: { id: number }[] = [];` just above the loop (at line ~167, before `for (const contact of contacts)`), and after each update/create push `processedContacts.push({ id: existing.id })` or `processedContacts.push({ id: created.id })`. Example replacement for the create branch at lines 216–230:
+
+```ts
+          const created = await prisma.contact.create({
+            data: {
+              leaid,
+              name,
+              title,
+              email,
+              phone,
+              linkedinUrl,
+              seniorityLevel,
+              persona,
+              isPrimary: false,
+              lastEnrichedAt: new Date(),
+            },
+          });
+          processedContacts.push({ id: created.id });
+          contactsCreated++;
+```
+
+Apply the same `processedContacts.push(...)` pattern after each of the other three `prisma.contact.update(...)` / `prisma.contact.create(...)` calls in the existing file.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+npm test -- --run src/app/api/webhooks/clay/__tests__/route.test.ts
+```
+
+Expected: both tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/api/webhooks/clay/
+git commit -m "feat(api): link principal contacts to schools via SchoolContact on webhook"
+```
+
+---
+
+## Task 10: Extend `useBulkEnrich` Mutation with `schoolLevels`
+
+**Files:**
+- Modify: `src/features/plans/lib/queries.ts:256-272`
+
+- [ ] **Step 1: Update the mutation signature**
+
+Replace the `useBulkEnrich` definition (lines 256–272) with:
+
+```ts
+export function useBulkEnrich() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      planId,
+      targetRole,
+      schoolLevels,
+    }: {
+      planId: string;
+      targetRole: string;
+      schoolLevels?: number[];
+    }) =>
+      fetchJson<{ total: number; skipped: number; queued: number }>(
+        `${API_BASE}/territory-plans/${planId}/contacts/bulk-enrich`,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            targetRole,
+            ...(schoolLevels ? { schoolLevels } : {}),
+          }),
+        }
+      ),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["planContacts", variables.planId] });
+    },
+  });
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no new errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/features/plans/lib/queries.ts
+git commit -m "feat(queries): useBulkEnrich accepts optional schoolLevels"
+```
+
+---
+
+## Task 11: ContactsActionBar — School-Level Subfilter UI
+
+Add the Principal branch to the popover. When `selectedRole === "Principal"`, render a School Level subsection below the dropdown. All 3 checkboxes checked by default. Start disabled when the set is empty. Pass the selected levels to `useBulkEnrich`.
+
+**Files:**
+- Modify: `src/features/plans/components/ContactsActionBar.tsx`
+
+- [ ] **Step 1: Add school-level state**
+
+In `ContactsActionBar.tsx`, just below the existing `const [selectedRole, setSelectedRole] = useState<TargetRole>("Superintendent");` (line 35), add:
+
+```tsx
+  // School-level subfilter (only meaningful when selectedRole === "Principal")
+  // Default: all 3 levels checked (1 = Primary/Elementary, 2 = Middle, 3 = High).
+  const [schoolLevels, setSchoolLevels] = useState<Set<number>>(new Set([1, 2, 3]));
+```
+
+- [ ] **Step 2: Pass `schoolLevels` to the mutation in `handleStartEnrichment`**
+
+Inside `handleStartEnrichment` (line ~114), change the `bulkEnrich.mutateAsync` call (line ~118) from:
+
+```tsx
+      const result = await bulkEnrich.mutateAsync({ planId, targetRole: selectedRole });
+```
+
+to:
+
+```tsx
+      const result = await bulkEnrich.mutateAsync({
+        planId,
+        targetRole: selectedRole,
+        ...(selectedRole === "Principal"
+          ? { schoolLevels: Array.from(schoolLevels).sort() }
+          : {}),
+      });
+```
+
+Also extend the dependency array on line ~144 from `[planId, selectedRole, bulkEnrich]` to `[planId, selectedRole, schoolLevels, bulkEnrich]`.
+
+- [ ] **Step 3: Render the subsection + fix the Start button's disabled condition**
+
+Replace the popover contents (the `{showPopover && ( ... )}` block at lines 219–249) with:
+
+```tsx
+            {showPopover && (
+              <div
+                className="absolute left-0 top-full mt-1 w-64 bg-white rounded-lg shadow-xl border border-[#EFEDF5] p-3 z-50"
+                style={{ animation: "tooltipEnter 200ms cubic-bezier(0.16, 1, 0.3, 1) forwards" }}
+              >
+                <label className="block text-[11px] font-semibold text-[#403770]/60 uppercase tracking-wider mb-1.5">
+                  Target Role
+                </label>
+                <div className="relative mb-3">
+                  <select
+                    value={selectedRole}
+                    onChange={(e) => setSelectedRole(e.target.value as TargetRole)}
+                    className="w-full appearance-none px-3 py-2 pr-8 text-[13px] text-[#403770] bg-[#F7F5FA] border border-[#EFEDF5] rounded-lg focus:outline-none focus:ring-2 focus:ring-[#403770]/20"
+                  >
+                    {TARGET_ROLES.map((role) => (
+                      <option key={role} value={role}>
+                        {role}
+                      </option>
+                    ))}
+                  </select>
+                  <ChevronDown className="absolute right-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-[#403770]/40 pointer-events-none" />
+                </div>
+
+                {selectedRole === "Principal" && (
+                  <div className="mb-3">
+                    <label className="block text-[11px] font-semibold text-[#403770]/60 uppercase tracking-wider mb-1.5">
+                      School Level
+                    </label>
+                    <div className="flex flex-col gap-1.5">
+                      {[
+                        { value: 1, label: "Primary" },
+                        { value: 2, label: "Middle" },
+                        { value: 3, label: "High" },
+                      ].map(({ value, label }) => (
+                        <label
+                          key={value}
+                          className="flex items-center gap-2 text-[13px] text-[#403770] cursor-pointer"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={schoolLevels.has(value)}
+                            onChange={(e) => {
+                              setSchoolLevels((prev) => {
+                                const next = new Set(prev);
+                                if (e.target.checked) next.add(value);
+                                else next.delete(value);
+                                return next;
+                              });
+                            }}
+                            className="w-3.5 h-3.5 accent-[#403770]"
+                          />
+                          {label}
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                <button
+                  onClick={handleStartEnrichment}
+                  disabled={
+                    bulkEnrich.isPending ||
+                    (selectedRole === "Principal" && schoolLevels.size === 0)
+                  }
+                  className="w-full px-3 py-2 text-[13px] font-medium text-white bg-[#403770] hover:bg-[#322a5a] disabled:opacity-50 disabled:cursor-not-allowed rounded-lg transition-colors"
+                >
+                  {bulkEnrich.isPending ? "Starting..." : "Start"}
+                </button>
+              </div>
+            )}
+```
+
+- [ ] **Step 4: Typecheck**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no new errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/plans/components/ContactsActionBar.tsx
+git commit -m "feat(ui): school-level subfilter for Principal in Find Contacts popover"
+```
+
+---
+
+## Task 12: CSV Export — One Row Per Contact + School Columns
+
+Change the existing `handleExportCsv` from one-row-per-district to one-row-per-contact. Empty districts still produce one blank row (coverage gap signal).
+
+**Files:**
+- Modify: `src/features/plans/components/ContactsActionBar.tsx` (`handleExportCsv`, lines 146–197)
+
+- [ ] **Step 1: Add the shared-label import**
+
+Near the top of `ContactsActionBar.tsx` (below the existing imports), add:
+
+```tsx
+import { SCHOOL_LEVEL_LABELS, SCHOOL_TYPE_LABELS } from "@/features/shared/lib/schoolLabels";
+```
+
+- [ ] **Step 2: Replace the CSV export function**
+
+Replace `handleExportCsv` (lines 146–197) with:
+
+```tsx
+  const handleExportCsv = useCallback(() => {
+    const headers = [
+      "District Name",
+      "Website",
+      "School Name",
+      "School Level",
+      "School Type",
+      "Contact Name",
+      "Title",
+      "Email",
+      "Phone",
+      "Department",
+      "Seniority Level",
+    ];
+
+    const rows: string[][] = [];
+    const seenDistricts = new Set<string>();
+
+    // One row per contact
+    for (const contact of contacts) {
+      seenDistricts.add(contact.leaid);
+      const districtName = districtNameMap?.get(contact.leaid) || contact.leaid;
+      const websiteUrl = districtWebsiteMap?.get(contact.leaid) || "";
+
+      const link = contact.schoolContacts?.[0];
+      const schoolName = link?.name ?? "";
+      const schoolLevel =
+        link?.schoolLevel != null ? (SCHOOL_LEVEL_LABELS[link.schoolLevel] ?? "") : "";
+      const schoolType =
+        link?.schoolType != null ? (SCHOOL_TYPE_LABELS[link.schoolType] ?? "") : "";
+
+      rows.push([
+        districtName,
+        websiteUrl,
+        schoolName,
+        schoolLevel,
+        schoolType,
+        contact.name || "",
+        contact.title || "",
+        contact.email || "",
+        contact.phone || "",
+        contact.persona || "",
+        contact.seniorityLevel || "",
+      ]);
+    }
+
+    // Preserve coverage-gap signal: one blank row per district with zero contacts
+    for (const leaid of allDistrictLeaids) {
+      if (seenDistricts.has(leaid)) continue;
+      const districtName = districtNameMap?.get(leaid) || leaid;
+      const websiteUrl = districtWebsiteMap?.get(leaid) || "";
+      rows.push([districtName, websiteUrl, "", "", "", "", "", "", "", "", ""]);
+    }
+
+    const csvContent = [headers, ...rows]
+      .map((row) => row.map((cell) => `"${cell.replace(/"/g, '""')}"`).join(","))
+      .join("\n");
+
+    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    const safeName = planName.replace(/[^a-zA-Z0-9-_ ]/g, "").replace(/\s+/g, "-").toLowerCase();
+    link.download = `${safeName}-contacts-${new Date().toISOString().split("T")[0]}.csv`;
+    link.click();
+    URL.revokeObjectURL(url);
+  }, [contacts, allDistrictLeaids, districtNameMap, districtWebsiteMap, planName]);
+```
+
+(Note: the dependency array adds `districtWebsiteMap`, which was missing from the original.)
+
+- [ ] **Step 3: Typecheck**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no new errors. (`contact.schoolContacts` is now on the `Contact` type from Task 6.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/features/plans/components/ContactsActionBar.tsx
+git commit -m "feat(ui): CSV export one row per contact + school columns"
+```
+
+---
+
+## Task 13: Component Test — Popover Behavior
+
+**Files:**
+- Test: `src/features/plans/components/__tests__/ContactsActionBar.test.tsx`
+
+- [ ] **Step 1: Write the component test**
+
+Create `src/features/plans/components/__tests__/ContactsActionBar.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import ContactsActionBar from "../ContactsActionBar";
+
+const mockMutateAsync = vi.fn().mockResolvedValue({ total: 3, skipped: 0, queued: 3 });
+
+vi.mock("@/features/plans/lib/queries", () => ({
+  useBulkEnrich: () => ({
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+  }),
+  useEnrichProgress: () => ({
+    data: { total: 0, enriched: 0, queued: 0 },
+  }),
+}));
+
+describe("ContactsActionBar — Principal popover", () => {
+  beforeEach(() => {
+    mockMutateAsync.mockClear();
+  });
+
+  it("shows School Level checkboxes when Principal is selected", () => {
+    render(
+      <ContactsActionBar
+        planId="plan-1"
+        planName="Plan"
+        contacts={[]}
+        allDistrictLeaids={["0100001"]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /find contacts/i }));
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "Principal" } });
+
+    expect(screen.getByText("School Level")).toBeInTheDocument();
+    expect(screen.getByLabelText("Primary")).toBeChecked();
+    expect(screen.getByLabelText("Middle")).toBeChecked();
+    expect(screen.getByLabelText("High")).toBeChecked();
+  });
+
+  it("disables Start when all school-level checkboxes are cleared", () => {
+    render(
+      <ContactsActionBar
+        planId="plan-1"
+        planName="Plan"
+        contacts={[]}
+        allDistrictLeaids={["0100001"]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /find contacts/i }));
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "Principal" } });
+
+    fireEvent.click(screen.getByLabelText("Primary"));
+    fireEvent.click(screen.getByLabelText("Middle"));
+    fireEvent.click(screen.getByLabelText("High"));
+
+    expect(screen.getByRole("button", { name: /start/i })).toBeDisabled();
+  });
+
+  it("passes schoolLevels to useBulkEnrich on Start", async () => {
+    render(
+      <ContactsActionBar
+        planId="plan-1"
+        planName="Plan"
+        contacts={[]}
+        allDistrictLeaids={["0100001"]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /find contacts/i }));
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "Principal" } });
+    fireEvent.click(screen.getByLabelText("Middle")); // uncheck middle
+    fireEvent.click(screen.getByRole("button", { name: /start/i }));
+
+    await vi.waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        planId: "plan-1",
+        targetRole: "Principal",
+        schoolLevels: [1, 3],
+      });
+    });
+  });
+
+  it("does not pass schoolLevels for non-Principal roles", async () => {
+    render(
+      <ContactsActionBar
+        planId="plan-1"
+        planName="Plan"
+        contacts={[]}
+        allDistrictLeaids={["0100001"]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /find contacts/i }));
+    // Superintendent is the default — just click Start
+    fireEvent.click(screen.getByRole("button", { name: /start/i }));
+
+    await vi.waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        planId: "plan-1",
+        targetRole: "Superintendent",
+      });
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test**
+
+```bash
+npm test -- --run src/features/plans/components/__tests__/ContactsActionBar.test.tsx
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/features/plans/components/__tests__/ContactsActionBar.test.tsx
+git commit -m "test(ui): ContactsActionBar Principal popover + school-level behavior"
+```
+
+---
+
+## Task 14: End-to-End Smoke + PR
+
+**Files:** none.
+
+- [ ] **Step 1: Full test suite**
+
+```bash
+npm test -- --run
+```
+
+Expected: all tests PASS, including pre-existing suites.
+
+- [ ] **Step 2: Typecheck the whole tree**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no new errors introduced by this branch. Pre-existing errors (see `project_compilation_warnings.md`) are out of scope.
+
+- [ ] **Step 3: Local smoke test**
+
+If local dev is available (see `project_local_dev_broken.md` — fix that blocker first if needed):
+
+```bash
+npm run dev
+```
+
+Then in the browser at `http://localhost:3005`:
+1. Open a territory plan that has districts with known schools.
+2. Click **Find Contacts**. Confirm the popover shows the role dropdown only.
+3. Pick **Principal**. Confirm the School Level subsection appears with 3 checkboxes checked.
+4. Uncheck all three. Confirm Start is disabled.
+5. Re-check Middle + High. Click Start. Confirm the toast appears ("Contact enrichment started for N districts/schools") and the progress bar renders.
+6. If Clay is not yet wired (per Task 1), the webhook fire will succeed but no contacts return — that's expected.
+7. Click the Export CSV icon. Open the file and confirm headers are `District Name | Website | School Name | School Level | School Type | Contact Name | Title | Email | Phone | Department | Seniority Level`. Districts with zero contacts should still produce one blank row.
+
+- [ ] **Step 4: Push and open PR**
+
+```bash
+git push -u origin feat/find-contacts-principals
+gh pr create --title "feat: Principal target role + per-school Clay enrichment + school-level CSV export" --body "$(cat <<'EOF'
+## Summary
+- Adds "Principal" to the Find Contacts Target Role dropdown with an inline School Level (Primary / Middle / High) subfilter.
+- Bulk-enrich API branches on \`targetRole === "Principal"\` to fire one Clay webhook per school (filtered by \`schoolLevel\`), skipping schools already linked to a principal via \`SchoolContact\`.
+- Clay webhook callback now creates a \`SchoolContact\` row whenever \`ncessch\` is present in the payload.
+- CSV export changes from one-row-per-district to one-row-per-contact and adds \`School Name\`, \`School Level\`, \`School Type\` columns. Districts with zero contacts still produce one blank row for coverage-gap visibility.
+- No Prisma schema changes.
+
+## Clay workflow audit
+<!-- Record Task 1 outcome here: whether Clay already supported per-school, what was edited, or whether the workflow edit is still pending. -->
+
+## School data coverage (Task 2)
+<!-- Record the SQL result: pct_level / pct_type populated. -->
+
+## Test plan
+- [ ] \`npm test -- --run\` passes
+- [ ] \`npx tsc --noEmit\` clean for this branch
+- [ ] Popover shows School Level section only when Principal is selected
+- [ ] Start button is disabled when all school-level checkboxes are cleared
+- [ ] CSV has the new header row and one row per contact
+- [ ] Districts with zero contacts still emit a blank row
+- [ ] Clay webhook callback with \`ncessch\` creates both \`Contact\` and \`SchoolContact\`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL printed.
+
+---
+
+## Self-Review Checklist (already run)
+
+- **Spec coverage:**
+  - §1 UI (Principal popover + School Level checkboxes) → Task 11.
+  - §2 `TARGET_ROLES` constant → Task 5.
+  - §3 bulk-enrich API (schoolLevels, per-school fetch, skip-already-principal, metadata, batching) → Task 7.
+  - §4 Clay callback SchoolContact upsert → Task 9.
+  - §5 "already enriched" heuristic (title /principal/i) → Task 7 Step 3 (comment notes fallback).
+  - §6 CSV export (one row per contact, new columns, empty-district rows) → Task 12.
+  - §7 `SCHOOL_TYPE_LABELS` shared location → Task 4.
+  - §8 ContactsTable verification → covered by manual smoke (Task 14 Step 3), no code change needed.
+  - Data dependencies: Clay audit → Task 1, schoolType coverage → Task 2.
+  - Concurrency guard still applies (spec §3 last paragraph) → Task 7 preserves it; Task 8 extends progress counting for Principal mode (implicit in spec).
+
+- **Placeholders:** none (no TBD/TODO, no "add appropriate error handling", every code step has full code).
+
+- **Type consistency:** `schoolLevels: number[]` consistently; `ContactSchoolLink` used in Task 6 and referenced (via `Contact.schoolContacts`) in Task 12; `schoolContact.upsert` composite key is `schoolId_contactId` (Prisma's generated name from the `@@id([schoolId, contactId])` in `prisma/schema.prisma:1110`); `SCHOOL_LEVEL_LABELS` / `SCHOOL_TYPE_LABELS` same names across tasks 4, 12.

--- a/Docs/superpowers/specs/2026-04-16-leaderboard-tier-removal-dynamic-fy-spec.md
+++ b/Docs/superpowers/specs/2026-04-16-leaderboard-tier-removal-dynamic-fy-spec.md
@@ -1,0 +1,186 @@
+# Leaderboard: Remove Tier Badges + Dynamic FY Checkboxes
+
+**Date:** 2026-04-16
+**Scope:** Frontend (LeaderboardHomeWidget, LeaderboardModal, LeaderboardDetailView, RevenueOverviewTab) + API (leaderboard route)
+
+---
+
+## 1. Remove Tier Badges from UI
+
+Remove all visible tier badge rendering from three components. The backend continues to compute tiers (no API changes needed here) — we just stop displaying them.
+
+### LeaderboardHomeWidget (profile sidebar)
+
+**File:** `src/features/leaderboard/components/LeaderboardHomeWidget.tsx`
+
+- Remove `TierBadge` import and rendering (line 90)
+- Remove tier-based background color and glow styling — use a neutral Fullmind plum background instead (`#F7F5FA` bg, `rgba(138,128,168,0.3)` glow)
+- Remove `parseTierRank` and `TIER_COLORS` imports since they're only used for styling
+- Keep rank display (`#{data.rank}`) and ticker — these are the pure ranking elements
+
+### LeaderboardModal
+
+**File:** `src/features/leaderboard/components/LeaderboardModal.tsx`
+
+- Remove tier grouping/dividers — entries should be a flat ranked list
+- Remove per-entry `TierBadge` rendering
+- Keep rank numbers (#1, #2, etc.)
+
+### LeaderboardDetailView
+
+**File:** `src/features/leaderboard/components/LeaderboardDetailView.tsx`
+
+- Remove `TierBadge` from the table rows
+- Keep rank column
+
+---
+
+## 2. Dynamic FY Checkboxes (Revenue Overview Tab)
+
+Replace the two `FYSelect` dropdowns with checkbox groups using relative labels.
+
+### Type Changes
+
+**File:** `src/features/leaderboard/lib/types.ts`
+
+Add prior FY fields to `LeaderboardEntry`:
+```typescript
+pipelinePriorFY: number;
+targetedPriorFY: number;
+```
+
+### New FY Selection Model
+
+Replace `FYSelection = "current" | "next" | "both"` with:
+
+```typescript
+interface FYChecked {
+  prior: boolean;
+  current: boolean;
+  next: boolean;
+}
+```
+
+Default state: `{ prior: false, current: true, next: true }`
+
+### Checkbox UI
+
+**File:** `src/features/leaderboard/components/RevenueOverviewTab.tsx`
+
+Replace each `FYSelect` dropdown with an inline checkbox group:
+
+```
+PIPELINE:  ☐ Previous (FY25)  ☑ Current (FY26)  ☑ Next (FY27)
+TARGETED:  ☐ Previous (FY25)  ☑ Current (FY26)  ☑ Next (FY27)
+```
+
+- Each checkbox shows: relative label + dynamic FY string from API response (`fiscalYears.priorFY`, `fiscalYears.currentFY`, `fiscalYears.nextFY`)
+- Styled as small inline checkboxes matching Fullmind brand (plum accent `#403770` for checked state)
+- Compact layout — fits in the existing filter bar
+
+### Minimum Selection Enforcement
+
+When the user unchecks the last remaining checkbox:
+1. Re-check it immediately (prevent empty selection)
+2. Show a brief toast: **"At least one fiscal year must be selected"**
+3. Toast auto-dismisses after 2 seconds
+4. Toast positioned near the checkboxes (inline or bottom of filter bar), not a global toast
+
+### Value Computation
+
+Sum the checked FY values for each entry:
+
+```typescript
+function computeValue(
+  entry: LeaderboardEntry,
+  field: "pipeline" | "targeted",
+  checked: FYChecked
+): number {
+  let sum = 0;
+  if (checked.prior) sum += entry[`${field}PriorFY`];
+  if (checked.current) sum += entry[`${field}CurrentFY`];
+  if (checked.next) sum += entry[`${field}NextFY`];
+  return sum;
+}
+```
+
+Same logic applies to team totals.
+
+---
+
+## 3. API Changes
+
+**File:** `src/app/api/leaderboard/route.ts`
+
+### Add Prior FY Pipeline Data
+
+The API already fetches `priorSchoolYr` actuals but only extracts revenue from it. Add:
+
+```typescript
+pipelinePriorFY: yearActuals.get(priorSchoolYr)?.openPipeline ?? 0,
+```
+
+to the per-user actuals map (alongside existing `pipelineCurrentFY`, `pipelineNextFY`).
+
+### Add Prior FY Targeted Data
+
+Add a third query for prior FY territory plan districts:
+
+```typescript
+const priorFYInt = currentFY - 1;
+
+const targetedPriorFYDistricts = await prisma.territoryPlanDistrict.findMany({
+  where: { plan: { ...ownerFilter, fiscalYear: priorFYInt } },
+  select: { /* same as current/next */ },
+});
+const targetedPriorFYByUser = sumTargets(targetedPriorFYDistricts);
+```
+
+Add to Promise.all with the existing current/next FY queries.
+
+### Expand Response
+
+Per entry, add:
+- `pipelinePriorFY`
+- `targetedPriorFY`
+
+In `fiscalYears` response object, add:
+- `priorFY: priorSchoolYr` (e.g., `"2024-25"`)
+
+In `teamTotals`, add:
+- `pipelinePriorFY`, `unassignedPipelinePriorFY`
+- `targetedPriorFY`, `unassignedTargetedPriorFY`
+
+### Error path fallback
+
+Update the catch fallback object to include `pipelinePriorFY: 0`.
+
+---
+
+## 4. Fiscal Year Auto-Rolling
+
+No new work needed — the API already computes fiscal years dynamically:
+
+```typescript
+const currentFY = now.getMonth() >= 6 ? now.getFullYear() + 1 : now.getFullYear();
+```
+
+In June 2029, `currentFY` = 2030, so:
+- Prior = FY29 (`"2028-29"`)
+- Current = FY30 (`"2029-30"`)
+- Next = FY31 (`"2030-31"`)
+
+The frontend labels pull from the API response, so everything auto-rolls.
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/features/leaderboard/components/LeaderboardHomeWidget.tsx` | Remove TierBadge, use neutral styling |
+| `src/features/leaderboard/components/LeaderboardModal.tsx` | Remove tier grouping + per-entry badges |
+| `src/features/leaderboard/components/LeaderboardDetailView.tsx` | Remove tier badge column |
+| `src/features/leaderboard/components/RevenueOverviewTab.tsx` | Replace FYSelect with checkbox groups + toast |
+| `src/features/leaderboard/lib/types.ts` | Add `pipelinePriorFY`, `targetedPriorFY` to entry type |
+| `src/app/api/leaderboard/route.ts` | Add prior FY pipeline/targeted data + expand response |

--- a/Docs/superpowers/specs/2026-04-20-find-contacts-principals-design.md
+++ b/Docs/superpowers/specs/2026-04-20-find-contacts-principals-design.md
@@ -149,7 +149,13 @@ The existing `ContactsTable` should already render principal contacts since it j
 ## Data / dependencies
 
 - **No Prisma schema changes.**
-- **Clay workflow:** requires confirmation that Clay's template can accept `ncessch`/`school_name`/`target_role: "Principal"` and return a principal contact. **Treat as a coordination step in the plan.** If Clay doesn't support this today, flag to the user before coding starts.
+- **Clay workflow audit (explicit plan step):** the existing Clay workflow is keyed to `CLAY_WEBHOOK_URL` and accepts per-district fields only. Before code ships, the user will open Clay and verify / update:
+  1. **Input columns** — the table that receives `CLAY_WEBHOOK_URL` POSTs needs new columns: `ncessch`, `school_name`, `school_level`, `school_type`.
+  2. **Enrichment step** — must look up a person by title + school (not title + district). In Clay, this is typically a "Find Person" / Apollo / ZoomInfo step where the company input is the school, not the district.
+  3. **Callback HTTP column** — the column that POSTs back to `/api/webhooks/clay` must include `ncessch` in its payload so the app can link the returned contact to the correct school.
+
+  If any of the three is missing, the user edits the Clay workflow before flipping the feature on. The app-side code can be built and merged independently of this audit — it just won't produce correct results until Clay is ready.
+
 - **School data coverage:** `schoolLevel` and `schoolType` population rate is unknown. Spot-check in the plan: query for districts where a reasonable % of schools have null values. If `schoolType` is mostly null, the export column is still correct (just blank) and sales reps will see the gap.
 
 ## Testing
@@ -170,6 +176,6 @@ Sales reps may run this on a plan with 500+ schools. Existing batching (10 webho
 
 ## Open items for the implementation plan
 
-1. Confirm Clay workflow supports per-school principal lookup (or coordinate an update). Treat as a blocker before the code ships, not before coding starts.
+1. **Clay workflow audit (step 1 of the plan)** — user opens Clay, checks the 3 items above (input columns, enrichment step, callback payload), and edits the workflow if any are missing. The plan should explicitly include this as a first step so it doesn't get forgotten.
 2. Confirm `School.schoolType` data coverage (quick query against prod DB).
 3. Decide where `SCHOOL_TYPE_LABELS` and `SCHOOL_LEVEL_LABELS` ultimately live — the map-only location is fine for now, but export code will need to import them, so a shared location (`src/features/shared/lib/schoolLabels.ts` or similar) is cleaner.

--- a/Docs/superpowers/specs/2026-04-20-find-contacts-principals-design.md
+++ b/Docs/superpowers/specs/2026-04-20-find-contacts-principals-design.md
@@ -1,0 +1,175 @@
+# Find Contacts: Principal Target Role + School-Level Export
+
+**Date:** 2026-04-20
+**Branch:** `feat/find-contacts-principals`
+**Status:** Design approved, pending implementation plan
+
+## Problem
+
+The current "Find Contacts" flow (`ContactsActionBar` → Clay bulk enrichment) returns **one contact per district** for district-level roles (Superintendent, CTO, etc.). Sales reps also need **school-level** contacts — specifically **principals** — and when those are exported, each row must identify which school it belongs to (name, level, type).
+
+## Scope
+
+**In scope:**
+- Add `"Principal"` to `TARGET_ROLES`
+- When Principal is selected, expose a school-level filter (PS / MS / HS checkboxes, all on by default)
+- Fire Clay enrichment per-school instead of per-district when Principal is selected
+- Link returned principal contacts to the `School` record via `SchoolContact`
+- Change CSV export from "one row per district" to **one row per contact**, adding `School Name`, `School Level`, and `School Type` columns
+
+**Out of scope:**
+- Adding `"Chief Academic Officer"` (noted as a gap but deferred)
+- Renaming the "Find Contacts" button
+- New UI for filtering existing contacts by school type (export only)
+- A "consolidate to one row per district" toggle (can add later if sales reps push back)
+- Schema changes — everything needed already exists
+
+## User Flow
+
+1. User opens a territory plan with districts selected.
+2. Clicks **Find Contacts** → popover opens.
+3. Selects **Target Role: Principal** → popover expands to show a **School Level** section.
+4. All 3 checkboxes (Primary / Middle / High) are checked by default. User can uncheck.
+5. Clicks **Start**. Disabled if zero levels are checked.
+6. Backend enqueues one Clay webhook per eligible school (not per district).
+7. Progress bar ticks as principals come back; they appear in the Contacts table tied to their school.
+8. User clicks the download icon → CSV with `District Name | Website | School Name | School Level | School Type | Contact Name | Title | Email | Phone | Department | Seniority Level`.
+
+## Design
+
+### 1. UI (`src/features/plans/components/ContactsActionBar.tsx`)
+
+- `TARGET_ROLES` gets a new entry: `"Principal"` (8th).
+- When `selectedRole === "Principal"`, render a **School Level** subsection below the role dropdown:
+  - 3 labeled checkboxes: Primary, Middle, High
+  - All checked by default (via `useState<Set<number>>(new Set([1, 2, 3]))`)
+  - Start button disabled when the set is empty
+- Non-Principal roles: popover renders exactly as today (no subsection).
+- Keep existing Fullmind brand tokens (`#403770`, `#F7F5FA`, `#EFEDF5`).
+
+### 2. Target Roles constant (`src/features/shared/types/contact-types.ts`)
+
+```ts
+export const TARGET_ROLES = [
+  "Superintendent",
+  "Assistant Superintendent",
+  "Chief Technology Officer",
+  "Chief Financial Officer",
+  "Curriculum Director",
+  "Special Education Director",
+  "HR Director",
+  "Principal", // new
+] as const;
+```
+
+### 3. Bulk-enrich API (`src/app/api/territory-plans/[id]/contacts/bulk-enrich/route.ts`)
+
+**Request body extension:**
+```ts
+{
+  targetRole: TargetRole;
+  schoolLevels?: number[]; // only read when targetRole === "Principal"
+}
+```
+
+**Branching on `targetRole`:**
+
+- **Not Principal** → existing per-district logic unchanged.
+- **Principal** → new per-school logic:
+  1. Fetch `School` records where `leaid IN (plan's districts)` AND `schoolLevel IN (schoolLevels)`.
+  2. Skip schools that already have an associated principal contact (join on `SchoolContact`, filter by title match — see §5 below for the "already enriched" heuristic).
+  3. Build Clay payload per school:
+     ```ts
+     {
+       ncessch: school.ncessch,
+       school_name: school.name,
+       school_level: school.schoolLevel,
+       school_type: school.schoolType,
+       leaid: school.leaid,
+       district_name, state, city, street, zip, website_url,
+       target_role: "Principal",
+       callback_url,
+     }
+     ```
+  4. Fire in batches of 10 with 1s delay — same pattern as today.
+  5. `enrichmentQueued` = count of schools queued. `Activity.metadata` includes `{ targetRole: "Principal", schoolLevels, schoolsQueued, districtCount }`.
+
+**Concurrency guard:** existing guard still applies; it just compares "have we seen enough back yet" against `enrichmentQueued`, which now counts schools when Principal.
+
+### 4. Clay webhook callback (`/api/webhooks/clay`)
+
+The callback already creates `Contact` rows. Add logic: if payload includes `ncessch` (present only for principal enrichment), also insert a `SchoolContact` row linking the new contact to the school.
+
+Specifically: after creating/updating the `Contact`, `upsert` a `SchoolContact` keyed on `(contactId, ncessch)`.
+
+### 5. "Already enriched" heuristic for principals
+
+Current flow skips a district if it has **any** contact. For principals we need per-school granularity:
+
+- A school is considered "already enriched as principal" if it has a `SchoolContact` whose linked `Contact.title` matches `/principal/i` (case-insensitive).
+- If the heuristic proves fragile, fall back to skipping any school that has **any** `SchoolContact` at all.
+
+Spec'd as (a); leave a plan comment to revisit if the match rate is off.
+
+### 6. CSV export (`src/features/plans/components/ContactsActionBar.tsx` `handleExportCsv`)
+
+**Behavior change:** one row per contact (not per district).
+
+New header:
+```
+District Name | Website | School Name | School Level | School Type |
+Contact Name | Title | Email | Phone | Department | Seniority Level
+```
+
+For each contact:
+- If contact has `schoolContacts[0]` → pull School Name (`school.name`), School Level (mapped via `SCHOOL_LEVEL_LABELS`), School Type (mapped via a new `SCHOOL_TYPE_LABELS` constant — see §7).
+- If contact has no school link → leave those 3 columns empty.
+
+**Empty districts:** the old export included a row for districts with zero contacts. Preserve that — a district with zero contacts still yields one row (all contact/school fields empty) so the rep sees coverage gaps.
+
+### 7. School Type label mapping
+
+Add a small constant (co-locate with `SCHOOL_LEVEL_LABELS` in `MapV2Tooltip.tsx`, or move both into `src/features/shared/types/contact-types.ts` if they're re-used outside the map — decide in the plan):
+
+```ts
+const SCHOOL_TYPE_LABELS: Record<number, string> = {
+  1: "Regular",
+  2: "Special Education",
+  3: "Career & Technical",
+  4: "Alternative",
+};
+```
+
+For the export, if `schoolType` is null or unmapped, leave empty. "Transfer" schools are identified downstream by combining `School Level = HS AND School Type = Alternative`.
+
+### 8. ContactsTable (display of enriched principals)
+
+The existing `ContactsTable` should already render principal contacts since it just lists `Contact` rows. Verify during implementation — no spec change unless it groups by district in a way that hides school-level rows.
+
+## Data / dependencies
+
+- **No Prisma schema changes.**
+- **Clay workflow:** requires confirmation that Clay's template can accept `ncessch`/`school_name`/`target_role: "Principal"` and return a principal contact. **Treat as a coordination step in the plan.** If Clay doesn't support this today, flag to the user before coding starts.
+- **School data coverage:** `schoolLevel` and `schoolType` population rate is unknown. Spot-check in the plan: query for districts where a reasonable % of schools have null values. If `schoolType` is mostly null, the export column is still correct (just blank) and sales reps will see the gap.
+
+## Testing
+
+- **Unit:** `TARGET_ROLES` includes `"Principal"`. `SCHOOL_TYPE_LABELS` maps 1–4.
+- **Component:** rendering the popover with Principal selected shows the school-level subsection; unchecking all disables Start.
+- **API route test (`bulk-enrich`):**
+  - Principal payload with `schoolLevels: [3]` queues only high schools from plan districts.
+  - Schools with an existing "principal" `SchoolContact` are skipped.
+  - Activity metadata contains `targetRole`, `schoolLevels`, `schoolsQueued`.
+  - Non-Principal requests unchanged (regression guard).
+- **Clay webhook callback test:** payload with `ncessch` creates both `Contact` and `SchoolContact`.
+- **CSV export test:** one row per contact; rows with no school link have empty School columns; districts with zero contacts still emit a row.
+
+## Performance notes
+
+Sales reps may run this on a plan with 500+ schools. Existing batching (10 webhooks per 1s) caps fan-out — 500 schools ≈ 50s of webhook firing. Background-fired, progress-tracked, acceptable. Nothing new.
+
+## Open items for the implementation plan
+
+1. Confirm Clay workflow supports per-school principal lookup (or coordinate an update). Treat as a blocker before the code ships, not before coding starts.
+2. Confirm `School.schoolType` data coverage (quick query against prod DB).
+3. Decide where `SCHOOL_TYPE_LABELS` and `SCHOOL_LEVEL_LABELS` ultimately live — the map-only location is fine for now, but export code will need to import them, so a shared location (`src/features/shared/lib/schoolLabels.ts` or similar) is cleaner.

--- a/src/app/api/territory-plans/[id]/contacts/bulk-enrich/__tests__/route.test.ts
+++ b/src/app/api/territory-plans/[id]/contacts/bulk-enrich/__tests__/route.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/supabase/server", () => ({
+  getUser: vi.fn().mockResolvedValue({ id: "user-1" }),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    territoryPlan: {
+      findUnique: vi.fn(),
+      update: vi.fn(),
+    },
+    contact: {
+      groupBy: vi.fn(),
+    },
+    district: {
+      findMany: vi.fn(),
+    },
+    school: {
+      findMany: vi.fn(),
+    },
+    schoolContact: {
+      findMany: vi.fn(),
+    },
+    activity: {
+      create: vi.fn(),
+    },
+  },
+}));
+
+// Stub global fetch so we can assert Clay webhook calls without network I/O
+const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+vi.stubGlobal("fetch", mockFetch);
+
+import prisma from "@/lib/prisma";
+import { POST } from "../route";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockPrisma = vi.mocked(prisma) as any;
+
+function buildRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/territory-plans/plan-1/contacts/bulk-enrich", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.CLAY_WEBHOOK_URL = "https://clay.test/hook";
+  process.env.NEXT_PUBLIC_SITE_URL = "https://app.test";
+  mockPrisma.territoryPlan.findUnique.mockResolvedValue({
+    id: "plan-1",
+    enrichmentStartedAt: null,
+    enrichmentQueued: null,
+    districts: [
+      { districtLeaid: "0100001" },
+      { districtLeaid: "0100002" },
+    ],
+  });
+  mockPrisma.territoryPlan.update.mockResolvedValue({});
+  mockPrisma.activity.create.mockResolvedValue({ id: "activity-1" });
+});
+
+describe("POST /bulk-enrich — Principal", () => {
+  it("queues one webhook per eligible school at the requested levels", async () => {
+    mockPrisma.school.findMany.mockResolvedValue([
+      { ncessch: "010000100001", schoolName: "Alpha HS", schoolLevel: 3, schoolType: 1, leaid: "0100001", streetAddress: "1 A St", city: "A", stateAbbrev: "AL", zip: "10000", phone: null },
+      { ncessch: "010000100002", schoolName: "Beta HS",  schoolLevel: 3, schoolType: 4, leaid: "0100001", streetAddress: "2 B St", city: "B", stateAbbrev: "AL", zip: "10001", phone: null },
+      { ncessch: "010000200001", schoolName: "Gamma HS", schoolLevel: 3, schoolType: 1, leaid: "0100002", streetAddress: "3 C St", city: "C", stateAbbrev: "AL", zip: "10002", phone: null },
+    ]);
+    mockPrisma.schoolContact.findMany.mockResolvedValue([]); // none already enriched
+    mockPrisma.district.findMany.mockResolvedValue([
+      { leaid: "0100001", name: "Alpha SD", stateAbbrev: "AL", websiteUrl: "alpha.edu" },
+      { leaid: "0100002", name: "Beta SD",  stateAbbrev: "AL", websiteUrl: "beta.edu"  },
+    ]);
+
+    const res = await POST(buildRequest({ targetRole: "Principal", schoolLevels: [3] }), {
+      params: Promise.resolve({ id: "plan-1" }),
+    });
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.queued).toBe(3);
+
+    expect(mockPrisma.school.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          leaid: { in: ["0100001", "0100002"] },
+          schoolLevel: { in: [3] },
+          schoolStatus: 1,
+        }),
+      })
+    );
+
+    // Allow fire-and-forget to tick
+    await new Promise((r) => setTimeout(r, 20));
+    const webhookCalls = mockFetch.mock.calls.filter((call) => call[0] === "https://clay.test/hook");
+    expect(webhookCalls).toHaveLength(3);
+    const firstPayload = JSON.parse(webhookCalls[0][1].body as string);
+    expect(firstPayload.ncessch).toBe("010000100001");
+    expect(firstPayload.target_role).toBe("Principal");
+    expect(firstPayload.school_level).toBe(3);
+  });
+
+  it("skips schools that already have a principal SchoolContact", async () => {
+    mockPrisma.school.findMany.mockResolvedValue([
+      { ncessch: "S1", schoolName: "One", schoolLevel: 3, schoolType: 1, leaid: "0100001", streetAddress: "", city: "", stateAbbrev: "AL", zip: "", phone: null },
+      { ncessch: "S2", schoolName: "Two", schoolLevel: 3, schoolType: 1, leaid: "0100001", streetAddress: "", city: "", stateAbbrev: "AL", zip: "", phone: null },
+    ]);
+    // S1 already has a principal contact
+    mockPrisma.schoolContact.findMany.mockResolvedValue([{ schoolId: "S1" }]);
+    mockPrisma.district.findMany.mockResolvedValue([
+      { leaid: "0100001", name: "Alpha SD", stateAbbrev: "AL", websiteUrl: null },
+    ]);
+
+    const res = await POST(buildRequest({ targetRole: "Principal", schoolLevels: [3] }), {
+      params: Promise.resolve({ id: "plan-1" }),
+    });
+    const data = await res.json();
+
+    expect(data.queued).toBe(1);
+    expect(data.skipped).toBe(1);
+  });
+
+  it("records targetRole, schoolLevels, schoolsQueued in Activity metadata", async () => {
+    mockPrisma.school.findMany.mockResolvedValue([
+      { ncessch: "S1", schoolName: "One", schoolLevel: 1, schoolType: 1, leaid: "0100001", streetAddress: "", city: "", stateAbbrev: "AL", zip: "", phone: null },
+    ]);
+    mockPrisma.schoolContact.findMany.mockResolvedValue([]);
+    mockPrisma.district.findMany.mockResolvedValue([
+      { leaid: "0100001", name: "Alpha SD", stateAbbrev: "AL", websiteUrl: null },
+    ]);
+
+    await POST(buildRequest({ targetRole: "Principal", schoolLevels: [1, 2] }), {
+      params: Promise.resolve({ id: "plan-1" }),
+    });
+
+    expect(mockPrisma.activity.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          metadata: expect.objectContaining({
+            targetRole: "Principal",
+            schoolLevels: [1, 2],
+            schoolsQueued: 1,
+          }),
+        }),
+      })
+    );
+  });
+
+  it("returns 400 when Principal is selected with empty schoolLevels", async () => {
+    const res = await POST(buildRequest({ targetRole: "Principal", schoolLevels: [] }), {
+      params: Promise.resolve({ id: "plan-1" }),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /bulk-enrich — non-Principal (regression)", () => {
+  it("Superintendent path still fires per-district webhooks", async () => {
+    mockPrisma.contact.groupBy.mockResolvedValue([]); // no districts already enriched
+    mockPrisma.district.findMany.mockResolvedValue([
+      { leaid: "0100001", name: "Alpha SD", stateAbbrev: "AL", cityLocation: "A", streetLocation: "1 A", zipLocation: "10000", websiteUrl: "alpha.edu" },
+      { leaid: "0100002", name: "Beta SD",  stateAbbrev: "AL", cityLocation: "B", streetLocation: "2 B", zipLocation: "10001", websiteUrl: "beta.edu" },
+    ]);
+
+    const res = await POST(buildRequest({ targetRole: "Superintendent" }), {
+      params: Promise.resolve({ id: "plan-1" }),
+    });
+    const data = await res.json();
+
+    expect(data.queued).toBe(2);
+    // School path should not have been consulted
+    expect(mockPrisma.school.findMany).not.toHaveBeenCalled();
+    expect(mockPrisma.schoolContact.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/territory-plans/[id]/contacts/bulk-enrich/route.ts
+++ b/src/app/api/territory-plans/[id]/contacts/bulk-enrich/route.ts
@@ -4,15 +4,15 @@ import { getUser } from "@/lib/supabase/server";
 
 export const dynamic = "force-dynamic";
 
-// How long before a previous enrichment is considered expired (10 minutes)
 const ENRICHMENT_TIMEOUT_MS = 10 * 60 * 1000;
 
 /**
  * POST /api/territory-plans/[id]/contacts/bulk-enrich
  *
- * Trigger bulk Clay contact enrichment for all districts in a plan.
- * Skips districts that already have contacts. Creates an Activity record
- * for admin visibility. Fires Clay webhooks in batches of 10.
+ * Trigger bulk Clay contact enrichment for a plan.
+ *   - Non-Principal roles: one webhook per district (skipping districts that already have contacts).
+ *   - Principal: one webhook per School at the requested schoolLevels (skipping schools already linked
+ *     to a principal via SchoolContact).
  */
 export async function POST(
   request: NextRequest,
@@ -27,35 +27,77 @@ export async function POST(
     }
 
     const body = await request.json();
-    const { targetRole = "Superintendent" } = body;
+    const targetRole: string = body.targetRole ?? "Superintendent";
+    const schoolLevelsRaw: unknown = body.schoolLevels;
 
-    // Fetch the plan with its districts
+    const isPrincipal = targetRole === "Principal";
+
+    let schoolLevels: number[] = [];
+    if (isPrincipal) {
+      if (!Array.isArray(schoolLevelsRaw) || schoolLevelsRaw.length === 0) {
+        return NextResponse.json(
+          { error: "schoolLevels is required and must be non-empty when targetRole is Principal" },
+          { status: 400 }
+        );
+      }
+      schoolLevels = schoolLevelsRaw
+        .map((n) => Number(n))
+        .filter((n) => Number.isInteger(n) && n >= 1 && n <= 4);
+      if (schoolLevels.length === 0) {
+        return NextResponse.json(
+          { error: "schoolLevels must contain integers 1–4" },
+          { status: 400 }
+        );
+      }
+    }
+
     const plan = await prisma.territoryPlan.findUnique({
       where: { id },
-      include: {
-        districts: {
-          select: { districtLeaid: true },
-        },
-      },
+      include: { districts: { select: { districtLeaid: true } } },
     });
 
     if (!plan) {
       return NextResponse.json({ error: "Territory plan not found" }, { status: 404 });
     }
 
-    // Concurrency guard: check if enrichment is already in progress
+    const allLeaids = plan.districts.map((d) => d.districtLeaid);
+
+    if (allLeaids.length === 0) {
+      return NextResponse.json({ total: 0, skipped: 0, queued: 0 });
+    }
+
+    const clayWebhookUrl = process.env.CLAY_WEBHOOK_URL;
+    if (!clayWebhookUrl) {
+      return NextResponse.json(
+        { error: "Clay webhook not configured. Please add CLAY_WEBHOOK_URL to environment variables." },
+        { status: 500 }
+      );
+    }
+
+    const callbackUrl = `${process.env.NEXT_PUBLIC_SITE_URL || "https://plan.fullmindlearning.com"}/api/webhooks/clay`;
+
+    // ---------- Concurrency guard (shared) ----------
     if (
       plan.enrichmentStartedAt &&
       plan.enrichmentQueued &&
       Date.now() - plan.enrichmentStartedAt.getTime() < ENRICHMENT_TIMEOUT_MS
     ) {
-      // Count how many queued districts now have contacts
-      const allLeaids = plan.districts.map((d) => d.districtLeaid);
+      // For district mode, the existing check against contact groupBy is correct.
+      // For Principal mode, we conservatively refuse until the previous run times out.
+      if (isPrincipal) {
+        return NextResponse.json(
+          {
+            error: "Enrichment already in progress",
+            enriched: 0,
+            queued: plan.enrichmentQueued,
+          },
+          { status: 409 }
+        );
+      }
       const enrichedCount = await prisma.contact.groupBy({
         by: ["leaid"],
         where: { leaid: { in: allLeaids } },
       });
-
       if (enrichedCount.length < plan.enrichmentQueued) {
         return NextResponse.json(
           {
@@ -68,13 +110,139 @@ export async function POST(
       }
     }
 
-    const allLeaids = plan.districts.map((d) => d.districtLeaid);
+    // ============================================================
+    // Principal path — one webhook per school
+    // ============================================================
+    if (isPrincipal) {
+      const schools = await prisma.school.findMany({
+        where: {
+          leaid: { in: allLeaids },
+          schoolLevel: { in: schoolLevels },
+          schoolStatus: 1, // open schools only
+        },
+        select: {
+          ncessch: true,
+          schoolName: true,
+          schoolLevel: true,
+          schoolType: true,
+          leaid: true,
+          streetAddress: true,
+          city: true,
+          stateAbbrev: true,
+          zip: true,
+          phone: true,
+        },
+      });
 
-    if (allLeaids.length === 0) {
-      return NextResponse.json({ total: 0, skipped: 0, queued: 0 });
+      if (schools.length === 0) {
+        return NextResponse.json({ total: 0, skipped: 0, queued: 0 });
+      }
+
+      // NOTE: the "already enriched as principal" heuristic matches title /principal/i.
+      // If match rate is poor in production, fall back to skipping schools with ANY SchoolContact.
+      const alreadyPrincipal = await prisma.schoolContact.findMany({
+        where: {
+          schoolId: { in: schools.map((s) => s.ncessch) },
+          contact: { title: { contains: "principal", mode: "insensitive" } },
+        },
+        select: { schoolId: true },
+      });
+      const alreadyPrincipalSet = new Set(alreadyPrincipal.map((r) => r.schoolId));
+      const toEnrich = schools.filter((s) => !alreadyPrincipalSet.has(s.ncessch));
+
+      const total = schools.length;
+      const skipped = alreadyPrincipalSet.size;
+      const queued = toEnrich.length;
+
+      if (queued === 0) {
+        return NextResponse.json({ total, skipped, queued: 0 });
+      }
+
+      const districtRows = await prisma.district.findMany({
+        where: { leaid: { in: Array.from(new Set(toEnrich.map((s) => s.leaid))) } },
+        select: {
+          leaid: true,
+          name: true,
+          stateAbbrev: true,
+          websiteUrl: true,
+        },
+      });
+      const districtByLeaid = new Map(districtRows.map((d) => [d.leaid, d]));
+
+      const activity = await prisma.activity.create({
+        data: {
+          type: "contact_enrichment",
+          title: `Bulk contact enrichment — Principal`,
+          status: "in_progress",
+          source: "system",
+          createdByUserId: user.id,
+          metadata: {
+            targetRole: "Principal",
+            schoolLevels,
+            schoolsQueued: queued,
+            districtCount: districtRows.length,
+            skipped,
+          },
+          plans: { create: { planId: id } },
+        },
+      });
+
+      await prisma.territoryPlan.update({
+        where: { id },
+        data: {
+          enrichmentStartedAt: new Date(),
+          enrichmentQueued: queued,
+          enrichmentActivityId: activity.id,
+        },
+      });
+
+      const batchSize = 10;
+      const fireBatches = async () => {
+        for (let i = 0; i < toEnrich.length; i += batchSize) {
+          const batch = toEnrich.slice(i, i + batchSize);
+          await Promise.all(
+            batch.map(async (school) => {
+              const district = districtByLeaid.get(school.leaid);
+              try {
+                await fetch(clayWebhookUrl, {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({
+                    ncessch: school.ncessch,
+                    school_name: school.schoolName,
+                    school_level: school.schoolLevel,
+                    school_type: school.schoolType,
+                    leaid: school.leaid,
+                    district_name: district?.name ?? null,
+                    state: school.stateAbbrev,
+                    city: school.city,
+                    street: school.streetAddress,
+                    zip: school.zip,
+                    website_url: district?.websiteUrl ?? null,
+                    target_role: "Principal",
+                    callback_url: callbackUrl,
+                  }),
+                });
+              } catch (error) {
+                console.error(`Clay webhook failed for school ${school.ncessch}:`, error);
+              }
+            })
+          );
+          if (i + batchSize < toEnrich.length) {
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+          }
+        }
+      };
+      fireBatches().catch((error) => {
+        console.error("Batch enrichment error (Principal):", error);
+      });
+
+      return NextResponse.json({ total, skipped, queued });
     }
 
-    // Find districts that already have contacts (skip these)
+    // ============================================================
+    // Existing per-district path (unchanged behavior)
+    // ============================================================
     const districtsWithContacts = await prisma.contact.groupBy({
       by: ["leaid"],
       where: { leaid: { in: allLeaids } },
@@ -90,7 +258,6 @@ export async function POST(
       return NextResponse.json({ total, skipped, queued: 0 });
     }
 
-    // Fetch district details for Clay payload
     const districts = await prisma.district.findMany({
       where: { leaid: { in: leaidsToEnrich } },
       select: {
@@ -104,17 +271,6 @@ export async function POST(
       },
     });
 
-    const clayWebhookUrl = process.env.CLAY_WEBHOOK_URL;
-    if (!clayWebhookUrl) {
-      return NextResponse.json(
-        { error: "Clay webhook not configured. Please add CLAY_WEBHOOK_URL to environment variables." },
-        { status: 500 }
-      );
-    }
-
-    const callbackUrl = `${process.env.NEXT_PUBLIC_SITE_URL || "https://plan.fullmindlearning.com"}/api/webhooks/clay`;
-
-    // Create Activity record for admin visibility
     const activity = await prisma.activity.create({
       data: {
         type: "contact_enrichment",
@@ -123,13 +279,10 @@ export async function POST(
         source: "system",
         createdByUserId: user.id,
         metadata: { targetRole, queued, skipped },
-        plans: {
-          create: { planId: id },
-        },
+        plans: { create: { planId: id } },
       },
     });
 
-    // Update plan with enrichment tracking
     await prisma.territoryPlan.update({
       where: { id },
       data: {
@@ -139,13 +292,10 @@ export async function POST(
       },
     });
 
-    // Fire Clay webhooks in batches of 10, sequentially with 1s delay
-    // This runs in the background after we return the response
     const batchSize = 10;
     const fireBatches = async () => {
       for (let i = 0; i < districts.length; i += batchSize) {
         const batch = districts.slice(i, i + batchSize);
-
         await Promise.all(
           batch.map(async (district) => {
             try {
@@ -170,15 +320,11 @@ export async function POST(
             }
           })
         );
-
-        // 1 second delay between batches (skip after last batch)
         if (i + batchSize < districts.length) {
           await new Promise((resolve) => setTimeout(resolve, 1000));
         }
       }
     };
-
-    // Fire batches without awaiting — return immediately
     fireBatches().catch((error) => {
       console.error("Batch enrichment error:", error);
     });

--- a/src/app/api/territory-plans/[id]/contacts/enrich-progress/route.ts
+++ b/src/app/api/territory-plans/[id]/contacts/enrich-progress/route.ts
@@ -7,7 +7,11 @@ export const dynamic = "force-dynamic";
 /**
  * GET /api/territory-plans/[id]/contacts/enrich-progress
  *
- * Returns enrichment progress: how many queued districts now have contacts.
+ * Returns enrichment progress. Branches on the active enrichment Activity's
+ * metadata.targetRole:
+ *   - "Principal": counts schools with a principal SchoolContact.
+ *   - anything else (or no active activity): counts districts with any contact.
+ *
  * Also completes the Activity record when enrichment finishes or stalls.
  */
 export async function GET(
@@ -24,11 +28,7 @@ export async function GET(
 
     const plan = await prisma.territoryPlan.findUnique({
       where: { id },
-      include: {
-        districts: {
-          select: { districtLeaid: true },
-        },
-      },
+      include: { districts: { select: { districtLeaid: true } } },
     });
 
     if (!plan) {
@@ -43,18 +43,44 @@ export async function GET(
       return NextResponse.json({ total, enriched: 0, queued: 0 });
     }
 
-    // Count districts that have at least one contact
-    const districtsWithContacts = await prisma.contact.groupBy({
-      by: ["leaid"],
-      where: { leaid: { in: allLeaids } },
-    });
+    // Read the active activity's metadata to decide counting strategy
+    let targetRole: string | null = null;
+    let activityMeta: Record<string, unknown> = {};
+    if (plan.enrichmentActivityId) {
+      const activity = await prisma.activity.findUnique({
+        where: { id: plan.enrichmentActivityId },
+        select: { metadata: true },
+      });
+      activityMeta = (activity?.metadata as Record<string, unknown>) ?? {};
+      targetRole = typeof activityMeta.targetRole === "string" ? activityMeta.targetRole : null;
+    }
 
-    // Enriched = districts with contacts minus those that were skipped (pre-existing)
-    // skipped = total - queued (districts that already had contacts before enrichment)
-    const skipped = total - queued;
-    const enriched = Math.max(0, districtsWithContacts.length - skipped);
+    let enriched: number;
+    let skipped: number;
 
-    // Check if enrichment is complete or stalled
+    if (targetRole === "Principal") {
+      // Count distinct schools (in the plan's districts) that now have a principal SchoolContact.
+      const principalLinks = await prisma.schoolContact.findMany({
+        where: {
+          school: { leaid: { in: allLeaids } },
+          contact: { title: { contains: "principal", mode: "insensitive" } },
+        },
+        select: { schoolId: true },
+        distinct: ["schoolId"],
+      });
+      const schoolsWithPrincipal = principalLinks.length;
+      // `skipped` was recorded at fire time; subtract it so we only count newly enriched.
+      skipped = typeof activityMeta.skipped === "number" ? activityMeta.skipped : 0;
+      enriched = Math.max(0, schoolsWithPrincipal - skipped);
+    } else {
+      const districtsWithContacts = await prisma.contact.groupBy({
+        by: ["leaid"],
+        where: { leaid: { in: allLeaids } },
+      });
+      skipped = total - queued;
+      enriched = Math.max(0, districtsWithContacts.length - skipped);
+    }
+
     const isComplete = enriched >= queued;
     const isStalled =
       plan.enrichmentStartedAt &&
@@ -62,28 +88,20 @@ export async function GET(
 
     if ((isComplete || isStalled) && plan.enrichmentActivityId) {
       try {
-        // Read existing Activity to preserve targetRole from metadata
-        const existingActivity = await prisma.activity.findUnique({
-          where: { id: plan.enrichmentActivityId },
-          select: { metadata: true },
-        });
-        const existingMeta = (existingActivity?.metadata as Record<string, unknown>) ?? {};
-
         await prisma.activity.update({
           where: { id: plan.enrichmentActivityId },
           data: {
             status: "completed",
-            metadata: { ...existingMeta, queued, skipped, enriched },
+            metadata: { ...activityMeta, queued, skipped, enriched },
             ...(isStalled && !isComplete
               ? {
-                  outcome: `Partial — enrichment stalled after ${enriched} of ${queued} districts`,
+                  outcome: `Partial — enrichment stalled after ${enriched} of ${queued}`,
                   outcomeType: "neutral",
                 }
               : {}),
           },
         });
 
-        // Clear enrichment tracking on the plan
         await prisma.territoryPlan.update({
           where: { id },
           data: {
@@ -93,7 +111,6 @@ export async function GET(
           },
         });
       } catch (error) {
-        // Non-fatal: progress is still correct even if activity update fails
         console.error("Failed to update enrichment activity:", error);
       }
     }

--- a/src/app/api/territory-plans/[id]/contacts/route.ts
+++ b/src/app/api/territory-plans/[id]/contacts/route.ts
@@ -52,6 +52,20 @@ export async function GET(
         { isPrimary: "desc" },
         { name: "asc" },
       ],
+      include: {
+        schoolContacts: {
+          include: {
+            school: {
+              select: {
+                ncessch: true,
+                schoolName: true,
+                schoolLevel: true,
+                schoolType: true,
+              },
+            },
+          },
+        },
+      },
     });
 
     // De-duplicate by email: keep only the first contact per email address.
@@ -81,6 +95,12 @@ export async function GET(
         seniorityLevel: c.seniorityLevel,
         createdAt: c.createdAt.toISOString(),
         lastEnrichedAt: c.lastEnrichedAt?.toISOString() ?? null,
+        schoolContacts: c.schoolContacts.map((sc) => ({
+          ncessch: sc.school.ncessch,
+          name: sc.school.schoolName,
+          schoolLevel: sc.school.schoolLevel,
+          schoolType: sc.school.schoolType,
+        })),
       }))
     );
   } catch (error) {

--- a/src/app/api/territory-plans/route.ts
+++ b/src/app/api/territory-plans/route.ts
@@ -187,7 +187,7 @@ export async function POST(request: NextRequest) {
       data: {
         name: name.trim(),
         description: description?.trim() || null,
-        ownerId: ownerId || null,
+        ownerId: ownerId || user.id,
         color: color || "#403770",
         status: status || "planning",
         fiscalYear,

--- a/src/app/api/webhooks/clay/__tests__/route.test.ts
+++ b/src/app/api/webhooks/clay/__tests__/route.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    district: { findUnique: vi.fn() },
+    school: { findUnique: vi.fn() },
+    contact: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    schoolContact: {
+      upsert: vi.fn(),
+    },
+  },
+}));
+
+import prisma from "@/lib/prisma";
+import { POST } from "../route";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockPrisma = vi.mocked(prisma) as any;
+
+function buildRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/webhooks/clay", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.district.findUnique.mockResolvedValue({ leaid: "0100001" });
+  mockPrisma.contact.findFirst.mockResolvedValue(null);
+  mockPrisma.contact.create.mockResolvedValue({ id: 42 });
+  mockPrisma.schoolContact.upsert.mockResolvedValue({});
+});
+
+describe("POST /api/webhooks/clay", () => {
+  it("creates a SchoolContact when payload includes ncessch", async () => {
+    const res = await POST(buildRequest({
+      leaid: "0100001",
+      ncessch: "010000100001",
+      name: "Jane Principal",
+      title: "Principal",
+      email: "jane@alpha.edu",
+    }));
+
+    expect(res.status).toBe(200);
+    expect(mockPrisma.contact.create).toHaveBeenCalled();
+    expect(mockPrisma.schoolContact.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { schoolId_contactId: { schoolId: "010000100001", contactId: 42 } },
+        create: { schoolId: "010000100001", contactId: 42 },
+        update: {},
+      })
+    );
+  });
+
+  it("does NOT call schoolContact.upsert when payload has no ncessch", async () => {
+    const res = await POST(buildRequest({
+      leaid: "0100001",
+      name: "Super Intendent",
+      title: "Superintendent",
+      email: "super@alpha.edu",
+    }));
+
+    expect(res.status).toBe(200);
+    expect(mockPrisma.schoolContact.upsert).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/webhooks/clay/route.ts
+++ b/src/app/api/webhooks/clay/route.ts
@@ -51,11 +51,13 @@ interface ClayContact {
   seniority_level?: string;
   persona?: string;
   department?: string;
+  ncessch?: string;
 }
 
 // Interface for the full Clay webhook payload
 interface ClayWebhookPayload {
   leaid: string;
+  ncessch?: string;
   contacts?: ClayContact[];
   // Alternative: Clay might send a single contact per webhook call
   name?: string;
@@ -163,6 +165,10 @@ async function handleClayWebhook(request: NextRequest) {
 
     let contactsCreated = 0;
     let contactsUpdated = 0;
+    // Track the resolved Contact row for each processed payload entry so that,
+    // if this is a per-school enrichment (ncessch present), we can link each
+    // contact to its school via SchoolContact after the main loop.
+    const processedContacts: { id: number }[] = [];
 
     // Process each contact
     for (const contact of contacts) {
@@ -210,10 +216,11 @@ async function handleClayWebhook(request: NextRequest) {
               lastEnrichedAt: new Date(),
             },
           });
+          processedContacts.push({ id: existing.id });
           contactsUpdated++;
         } else {
           // Create new contact
-          await prisma.contact.create({
+          const created = await prisma.contact.create({
             data: {
               leaid,
               name,
@@ -227,6 +234,7 @@ async function handleClayWebhook(request: NextRequest) {
               lastEnrichedAt: new Date(),
             },
           });
+          processedContacts.push({ id: created.id });
           contactsCreated++;
         }
       } else {
@@ -251,10 +259,11 @@ async function handleClayWebhook(request: NextRequest) {
               lastEnrichedAt: new Date(),
             },
           });
+          processedContacts.push({ id: existing.id });
           contactsUpdated++;
         } else {
           // Create new contact without email
-          await prisma.contact.create({
+          const created = await prisma.contact.create({
             data: {
               leaid,
               name,
@@ -267,8 +276,21 @@ async function handleClayWebhook(request: NextRequest) {
               lastEnrichedAt: new Date(),
             },
           });
+          processedContacts.push({ id: created.id });
           contactsCreated++;
         }
+      }
+    }
+
+    // Per-school enrichment: link each resolved Contact to the School via SchoolContact
+    const rootNcessch = payload.ncessch;
+    if (rootNcessch) {
+      for (const c of processedContacts) {
+        await prisma.schoolContact.upsert({
+          where: { schoolId_contactId: { schoolId: rootNcessch, contactId: c.id } },
+          create: { schoolId: rootNcessch, contactId: c.id },
+          update: {},
+        });
       }
     }
 

--- a/src/features/map/components/MapV2Tooltip.tsx
+++ b/src/features/map/components/MapV2Tooltip.tsx
@@ -3,6 +3,7 @@
 import { useEffect, forwardRef } from "react";
 import { useMapV2Store } from "@/features/map/lib/store";
 import { TRANSITION_BUCKET_MAP } from "@/features/map/lib/comparison";
+import { SCHOOL_LEVEL_LABELS } from "@/features/shared/lib/schoolLabels";
 
 const CATEGORY_LABELS: Record<string, string> = {
   multi_year_growing: "Multi-year (Growing)",
@@ -27,13 +28,6 @@ const CATEGORY_COLORS: Record<string, string> = {
   lapsed: "#FFB347",
   pipeline: "#c4dae6",
   target: "#e8f1f5",
-};
-
-const SCHOOL_LEVEL_LABELS: Record<number, string> = {
-  1: "Elementary",
-  2: "Middle",
-  3: "High",
-  4: "Other",
 };
 
 const SCHOOL_LEVEL_COLORS: Record<number, string> = {

--- a/src/features/map/components/SearchResults/PlanContactsTab.tsx
+++ b/src/features/map/components/SearchResults/PlanContactsTab.tsx
@@ -3,9 +3,10 @@
 import { useState, useCallback, useMemo } from "react";
 import { usePlanContacts, useDistrictWebsites } from "@/lib/api";
 import { useCreateContact, useUpdateContact } from "@/features/shared/lib/queries";
-import type { Contact } from "@/features/shared/types/api-types";
+import type { Contact, ContactSchoolLink } from "@/features/shared/types/api-types";
 import { PERSONAS, SENIORITY_LEVELS } from "@/features/shared/types/contact-types";
 import ContactsActionBar from "@/features/plans/components/ContactsActionBar";
+import SchoolBadge from "@/features/plans/components/SchoolBadge";
 
 // ─── Types ──────────────────────────────────────────────────────
 
@@ -436,6 +437,7 @@ function DistrictContactGroup({
                           onCancel={onCancel}
                           isPending={isUpdatePending}
                           isEditing
+                          schoolLink={contact.schoolContacts?.[0]}
                         />
                       </div>
                     ) : (
@@ -517,6 +519,11 @@ function ContactRow({ contact, onClick }: { contact: Contact; onClick: () => voi
         {contact.title && (
           <p className="text-[10px] text-[#8A80A8] truncate">{contact.title}</p>
         )}
+        {contact.schoolContacts?.[0] && (
+          <div className="mt-0.5">
+            <SchoolBadge link={contact.schoolContacts[0]} />
+          </div>
+        )}
       </div>
 
       {/* Quick actions */}
@@ -558,6 +565,7 @@ function ContactInlineForm({
   onCancel,
   isPending,
   isEditing,
+  schoolLink,
 }: {
   formData: ContactFormData;
   setFormData: (data: ContactFormData) => void;
@@ -565,6 +573,7 @@ function ContactInlineForm({
   onCancel: () => void;
   isPending: boolean;
   isEditing?: boolean;
+  schoolLink?: ContactSchoolLink;
 }) {
   const inputClass =
     "w-full px-2.5 py-1.5 text-xs border border-[#E2DEEC] rounded-lg bg-white text-[#544A78] placeholder:text-[#C2BBD4] focus:outline-none focus:ring-2 focus:ring-[#403770]/20 focus:border-[#403770] transition-colors";
@@ -576,6 +585,9 @@ function ContactInlineForm({
       <div className="text-[9px] font-bold uppercase tracking-wider text-[#6EA3BE] mb-1">
         {isEditing ? "Edit Contact" : "New Contact"}
       </div>
+      {schoolLink && (
+        <SchoolBadge link={schoolLink} variant="block" />
+      )}
       <div className="flex gap-2">
         <input
           type="text"

--- a/src/features/map/components/SearchResults/index.tsx
+++ b/src/features/map/components/SearchResults/index.tsx
@@ -336,8 +336,16 @@ export default function SearchResults() {
         color: newPlanColor,
         fiscalYear,
       });
-      // Auto-select the new plan so user can hit "Add to plan"
-      setSelectedPlanIds((prev) => new Set(prev).add(plan.id));
+      // Immediately add selected districts to the new plan
+      const leaidsToAdd = selectedDistrictLeaids.size > 0
+        ? [...selectedDistrictLeaids]
+        : searchResultLeaids;
+      if (leaidsToAdd.length > 0) {
+        await addDistricts.mutateAsync({ planId: plan.id, leaids: leaidsToAdd });
+      }
+      setShowAddAllDropdown(false);
+      setSelectedPlanIds(new Set());
+      setPlanSearchQuery("");
       setShowNewPlanForm(false);
       setNewPlanName("");
       setNewPlanColor("#403770");
@@ -746,7 +754,7 @@ export default function SearchResults() {
                       disabled={!newPlanName.trim() || createPlan.isPending}
                       className="w-full py-1.5 rounded-lg text-xs font-semibold text-white bg-plum hover:bg-[#322a5a] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                     >
-                      {createPlan.isPending ? "Creating..." : "Create Plan"}
+                      {createPlan.isPending || addDistricts.isPending ? "Creating..." : "Create & Add"}
                     </button>
                   </div>
                 ) : (

--- a/src/features/map/components/panels/district/CharterSchools.tsx
+++ b/src/features/map/components/panels/district/CharterSchools.tsx
@@ -1,13 +1,7 @@
 "use client";
 
 import { useSchoolsByDistrict } from "@/lib/api";
-
-const SCHOOL_LEVEL_LABELS: Record<number, string> = {
-  1: "Primary",
-  2: "Middle",
-  3: "High",
-  4: "Other",
-};
+import { SCHOOL_LEVEL_LABELS } from "@/features/shared/lib/schoolLabels";
 
 interface CharterSchoolsProps {
   leaid: string;

--- a/src/features/map/components/panels/district/SchoolsCard.tsx
+++ b/src/features/map/components/panels/district/SchoolsCard.tsx
@@ -3,13 +3,7 @@
 import { useState } from "react";
 import { useSchoolsByDistrict } from "@/lib/api";
 import type { SchoolListItem, SchoolsSummary } from "@/features/shared/types/api-types";
-
-const SCHOOL_LEVEL_LABELS: Record<number, string> = {
-  1: "Primary",
-  2: "Middle",
-  3: "High",
-  4: "Other",
-};
+import { SCHOOL_LEVEL_LABELS } from "@/features/shared/lib/schoolLabels";
 
 const TITLE_I_LABELS: Record<number, string> = {
   1: "Eligible (No Program)",

--- a/src/features/map/components/panels/district/tabs/SchoolsTab.tsx
+++ b/src/features/map/components/panels/district/tabs/SchoolsTab.tsx
@@ -2,13 +2,7 @@
 
 import { useMemo } from "react";
 import { useSchoolsByDistrict } from "@/lib/api";
-
-const SCHOOL_LEVEL_LABELS: Record<number, string> = {
-  1: "Primary",
-  2: "Middle",
-  3: "High",
-  4: "Other",
-};
+import { SCHOOL_LEVEL_LABELS } from "@/features/shared/lib/schoolLabels";
 
 interface SchoolsTabProps {
   leaid: string;

--- a/src/features/plans/components/ContactCard.tsx
+++ b/src/features/plans/components/ContactCard.tsx
@@ -6,6 +6,7 @@
 import { useState } from "react";
 import type { Contact } from "@/lib/api";
 import ContactOutreachActions from "@/features/integrations/components/ContactOutreachActions";
+import SchoolBadge from "./SchoolBadge";
 
 interface ContactCardProps {
   contact: Contact;
@@ -101,6 +102,13 @@ export default function ContactCard({ contact, districtName, onEdit, onDelete, o
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
           </svg>
           <span className="text-xs text-[#403770]/70 truncate">{districtName}</span>
+        </div>
+      )}
+
+      {/* School badge (for school-linked contacts like principals) */}
+      {contact.schoolContacts?.[0] && (
+        <div className="mb-2">
+          <SchoolBadge link={contact.schoolContacts[0]} />
         </div>
       )}
 

--- a/src/features/plans/components/ContactsActionBar.tsx
+++ b/src/features/plans/components/ContactsActionBar.tsx
@@ -91,7 +91,7 @@ export default function ContactsActionBar({
     // Completion check
     if (progress.queued > 0 && progress.enriched >= progress.queued) {
       setIsEnriching(false);
-      setToast({ message: `Contact enrichment complete — ${progress.enriched} districts enriched`, type: "success" });
+      setToast({ message: `Contact enrichment complete — ${progress.enriched} contact${progress.enriched !== 1 ? "s" : ""} found`, type: "success" });
       if (stallTimerRef.current) clearTimeout(stallTimerRef.current);
       return;
     }
@@ -103,7 +103,7 @@ export default function ContactsActionBar({
       if (stallTimerRef.current) clearTimeout(stallTimerRef.current);
       stallTimerRef.current = setTimeout(() => {
         setIsEnriching(false);
-        setToast({ message: "Enrichment may be stalled — some districts may not have results", type: "warning" });
+        setToast({ message: "Enrichment may be stalled — some contacts may not have results", type: "warning" });
       }, 2 * 60 * 1000);
     }
   }, [isEnriching, progress]);
@@ -128,7 +128,7 @@ export default function ContactsActionBar({
       });
 
       if (result.queued === 0) {
-        setToast({ message: "All districts already have contacts — nothing to enrich", type: "info" });
+        setToast({ message: "Nothing to enrich — all targets already have contacts", type: "info" });
         return;
       }
 
@@ -138,10 +138,10 @@ export default function ContactsActionBar({
       // Start stall timer
       stallTimerRef.current = setTimeout(() => {
         setIsEnriching(false);
-        setToast({ message: "Enrichment may be stalled — some districts may not have results", type: "warning" });
+        setToast({ message: "Enrichment may be stalled — some contacts may not have results", type: "warning" });
       }, 2 * 60 * 1000);
 
-      setToast({ message: `Contact enrichment started for ${result.queued} districts`, type: "info" });
+      setToast({ message: `Looking for ${result.queued} contact${result.queued !== 1 ? "s" : ""}`, type: "info" });
     } catch (error) {
       const message = error instanceof Error ? error.message : "Failed to start contact enrichment";
       if (message.includes("409") || message.includes("already in progress")) {

--- a/src/features/plans/components/ContactsActionBar.tsx
+++ b/src/features/plans/components/ContactsActionBar.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { Search, Download, ChevronDown } from "lucide-react";
 import { TARGET_ROLES, type TargetRole } from "@/features/shared/types/contact-types";
+import { SCHOOL_LEVEL_LABELS, SCHOOL_TYPE_LABELS } from "@/features/shared/lib/schoolLabels";
 import type { Contact } from "@/lib/api";
 import {
   useBulkEnrich,
@@ -153,43 +154,58 @@ export default function ContactsActionBar({
   }, [planId, selectedRole, schoolLevels, bulkEnrich]);
 
   const handleExportCsv = useCallback(() => {
-    const headers = ["District Name", "Website", "Contact Name", "Title", "Email", "Phone", "Department", "Seniority Level"];
+    const headers = [
+      "District Name",
+      "Website",
+      "School Name",
+      "School Level",
+      "School Type",
+      "Contact Name",
+      "Title",
+      "Email",
+      "Phone",
+      "Department",
+      "Seniority Level",
+    ];
 
-    // Build a map of leaid -> primary contact
-    const primaryByDistrict = new Map<string, Contact>();
+    const rows: string[][] = [];
+    const seenDistricts = new Set<string>();
+
+    // One row per contact
     for (const contact of contacts) {
-      const existing = primaryByDistrict.get(contact.leaid);
-      if (!existing) {
-        primaryByDistrict.set(contact.leaid, contact);
-      } else if (contact.isPrimary && !existing.isPrimary) {
-        primaryByDistrict.set(contact.leaid, contact);
-      } else if (
-        !existing.isPrimary &&
-        !contact.isPrimary &&
-        contact.name.localeCompare(existing.name) < 0
-      ) {
-        primaryByDistrict.set(contact.leaid, contact);
-      }
-    }
+      seenDistricts.add(contact.leaid);
+      const districtName = districtNameMap?.get(contact.leaid) || contact.leaid;
+      const websiteUrl = districtWebsiteMap?.get(contact.leaid) || "";
 
-    // One row per district (including districts with no contacts)
-    const rows = allDistrictLeaids.map((leaid) => {
-      const districtName = districtNameMap?.get(leaid) || leaid;
-      const contact = primaryByDistrict.get(leaid);
+      const link = contact.schoolContacts?.[0];
+      const schoolName = link?.name ?? "";
+      const schoolLevel =
+        link?.schoolLevel != null ? (SCHOOL_LEVEL_LABELS[link.schoolLevel] ?? "") : "";
+      const schoolType =
+        link?.schoolType != null ? (SCHOOL_TYPE_LABELS[link.schoolType] ?? "") : "";
 
-      const websiteUrl = districtWebsiteMap?.get(leaid) || "";
-
-      return [
+      rows.push([
         districtName,
         websiteUrl,
-        contact?.name || "",
-        contact?.title || "",
-        contact?.email || "",
-        contact?.phone || "",
-        contact?.persona || "",
-        contact?.seniorityLevel || "",
-      ];
-    });
+        schoolName,
+        schoolLevel,
+        schoolType,
+        contact.name || "",
+        contact.title || "",
+        contact.email || "",
+        contact.phone || "",
+        contact.persona || "",
+        contact.seniorityLevel || "",
+      ]);
+    }
+
+    // Preserve coverage-gap signal: one blank row per district with zero contacts
+    for (const leaid of allDistrictLeaids) {
+      if (seenDistricts.has(leaid)) continue;
+      const districtName = districtNameMap?.get(leaid) || leaid;
+      const websiteUrl = districtWebsiteMap?.get(leaid) || "";
+      rows.push([districtName, websiteUrl, "", "", "", "", "", "", "", "", ""]);
+    }
 
     const csvContent = [headers, ...rows]
       .map((row) => row.map((cell) => `"${cell.replace(/"/g, '""')}"`).join(","))
@@ -203,7 +219,7 @@ export default function ContactsActionBar({
     link.download = `${safeName}-contacts-${new Date().toISOString().split("T")[0]}.csv`;
     link.click();
     URL.revokeObjectURL(url);
-  }, [contacts, allDistrictLeaids, districtNameMap, planName]);
+  }, [contacts, allDistrictLeaids, districtNameMap, districtWebsiteMap, planName]);
 
   const progressPercent =
     progress && progress.queued > 0

--- a/src/features/plans/components/ContactsActionBar.tsx
+++ b/src/features/plans/components/ContactsActionBar.tsx
@@ -33,6 +33,9 @@ export default function ContactsActionBar({
 }: ContactsActionBarProps) {
   const [showPopover, setShowPopover] = useState(false);
   const [selectedRole, setSelectedRole] = useState<TargetRole>("Superintendent");
+  // School-level subfilter (only meaningful when selectedRole === "Principal").
+  // Default: all 3 levels checked (1 = Primary/Elementary, 2 = Middle, 3 = High).
+  const [schoolLevels, setSchoolLevels] = useState<Set<number>>(new Set([1, 2, 3]));
   const [isEnriching, setIsEnriching] = useState(false);
   const [toast, setToast] = useState<{ message: string; type: "info" | "success" | "warning" | "error" } | null>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
@@ -115,7 +118,13 @@ export default function ContactsActionBar({
     setShowPopover(false);
 
     try {
-      const result = await bulkEnrich.mutateAsync({ planId, targetRole: selectedRole });
+      const result = await bulkEnrich.mutateAsync({
+        planId,
+        targetRole: selectedRole,
+        ...(selectedRole === "Principal"
+          ? { schoolLevels: Array.from(schoolLevels).sort() }
+          : {}),
+      });
 
       if (result.queued === 0) {
         setToast({ message: "All districts already have contacts — nothing to enrich", type: "info" });
@@ -141,7 +150,7 @@ export default function ContactsActionBar({
         setToast({ message, type: "error" });
       }
     }
-  }, [planId, selectedRole, bulkEnrich]);
+  }, [planId, selectedRole, schoolLevels, bulkEnrich]);
 
   const handleExportCsv = useCallback(() => {
     const headers = ["District Name", "Website", "Contact Name", "Title", "Email", "Phone", "Department", "Seniority Level"];
@@ -238,10 +247,49 @@ export default function ContactsActionBar({
                   </select>
                   <ChevronDown className="absolute right-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-[#403770]/40 pointer-events-none" />
                 </div>
+
+                {selectedRole === "Principal" && (
+                  <div className="mb-3">
+                    <label className="block text-[11px] font-semibold text-[#403770]/60 uppercase tracking-wider mb-1.5">
+                      School Level
+                    </label>
+                    <div className="flex flex-col gap-1.5">
+                      {[
+                        { value: 1, label: "Primary" },
+                        { value: 2, label: "Middle" },
+                        { value: 3, label: "High" },
+                      ].map(({ value, label }) => (
+                        <label
+                          key={value}
+                          className="flex items-center gap-2 text-[13px] text-[#403770] cursor-pointer"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={schoolLevels.has(value)}
+                            onChange={(e) => {
+                              setSchoolLevels((prev) => {
+                                const next = new Set(prev);
+                                if (e.target.checked) next.add(value);
+                                else next.delete(value);
+                                return next;
+                              });
+                            }}
+                            className="w-3.5 h-3.5 accent-[#403770]"
+                          />
+                          {label}
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
                 <button
                   onClick={handleStartEnrichment}
-                  disabled={bulkEnrich.isPending}
-                  className="w-full px-3 py-2 text-[13px] font-medium text-white bg-[#403770] hover:bg-[#322a5a] disabled:opacity-50 rounded-lg transition-colors"
+                  disabled={
+                    bulkEnrich.isPending ||
+                    (selectedRole === "Principal" && schoolLevels.size === 0)
+                  }
+                  className="w-full px-3 py-2 text-[13px] font-medium text-white bg-[#403770] hover:bg-[#322a5a] disabled:opacity-50 disabled:cursor-not-allowed rounded-lg transition-colors"
                 >
                   {bulkEnrich.isPending ? "Starting..." : "Start"}
                 </button>

--- a/src/features/plans/components/ContactsTable.tsx
+++ b/src/features/plans/components/ContactsTable.tsx
@@ -10,6 +10,7 @@ import type { Contact } from "@/lib/api";
 import { useSortableTable } from "@/features/shared/hooks/useSortableTable";
 import { SortHeader } from "@/features/shared/components/SortHeader";
 import ContactsActionBar from "./ContactsActionBar";
+import SchoolBadge from "./SchoolBadge";
 
 // Generate a consistent color from a contact's name for their avatar
 // Uses the brand palette so every avatar feels intentional
@@ -260,6 +261,9 @@ export default function ContactsTable({
                 <th className="px-4 py-3 text-left text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
                   District
                 </th>
+                <th className="px-4 py-3 text-left text-[11px] font-semibold text-gray-500 uppercase tracking-wider">
+                  School
+                </th>
                 <SortHeader
                   field="persona"
                   label="Department"
@@ -366,6 +370,15 @@ export default function ContactsTable({
                         <span className="text-[13px] text-[#403770]/80 truncate max-w-[180px] block">
                           {districtName}
                         </span>
+                      ) : (
+                        <span className="text-[13px] text-gray-300">&mdash;</span>
+                      )}
+                    </td>
+
+                    {/* School */}
+                    <td className="px-4 py-3 max-w-[220px]">
+                      {contact.schoolContacts?.[0] ? (
+                        <SchoolBadge link={contact.schoolContacts[0]} />
                       ) : (
                         <span className="text-[13px] text-gray-300">&mdash;</span>
                       )}

--- a/src/features/plans/components/FilterBar.tsx
+++ b/src/features/plans/components/FilterBar.tsx
@@ -217,12 +217,27 @@ export default function FilterBar({
 
         {/* Filter dropdowns */}
         {filters.map((filter) => {
-          if (filter.options.length === 0) return null;
+          const isLoading = filter.options.length === 0;
 
-          const isActive = activeFilters[filter.id] &&
+          const isActive = !isLoading && activeFilters[filter.id] &&
             (Array.isArray(activeFilters[filter.id])
               ? (activeFilters[filter.id] as string[]).length > 0
               : true);
+
+          if (isLoading) {
+            return (
+              <button
+                key={filter.id}
+                disabled
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg bg-gray-100 text-gray-400 cursor-not-allowed"
+              >
+                {filter.label}
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
+              </button>
+            );
+          }
 
           return (
             <Dropdown

--- a/src/features/plans/components/PlanFormModal.tsx
+++ b/src/features/plans/components/PlanFormModal.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import type { TerritoryPlan } from "@/lib/api";
-import { useUsers, useStates } from "@/lib/api";
+import { useUsers, useStates, useProfile } from "@/lib/api";
 
 interface PlanFormModalProps {
   isOpen: boolean;
@@ -88,6 +88,7 @@ export default function PlanFormModal({
   const stateSearchRef = useRef<HTMLInputElement>(null);
   const { data: users } = useUsers();
   const { data: allStates } = useStates();
+  const { data: profile } = useProfile();
 
   // Reset form when modal opens/closes or initialData changes
   useEffect(() => {
@@ -95,7 +96,7 @@ export default function PlanFormModal({
       setFormData({
         name: initialData?.name || "",
         description: initialData?.description || "",
-        ownerId: initialData?.owner?.id ?? null,
+        ownerId: initialData?.owner?.id ?? profile?.id ?? null,
         color: initialData?.color || PLAN_COLORS[0].value,
         status: initialData?.status || "planning",
         fiscalYear: initialData?.fiscalYear || getDefaultFiscalYear(),
@@ -108,6 +109,7 @@ export default function PlanFormModal({
       // Focus input after a short delay for animation
       setTimeout(() => inputRef.current?.focus(), 100);
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- profile is a stable cached value, don't reset form when it loads
   }, [isOpen, initialData]);
 
   const handleSubmit = async (e: React.FormEvent) => {

--- a/src/features/plans/components/SchoolBadge.tsx
+++ b/src/features/plans/components/SchoolBadge.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+// SchoolBadge - compact badge showing which school a contact belongs to.
+// Renders "<School Name> · <Level Label>" plus a "Transfer" pill when the
+// school is a transfer school (schoolLevel=3 High AND schoolType=4 Alternative).
+
+import type { ContactSchoolLink } from "@/features/shared/types/api-types";
+import {
+  SCHOOL_LEVEL_LABELS,
+  SCHOOL_TYPE_LABELS,
+} from "@/features/shared/lib/schoolLabels";
+
+/** Transfer schools are identified as High School (level=3) + Alternative type (type=4). */
+export function isTransferSchool(link: ContactSchoolLink): boolean {
+  return link.schoolLevel === 3 && link.schoolType === 4;
+}
+
+interface SchoolBadgeProps {
+  link: ContactSchoolLink | undefined;
+  /** "inline" = single line for table cells; "block" = multi-line banner for edit forms. */
+  variant?: "inline" | "block";
+}
+
+export default function SchoolBadge({ link, variant = "inline" }: SchoolBadgeProps) {
+  if (!link) return null;
+
+  const levelLabel =
+    link.schoolLevel != null ? SCHOOL_LEVEL_LABELS[link.schoolLevel] : undefined;
+  const typeLabel =
+    link.schoolType != null ? SCHOOL_TYPE_LABELS[link.schoolType] : undefined;
+  const isTransfer = isTransferSchool(link);
+
+  if (variant === "block") {
+    return (
+      <div className="flex items-start gap-2 px-2.5 py-2 rounded-lg bg-[#F7F5FA] border border-[#EFEDF5]">
+        <svg
+          className="w-4 h-4 text-[#6EA3BE] mt-px flex-shrink-0"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M12 14l9-5-9-5-9 5 9 5zm0 0l6.16-3.422a12.083 12.083 0 01.665 6.479A11.952 11.952 0 0012 20.055a11.952 11.952 0 00-6.824-2.998 12.078 12.078 0 01.665-6.479L12 14z"
+          />
+        </svg>
+        <div className="min-w-0 flex-1">
+          <div className="text-[11px] font-semibold uppercase tracking-wider text-[#403770]/60 mb-0.5">
+            School
+          </div>
+          <div className="flex items-center gap-1.5 flex-wrap">
+            <span className="text-[13px] font-medium text-[#403770] truncate">
+              {link.name}
+            </span>
+            {isTransfer && <TransferPill />}
+          </div>
+          <div className="text-[11px] text-[#403770]/60 mt-0.5">
+            {levelLabel ?? "—"}
+            {typeLabel ? ` · ${typeLabel}` : ""}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // inline variant
+  return (
+    <span className="inline-flex items-center gap-1.5 max-w-full">
+      <span className="text-[12px] text-[#403770]/70 truncate">
+        {link.name}
+        {levelLabel ? (
+          <span className="text-[#403770]/40">{` · ${levelLabel}`}</span>
+        ) : null}
+      </span>
+      {isTransfer && <TransferPill />}
+    </span>
+  );
+}
+
+function TransferPill() {
+  return (
+    <span
+      className="flex-shrink-0 inline-flex items-center px-1.5 py-px text-[9px] font-bold uppercase tracking-wide bg-[#FFB347] text-white rounded"
+      title="Transfer school (High School · Alternative)"
+    >
+      Transfer
+    </span>
+  );
+}

--- a/src/features/plans/components/__tests__/ContactsActionBar.test.tsx
+++ b/src/features/plans/components/__tests__/ContactsActionBar.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import ContactsActionBar from "../ContactsActionBar";
+
+const mockMutateAsync = vi.fn().mockResolvedValue({ total: 3, skipped: 0, queued: 3 });
+
+vi.mock("@/features/plans/lib/queries", () => ({
+  useBulkEnrich: () => ({
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+  }),
+  useEnrichProgress: () => ({
+    data: { total: 0, enriched: 0, queued: 0 },
+  }),
+}));
+
+describe("ContactsActionBar — Principal popover", () => {
+  beforeEach(() => {
+    mockMutateAsync.mockClear();
+  });
+
+  it("shows School Level checkboxes when Principal is selected", () => {
+    render(
+      <ContactsActionBar
+        planId="plan-1"
+        planName="Plan"
+        contacts={[]}
+        allDistrictLeaids={["0100001"]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /find contacts/i }));
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "Principal" } });
+
+    expect(screen.getByText("School Level")).toBeInTheDocument();
+    expect(screen.getByLabelText("Primary")).toBeChecked();
+    expect(screen.getByLabelText("Middle")).toBeChecked();
+    expect(screen.getByLabelText("High")).toBeChecked();
+  });
+
+  it("disables Start when all school-level checkboxes are cleared", () => {
+    render(
+      <ContactsActionBar
+        planId="plan-1"
+        planName="Plan"
+        contacts={[]}
+        allDistrictLeaids={["0100001"]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /find contacts/i }));
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "Principal" } });
+
+    fireEvent.click(screen.getByLabelText("Primary"));
+    fireEvent.click(screen.getByLabelText("Middle"));
+    fireEvent.click(screen.getByLabelText("High"));
+
+    expect(screen.getByRole("button", { name: /start/i })).toBeDisabled();
+  });
+
+  it("passes schoolLevels to useBulkEnrich on Start", async () => {
+    render(
+      <ContactsActionBar
+        planId="plan-1"
+        planName="Plan"
+        contacts={[]}
+        allDistrictLeaids={["0100001"]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /find contacts/i }));
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "Principal" } });
+    fireEvent.click(screen.getByLabelText("Middle")); // uncheck middle
+    fireEvent.click(screen.getByRole("button", { name: /start/i }));
+
+    await vi.waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        planId: "plan-1",
+        targetRole: "Principal",
+        schoolLevels: [1, 3],
+      });
+    });
+  });
+
+  it("does not pass schoolLevels for non-Principal roles", async () => {
+    render(
+      <ContactsActionBar
+        planId="plan-1"
+        planName="Plan"
+        contacts={[]}
+        allDistrictLeaids={["0100001"]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /find contacts/i }));
+    // Superintendent is the default — just click Start
+    fireEvent.click(screen.getByRole("button", { name: /start/i }));
+
+    await vi.waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        planId: "plan-1",
+        targetRole: "Superintendent",
+      });
+    });
+  });
+});

--- a/src/features/plans/components/__tests__/ContactsTable.test.tsx
+++ b/src/features/plans/components/__tests__/ContactsTable.test.tsx
@@ -18,6 +18,7 @@ function makeContact(overrides: Partial<Contact> = {}): Contact {
     seniorityLevel: null,
     createdAt: "2026-01-01T00:00:00Z",
     lastEnrichedAt: null,
+    schoolContacts: [],
     ...overrides,
   };
 }

--- a/src/features/plans/components/__tests__/SchoolBadge.test.tsx
+++ b/src/features/plans/components/__tests__/SchoolBadge.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import SchoolBadge, { isTransferSchool } from "../SchoolBadge";
+
+describe("isTransferSchool", () => {
+  it("flags High + Alternative as transfer", () => {
+    expect(
+      isTransferSchool({ ncessch: "s1", name: "Transfer HS", schoolLevel: 3, schoolType: 4 })
+    ).toBe(true);
+  });
+
+  it("does not flag High + Regular", () => {
+    expect(
+      isTransferSchool({ ncessch: "s2", name: "Regular HS", schoolLevel: 3, schoolType: 1 })
+    ).toBe(false);
+  });
+
+  it("does not flag Middle + Alternative", () => {
+    expect(
+      isTransferSchool({ ncessch: "s3", name: "Alt MS", schoolLevel: 2, schoolType: 4 })
+    ).toBe(false);
+  });
+});
+
+describe("SchoolBadge", () => {
+  it("renders nothing when no link is provided", () => {
+    const { container } = render(<SchoolBadge link={undefined} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders school name and level label in inline variant", () => {
+    render(
+      <SchoolBadge
+        link={{ ncessch: "s1", name: "Lincoln HS", schoolLevel: 3, schoolType: 1 }}
+      />
+    );
+    expect(screen.getByText(/Lincoln HS/)).toBeInTheDocument();
+    expect(screen.getByText(/High/)).toBeInTheDocument();
+  });
+
+  it("renders Transfer pill for HS + Alternative schools", () => {
+    render(
+      <SchoolBadge
+        link={{ ncessch: "s1", name: "Transfer HS", schoolLevel: 3, schoolType: 4 }}
+      />
+    );
+    expect(screen.getByText("Transfer")).toBeInTheDocument();
+  });
+
+  it("does not render Transfer pill for non-transfer schools", () => {
+    render(
+      <SchoolBadge
+        link={{ ncessch: "s1", name: "Lincoln HS", schoolLevel: 3, schoolType: 1 }}
+      />
+    );
+    expect(screen.queryByText("Transfer")).not.toBeInTheDocument();
+  });
+
+  it("block variant shows School label and type", () => {
+    render(
+      <SchoolBadge
+        variant="block"
+        link={{ ncessch: "s1", name: "Transfer HS", schoolLevel: 3, schoolType: 4 }}
+      />
+    );
+    expect(screen.getByText("School")).toBeInTheDocument();
+    expect(screen.getByText(/Alternative/)).toBeInTheDocument();
+    expect(screen.getByText("Transfer")).toBeInTheDocument();
+  });
+});

--- a/src/features/plans/lib/queries.ts
+++ b/src/features/plans/lib/queries.ts
@@ -257,12 +257,23 @@ export function useBulkEnrich() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ planId, targetRole }: { planId: string; targetRole: string }) =>
+    mutationFn: ({
+      planId,
+      targetRole,
+      schoolLevels,
+    }: {
+      planId: string;
+      targetRole: string;
+      schoolLevels?: number[];
+    }) =>
       fetchJson<{ total: number; skipped: number; queued: number }>(
         `${API_BASE}/territory-plans/${planId}/contacts/bulk-enrich`,
         {
           method: "POST",
-          body: JSON.stringify({ targetRole }),
+          body: JSON.stringify({
+            targetRole,
+            ...(schoolLevels ? { schoolLevels } : {}),
+          }),
         }
       ),
     onSuccess: (_, variables) => {

--- a/src/features/shared/components/views/ActivitiesView.tsx
+++ b/src/features/shared/components/views/ActivitiesView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useRef, useEffect } from "react";
 import {
   startOfMonth,
   endOfMonth,
@@ -78,6 +78,15 @@ export default function ActivitiesView() {
   const { data: users } = useUsers();
 
   const isCalendar = view === "calendar";
+
+  // Default the owner filter to the current user once profile loads
+  const hasSetDefaultOwner = useRef(false);
+  useEffect(() => {
+    if (profile && !hasSetDefaultOwner.current) {
+      hasSetDefaultOwner.current = true;
+      setActiveFilters((prev) => prev.owner ? prev : { ...prev, owner: profile.id });
+    }
+  }, [profile]);
 
   // Build owner filter options — current user first, then "All", then others
   const ownerOptions = useMemo((): FilterOption[] => {

--- a/src/features/shared/lib/__tests__/schoolLabels.test.ts
+++ b/src/features/shared/lib/__tests__/schoolLabels.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { SCHOOL_LEVEL_LABELS, SCHOOL_TYPE_LABELS } from "../schoolLabels";
+
+describe("SCHOOL_LEVEL_LABELS", () => {
+  it("maps all 4 NCES school levels", () => {
+    expect(SCHOOL_LEVEL_LABELS[1]).toBe("Elementary");
+    expect(SCHOOL_LEVEL_LABELS[2]).toBe("Middle");
+    expect(SCHOOL_LEVEL_LABELS[3]).toBe("High");
+    expect(SCHOOL_LEVEL_LABELS[4]).toBe("Other");
+  });
+});
+
+describe("SCHOOL_TYPE_LABELS", () => {
+  it("maps all 4 NCES school types", () => {
+    expect(SCHOOL_TYPE_LABELS[1]).toBe("Regular");
+    expect(SCHOOL_TYPE_LABELS[2]).toBe("Special Education");
+    expect(SCHOOL_TYPE_LABELS[3]).toBe("Career & Technical");
+    expect(SCHOOL_TYPE_LABELS[4]).toBe("Alternative");
+  });
+});

--- a/src/features/shared/lib/schoolLabels.ts
+++ b/src/features/shared/lib/schoolLabels.ts
@@ -1,0 +1,16 @@
+// NCES school level codes (common core of data)
+export const SCHOOL_LEVEL_LABELS: Record<number, string> = {
+  1: "Elementary",
+  2: "Middle",
+  3: "High",
+  4: "Other",
+};
+
+// NCES school type codes (common core of data)
+// 1 = Regular, 2 = Special Education, 3 = Career & Technical, 4 = Alternative
+export const SCHOOL_TYPE_LABELS: Record<number, string> = {
+  1: "Regular",
+  2: "Special Education",
+  3: "Career & Technical",
+  4: "Alternative",
+};

--- a/src/features/shared/types/__tests__/contact-types.test.ts
+++ b/src/features/shared/types/__tests__/contact-types.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { TARGET_ROLES } from "../contact-types";
+
+describe("TARGET_ROLES", () => {
+  it("includes Principal as the 8th role", () => {
+    expect(TARGET_ROLES).toContain("Principal");
+  });
+
+  it("preserves existing roles in order", () => {
+    expect(TARGET_ROLES.slice(0, 7)).toEqual([
+      "Superintendent",
+      "Assistant Superintendent",
+      "Chief Technology Officer",
+      "Chief Financial Officer",
+      "Curriculum Director",
+      "Special Education Director",
+      "HR Director",
+    ]);
+  });
+});

--- a/src/features/shared/types/api-types.ts
+++ b/src/features/shared/types/api-types.ts
@@ -84,6 +84,13 @@ export interface Service {
   sortOrder: number;
 }
 
+export interface ContactSchoolLink {
+  ncessch: string;
+  name: string;
+  schoolLevel: number | null;
+  schoolType: number | null;
+}
+
 export interface Contact {
   id: number;
   leaid: string;
@@ -98,6 +105,8 @@ export interface Contact {
   seniorityLevel: string | null;
   createdAt: string;
   lastEnrichedAt: string | null;
+  /** Present when the contact is linked to one or more schools (e.g. principals). Empty array for district-level contacts. */
+  schoolContacts: ContactSchoolLink[];
 }
 
 export interface DistrictEducationData {

--- a/src/features/shared/types/contact-types.ts
+++ b/src/features/shared/types/contact-types.ts
@@ -72,6 +72,7 @@ export const TARGET_ROLES = [
   "Curriculum Director",
   "Special Education Director",
   "HR Director",
+  "Principal",
 ] as const;
 
 export type TargetRole = (typeof TARGET_ROLES)[number];


### PR DESCRIPTION
## Summary

- Adds **Principal** to the Find Contacts Target Role dropdown, with an inline **School Level** (Primary / Middle / High) subfilter. All three checked by default; Start disables when none are selected.
- `bulk-enrich` API branches on `targetRole === "Principal"` and fires **one Clay webhook per open school** (filtered by `schoolLevel`), skipping schools that already have a principal `SchoolContact`.
- Clay webhook callback now **creates a `SchoolContact` row** whenever the payload includes `ncessch`, linking the returned contact to the specific school.
- `enrich-progress` counts **schools-with-principal** (via `/principal/i` title match) when the active Activity's `targetRole === "Principal"`; the non-Principal path is unchanged.
- Plan contacts GET endpoint now returns `schoolContacts[]` per contact so the client can render school context.
- **UI surface area:**
  - New **School** column in `ContactsTable` showing `<School Name> · <Level Label>` and a `TRANSFER` pill for High School + Alternative schools.
  - Same `SchoolBadge` on `ContactCard` and the plan-detail sidebar's contact row + edit form banner (read-only).
- **CSV export** switches from one-row-per-district to **one-row-per-contact** and gains `School Name | School Level | School Type` columns. Districts with zero contacts still emit one blank row for coverage-gap visibility.
- Shared `SCHOOL_LEVEL_LABELS` + new `SCHOOL_TYPE_LABELS` live at `src/features/shared/lib/schoolLabels.ts`. Four map-panel components now import from that canonical source (replacing mixed "Primary"/"Elementary" with NCES-canonical "Elementary").
- Toast wording: "Looking for N contacts" / "enrichment complete — N contacts found" instead of "N districts".

No Prisma schema changes.

## Clay workflow audit

All three checks verified & edited where necessary:

- **Input columns** — added `ncessch`, `school_name`, `school_level`, `school_type` to the Territory Planner Webhook Requests table.
- **Enrichment step (Claygent / District Role Contact Finder)** — prompt updated with Principal conditional: when `target_role = Principal` and `school_name` is provided, restrict to that specific school; output JSON now includes `schoolName` and `ncessch`.
- **Callback HTTP column** — Endpoint changed from a hardcoded prod URL to the `Callback Url` column pill, so it POSTs to whatever environment (prod / preview / tunneled localhost) the app configures per run. All required fields (`leaid`, `name`, `email`, `phone`, `title`, `ncessch`) are in the query params.

## School data coverage

Spot-checked against the schools table (`school_status = 1`): **100% coverage** on both `school_level` and `school_type` across 99,336 open schools.

## Follow-up guidance added

`CLAUDE.md` gains a new **External Webhooks** section documenting the ngrok tunnel workflow — local verification of any third-party callback requires a tunnel + `NEXT_PUBLIC_SITE_URL` override, otherwise callbacks default to production.

## Test plan

- [x] `npm test -- --run src/` passes (only pre-existing failures remain: 1 SearchBar dimming test + leftover worktree dirs).
- [x] `npx tsc --noEmit` clean on this branch.
- [ ] Popover shows School Level section only when Principal is selected; all 3 checked by default.
- [ ] Start button disables when all school-level checkboxes are cleared.
- [ ] CSV export has the new 11-column header and one row per contact.
- [ ] Districts with zero contacts still emit a blank CSV row.
- [ ] Clay callback with `ncessch` creates both `Contact` and `SchoolContact` (unit test covers this; end-to-end verified locally via ngrok tunnel).
- [ ] Transfer pill renders on principal contacts at HS + Alternative schools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)