### PR TITLE
feat: existing-contacts options modal on Find Contacts

### DIFF
--- a/Docs/superpowers/2026-04-22-find-contacts-existing-options-final-report.md
+++ b/Docs/superpowers/2026-04-22-find-contacts-existing-options-final-report.md
@@ -1,0 +1,120 @@
+# Feature Report: Existing-Contacts Options Modal
+
+**Date:** 2026-04-22
+**Slug:** find-contacts-existing-options
+**Branch:** feat/find-contacts-principals (worktree: find-contacts-existing-options)
+**Status:** Ready for Review
+
+## Summary
+
+Replaces the dead-end "Nothing to enrich" toast on the Find Contacts action with
+a split-action modal offering two recovery paths: refresh the current plan's
+Contacts tab, or jump to another plan that already has contacts on the shared
+districts. Adds a team-wide read-only endpoint, a TanStack hook, and a new
+modal component; also surfaces the same modal after partial enrichment
+completion (queued>0 skipped>0). Plan was followed closely with a few
+reasonable deviations called out below — none blocking.
+
+## Changes
+
+| File | Action | Lines |
+|------|--------|-------|
+| `src/app/api/territory-plans/[id]/contact-sources/route.ts` | added | +162 |
+| `src/app/api/territory-plans/[id]/contact-sources/__tests__/route.test.ts` | added | +304 |
+| `src/features/plans/components/ExistingContactsModal.tsx` | added | +247 |
+| `src/features/plans/components/__tests__/ExistingContactsModal.test.tsx` | added | +182 |
+| `src/features/plans/components/ContactsActionBar.tsx` | modified | +27 / -2 |
+| `src/features/plans/components/__tests__/ContactsActionBar.test.tsx` | modified | +127 / -1 |
+| `src/features/plans/lib/queries.ts` | modified | +21 / 0 |
+| `Docs/superpowers/specs/2026-04-22-find-contacts-existing-options-spec.md` | added | +186 |
+| `Docs/superpowers/plans/2026-04-22-find-contacts-existing-options-plan.md` | added | +370 |
+| `Docs/superpowers/specs/2026-04-22-find-contacts-existing-options-backend-context.md` | added | +406 |
+
+## Test Results
+
+- New tests: 26 passing (9 backend route + 10 modal + 7 ActionBar — the
+  implementer's count of 17 appears to have undercounted the 4 pre-existing
+  ActionBar cases that were left intact)
+- Re-verified locally: `npx vitest run` scoped to the three modified/new test
+  files → all 26 pass
+- Full suite: not run — Stage 8 responsibility per instructions
+- `npm run build`: not run — Stage 8 responsibility
+- Coverage: hits spec-required cases (401, 404, empty-district short-circuit,
+  no-overlap, overlap-without-contacts, happy path, ranking w/ tiebreak,
+  limit 10, null owner; modal variants + loading + empty + error + dismiss +
+  anchor semantics; action-bar all three trigger branches)
+
+## Design Review
+
+Pending (running in parallel). See design-review report in conversation.
+
+## Code Review Findings
+
+### Strengths
+
+- Backend `ownerUser` join matches the exact precedent at
+  `src/app/api/territory-plans/route.ts:48-49,90-92` (`UserProfile.fullName`
+  via the `PlanOwner` relation). No schema guessing.
+- Auth scope (team-wide, no `ownerId` filter) correctly mirrors the plan-list
+  endpoint per the spec and carries a clear comment pointing at the precedent.
+- Query layout is efficient: `findUnique` + `findMany` + `groupBy` — exactly
+  three DB round-trips, no N+1. The `groupBy` aggregates over the current
+  plan's leaids (a small set) rather than per-candidate, so cost scales with
+  leaid count, not candidate count.
+- Ranking logic is correct: `contactCount DESC`, `lastEnrichedAt DESC NULLS
+  LAST` (via `-Infinity` sentinel), `name ASC` tiebreaker. Matches plan.
+- Self-exclusion via `id: { not: id }` + short-circuits for empty districts
+  and zero candidates avoid unnecessary queries.
+- Query key `["planContactSources", planId]` is a stable primitive per
+  CLAUDE.md perf rules. `ContactSourcePlan` interface is exported from
+  `queries.ts` and reused by the modal and its tests (no duplication).
+- The `setToast("Nothing to enrich")` dead-end is fully **replaced** (not left
+  as a fallback), exactly as the spec requires. Confirmed via `git diff`.
+- `pendingPartialRef` logic is sound: set only after `setIsEnriching(true)` in
+  the success path; consumed once on completion; cleared immediately to prevent
+  double-fire; not populated on the page-refresh auto-detect path (so reload
+  mid-enrichment won't incorrectly open the partial modal).
+- Focus trap is a clean inline implementation that correctly focuses the
+  primary button on mount (intentional deviation from a generic
+  `useFocusTrap` — the implementer documented this choice in their report and
+  the spec explicitly calls for "focus the Show them here primary button").
+- Plan rows use native `<a href="/plans/{id}">` preserving middle-click and
+  new-tab behavior (explicit spec requirement satisfied).
+- Partial-variant status message correctly uses `CheckCircle2` in `#69B34A`
+  plum-family green (not a Tailwind gray), and all color tokens in the modal
+  are plum-derived (`#403770`, `#6E6390`, `#E2DEEC`, `#F7F5FA`, `#EFEDF5`,
+  `#8A80A8`) per Fullmind brand rules.
+
+### Issues
+
+| Severity | Description | File | Recommendation |
+|----------|-------------|------|----------------|
+| Minor | Partial-variant copy deviates slightly from spec: spec's Variant B says "Found {queued} new contacts for {newCount} district{s}" (queued drives the contact count, newCount drives the district count — and in the spec "newCount" means "count of districts that got new contacts", distinct from `queued` which counts contacts). The implementation passes a single `newCount` prop and reuses it for both numbers (`Found {newCount} new contacts for {newCount} districts`). In practice `queued === newCount` only when exactly one contact is returned per district. For the common case (Superintendent: 1 contact per district) this is correct; for multi-contact enrichment the district count will visually equal the contact count. Low risk because the trigger logic currently enriches 1 contact per district, but worth flagging. | `src/features/plans/components/ExistingContactsModal.tsx:140-143`, `ContactsActionBar.tsx:131-149` | Either (a) clarify in a comment that `newCount` represents both values in the 1-contact-per-district model, or (b) pass `newContactCount` and `newDistrictCount` as two props. Safe to punt unless roadmap adds per-district multi-enrichment. |
+| Minor | The stretch goal "scroll first populated district group into view" after `handleShowHere` was skipped (implementer flagged it as intentional). Spec listed it as a requirement under Left column action, but the plan demoted it to "Optional: stretch goal" in `handleShowHere`. The skip matches the plan, not the spec — a small scope slip worth surfacing for maintainer sign-off. | `ExistingContactsModal.tsx:85-93` | Acceptable as-is; user can manually scroll and the invalidate+refetch is the actual functional requirement. Follow-up ticket if the maintainer wants it. |
+| Minor | `relativeDate` in the modal uses `new Date(iso).toLocaleDateString()` for dates older than 30 days, which produces locale-dependent output (US: `4/1/2026`) instead of an ISO-style or "Mar 1" format. Inconsistent with how other date displays in the app handle this, though there's no strict project standard I found. | `ExistingContactsModal.tsx:29` | Consider `{ month: "short", day: "numeric", year: "numeric" }` for consistency if other date displays use that format. Not blocking. |
+| Minor | No archive-status filter on candidate plans — archived plans still appear in the "other plans" list if they share districts and have contacts. The backend agent flagged this as an open question. Spec and plan don't require the filter, so this is spec-compliant, but in practice an archived plan is a confusing destination. | `src/app/api/territory-plans/[id]/contact-sources/route.ts:56-70` | Either (a) ship as-is and add an archive-exclusion ticket, or (b) add `status: { not: "archived" }` to the `findMany` where-clause. Low risk either way; confirm preference with maintainer. |
+| Minor | The `mockPrisma` type uses `as any` in the route test. Standard pattern in this codebase (matches the bulk-enrich test at `src/app/api/territory-plans/[id]/contacts/bulk-enrich/__tests__/route.test.ts:40`), so it's consistent, but the eslint-disable comment is worth noting. | `src/app/api/territory-plans/[id]/contact-sources/__tests__/route.test.ts:24-25` | No action needed; matches precedent. |
+| Minor | `act(...)` warnings emitted by the pre-existing ActionBar test cases (not the new ones) — these are pre-existing noise in `ContactsActionBar.test.tsx` unrelated to this change. | Pre-existing | Out of scope. |
+
+**No Critical or Important issues.**
+
+### Spec/Plan Compliance Matrix
+
+- Backend route behavior: matches steps 1-13 of plan B1 exactly.
+- Backend tests: covers all 9 cases B2 called for.
+- `useContactSources` hook: query key, staleTime, enabled flag — all match F1.
+- Modal variants, columns, dismiss behavior, plan row anchor, See-all toggle:
+  all match F2.
+- ActionBar wiring: state, ref, completion-effect trigger, JSX placement — all
+  match F3. The dead-end toast is fully replaced (not left as fallback).
+- Test coverage: F4's 10 cases and F5's 3 cases all present and passing.
+
+## Recommendation
+
+**READY FOR REVIEW** — Implementation tracks the spec and plan closely, all
+26 new tests pass, the dead-end toast is correctly replaced, auth/ranking/
+query-key patterns follow established precedent, and no N+1 or subscription
+pitfalls were introduced. The four minor issues (partial-variant copy nuance,
+skipped scroll stretch goal, `toLocaleDateString` format, archive-filter open
+question) are all safe to address post-merge if the maintainer wants — none
+are blocking. Design review and Stage 8 (full suite + `npm run build`) remain.

--- a/Docs/superpowers/plans/2026-04-22-find-contacts-existing-options-plan.md
+++ b/Docs/superpowers/plans/2026-04-22-find-contacts-existing-options-plan.md
@@ -1,0 +1,370 @@
+# Implementation Plan: Existing-Contacts Options Modal
+
+**Spec:** `Docs/superpowers/specs/2026-04-22-find-contacts-existing-options-spec.md`
+**Backend context:** `Docs/superpowers/specs/2026-04-22-find-contacts-existing-options-backend-context.md`
+**Branch:** `worktree-find-contacts-existing-options`
+
+## Ordering & Parallelism
+
+Two parallel tracks — backend (B) and frontend (F) — coordinated by the endpoint contract already locked in the spec. Final integration commit merges both.
+
+```
+B1: /contact-sources route ─┐
+B2: /contact-sources tests ─┤
+                            ├─► Merge & verify ► Stage 7 review
+F1: useContactSources hook ─┤
+F2: ExistingContactsModal ──┤
+F3: ContactsActionBar wire ─┤
+F4: Modal tests ────────────┤
+F5: ActionBar tests ────────┘
+```
+
+B and F tracks run in parallel. Within F, order is F1 → F2 → F3 (F3 imports F2; F2 consumes F1). Tests co-located at end of each track.
+
+---
+
+## Track B — Backend
+
+### B1. New route: `GET /api/territory-plans/[id]/contact-sources`
+
+**File:** `src/app/api/territory-plans/[id]/contact-sources/route.ts`
+
+**Steps:**
+1. Scaffold Next.js 16 App Router route (`export const dynamic = "force-dynamic"`), import `NextRequest, NextResponse`, `prisma`, `getUser`.
+2. Extract `id` from `params` (Next 16 promise pattern: `const { id } = await params`).
+3. `getUser()` → 401 if unauthenticated.
+4. Fetch current plan:
+   ```ts
+   const plan = await prisma.territoryPlan.findUnique({
+     where: { id },
+     include: { districts: { select: { districtLeaid: true } } },
+   });
+   if (!plan) return 404;
+   const leaids = plan.districts.map(d => d.districtLeaid);
+   if (leaids.length === 0) return NextResponse.json({ plans: [] });
+   ```
+5. Find candidate other plans sharing ≥1 leaid:
+   ```ts
+   const candidates = await prisma.territoryPlan.findMany({
+     where: {
+       id: { not: id },
+       districts: { some: { districtLeaid: { in: leaids } } },
+     },
+     include: {
+       districts: {
+         where: { districtLeaid: { in: leaids } },
+         select: { districtLeaid: true },
+       },
+     },
+   });
+   ```
+6. Fetch contact counts + last-enriched per leaid in a single groupBy:
+   ```ts
+   const contactAgg = await prisma.contact.groupBy({
+     by: ["leaid"],
+     where: { leaid: { in: leaids } },
+     _count: { _all: true },
+     _max: { lastEnrichedAt: true },
+   });
+   const byLeaid = new Map(contactAgg.map(a => [a.leaid, { count: a._count._all, lastEnriched: a._max.lastEnrichedAt }]));
+   ```
+7. Fetch owner display names (single `profile.findMany` keyed by distinct `ownerId`s).
+8. For each candidate, compute:
+   - `sharedDistrictCount = plan.districts.length` (the includes-filter returned only shared ones)
+   - `contactCount = sum of byLeaid[leaid].count for each shared leaid`
+   - `lastEnrichedAt = max of byLeaid[leaid].lastEnriched across shared leaids`
+9. **Filter out candidates where `contactCount === 0`** (only return plans that actually have contacts on shared districts).
+10. Rank: `contactCount DESC, lastEnrichedAt DESC NULLS LAST, name ASC`.
+11. Limit 10.
+12. Serialize:
+    ```ts
+    return NextResponse.json({
+      plans: ranked.map(p => ({
+        id: p.id,
+        name: p.name,
+        ownerName: p.ownerName ?? null,
+        sharedDistrictCount: p.sharedDistrictCount,
+        contactCount: p.contactCount,
+        lastEnrichedAt: p.lastEnrichedAt?.toISOString() ?? null,
+      })),
+    });
+    ```
+13. Wrap in try/catch → 500 on error with console.error.
+
+**Auth scope:** team-wide (no `userId`/`ownerId` filter) — matches `/api/territory-plans` list endpoint precedent per backend-context doc.
+
+**Profile join:** check existing plan-list endpoint for the profile lookup pattern (likely `prisma.profile.findMany({ where: { id: { in: ownerIds } } })` with a `name` or `displayName` field).
+
+### B2. Route tests
+
+**File:** `src/app/api/territory-plans/[id]/contact-sources/__tests__/route.test.ts`
+
+Mirror the structure of `src/app/api/territory-plans/[id]/contacts/bulk-enrich/__tests__/route.test.ts`:
+- Mock `@/lib/supabase/server.getUser` and `@/lib/prisma`
+- Pass `params` as `Promise.resolve({ id })`
+
+**Cases:**
+1. 401 when `getUser` returns null
+2. 404 when plan not found
+3. Returns `{ plans: [] }` when current plan has no districts
+4. Returns `{ plans: [] }` when no other plan shares any district
+5. Returns `{ plans: [] }` when overlapping plans exist but NONE have contacts on the shared districts
+6. Single-overlap happy path: one other plan, one shared district, 5 contacts → returns 1 row with correct shape
+7. Ranking: 3 overlapping plans with (12, 5, 5) contacts — returns (12, 5, 5), breaks tie on `lastEnrichedAt`
+8. Limit: 15 overlapping plans → returns top 10
+9. Owner name join: plan without an owner → `ownerName: null`
+
+---
+
+## Track F — Frontend
+
+### F1. `useContactSources(planId)` hook
+
+**File:** `src/features/plans/lib/queries.ts` (add near `usePlanContacts` at line 245)
+
+```ts
+export interface ContactSourcePlan {
+  id: string;
+  name: string;
+  ownerName: string | null;
+  sharedDistrictCount: number;
+  contactCount: number;
+  lastEnrichedAt: string | null;
+}
+
+export function useContactSources(planId: string | null) {
+  return useQuery({
+    queryKey: ["planContactSources", planId],
+    queryFn: () =>
+      fetchJson<{ plans: ContactSourcePlan[] }>(
+        `${API_BASE}/territory-plans/${planId}/contact-sources`
+      ),
+    enabled: !!planId,
+    staleTime: 2 * 60 * 1000,
+  });
+}
+```
+
+- Query key uses stable primitive (`planId` string) per CLAUDE.md perf rules.
+- `staleTime` matches `usePlanContacts` precedent.
+
+### F2. `ExistingContactsModal` component
+
+**File:** `src/features/plans/components/ExistingContactsModal.tsx`
+
+**Props:**
+```ts
+interface ExistingContactsModalProps {
+  planId: string;
+  variant: "queued-zero" | "partial";
+  districtCount: number;        // queued-zero: count of skipped districts; partial: count of skipped
+  newCount?: number;            // partial only: enriched count
+  onClose: () => void;
+}
+```
+
+**Structure:**
+- Backdrop `<div className="fixed inset-0 z-40 bg-black/40" onClick={onClose} />`
+- Modal `<div className="fixed inset-0 z-50 flex items-center justify-center">`
+  - Content: `bg-white rounded-2xl shadow-xl w-full max-w-2xl mx-4 max-h-[85vh] flex flex-col`
+- Header: title + `×` close button (follow `Documentation/UI Framework/Components/Containers/modal.md` → `_foundations.md`)
+  - Variant "queued-zero" title: `Contacts already exist`
+  - Variant "partial" title: `Enrichment complete`
+- Subline (below title, inside body):
+  - queued-zero: `Contacts for {districtCount} district{pluralize} in this plan are already in the system. They may not be showing on this tab yet.`
+  - partial: green-dot status line `Found {newCount} new contact{s} for {newCount} district{s}.` + `{districtCount} district{s} already had contacts.`
+- Body two-column grid: `grid grid-cols-1 md:grid-cols-2 gap-6 p-6`
+
+**Left column:**
+```tsx
+<div>
+  <h3 className="text-base font-semibold text-[#403770] mb-2">Show them here</h3>
+  <p className="text-sm text-[#6E6390] mb-4">
+    Refresh the Contacts tab to reveal existing contacts for this plan's districts.
+  </p>
+  <button
+    onClick={handleShowHere}
+    disabled={isRefreshing}
+    className="px-4 py-2 text-sm font-medium text-white bg-[#403770] rounded-lg hover:bg-[#322a5a] transition-colors disabled:opacity-50"
+  >
+    {isRefreshing ? "Refreshing…" : "Show them here"}
+  </button>
+</div>
+```
+
+`handleShowHere`:
+```ts
+const handleShowHere = async () => {
+  setIsRefreshing(true);
+  try {
+    await queryClient.invalidateQueries({ queryKey: ["planContacts", planId] });
+    onClose();
+    // Optional: scroll into view — stretch goal
+  } finally {
+    setIsRefreshing(false);
+  }
+};
+```
+
+**Right column:**
+- Consume `useContactSources(planId)`
+- States:
+  - Loading: render 3 skeleton rows (`animate-pulse bg-[#EFEDF5] h-14 rounded-lg`)
+  - Error: `<p className="text-sm text-[#F37167]">Couldn't load other plans. <button onClick={refetch} className="underline">Retry</button></p>`
+  - Empty: `<p className="text-sm text-[#6E6390]">No other plans contain these districts yet.</p>`
+  - Success: list of plan rows
+- Plan row (`<a href={/plans/${plan.id}}>` — no JS nav, use native `<a>` to preserve middle-click/new-tab):
+  ```tsx
+  <a
+    href={`/plans/${plan.id}`}
+    className="block p-3 rounded-lg hover:bg-[#F7F5FA] transition-colors border border-[#E2DEEC]"
+  >
+    <div className="flex items-center justify-between">
+      <span className="text-sm font-medium text-[#403770]">{plan.name}</span>
+      <span className="text-xs text-[#6E6390]">{plan.ownerName ?? "Unassigned"}</span>
+    </div>
+    <div className="mt-1 text-xs text-[#6E6390]">
+      {pluralize(plan.sharedDistrictCount, "district")} · {pluralize(plan.contactCount, "contact")}
+      {plan.lastEnrichedAt && ` · Last enriched ${relativeDate(plan.lastEnrichedAt)}`}
+    </div>
+  </a>
+  ```
+- Collapsed/expanded behavior:
+  - Default: show first 3 rows
+  - If `plans.length > 3`: show "See all {N}" toggle → reveals remaining rows inline
+  - State: `const [showAll, setShowAll] = useState(false)`
+
+**Helpers:**
+- `pluralize(n, word)` — local helper or check for existing in `src/features/shared/lib/format.ts`
+- `relativeDate(iso)` — check `src/features/shared/lib/format.ts`; use existing if available, else write inline
+
+**Keyboard & dismiss:**
+- `useEffect` Esc-to-close listener
+- Focus "Show them here" button on mount (`useEffect` + ref)
+- Focus trap: use existing pattern from codebase (check `src/features/plans/components/PlanFormModal.tsx` for reference). If no shared util, write a minimal trap inline
+
+**Icon:** Lucide `CheckCircle2` (green) for partial-variant status row; `X` for close button.
+
+### F3. Wire into `ContactsActionBar.tsx`
+
+**File:** `src/features/plans/components/ContactsActionBar.tsx`
+
+**Changes:**
+
+1. Add state at top of component:
+```ts
+const [modalState, setModalState] = useState<
+  { variant: "queued-zero" | "partial"; districtCount: number; newCount?: number } | null
+>(null);
+```
+
+2. In `handleStartEnrichment` (around line 130), replace:
+```ts
+if (result.queued === 0) {
+  setToast({ message: "Nothing to enrich — all targets already have contacts", type: "info" });
+  return;
+}
+```
+with:
+```ts
+if (result.queued === 0) {
+  setModalState({ variant: "queued-zero", districtCount: result.skipped });
+  return;
+}
+
+// Stash partial info so completion effect can trigger modal
+if (result.skipped > 0) {
+  pendingPartialRef.current = { newCount: result.queued, skippedCount: result.skipped };
+}
+```
+
+3. Add ref at component top: `const pendingPartialRef = useRef<{ newCount: number; skippedCount: number } | null>(null);`
+
+4. In the completion-detection effect (lines 88-97), after `setToast({ message: "Contact enrichment complete — ..." })`, add:
+```ts
+if (pendingPartialRef.current) {
+  setModalState({
+    variant: "partial",
+    districtCount: pendingPartialRef.current.skippedCount,
+    newCount: pendingPartialRef.current.newCount,
+  });
+  pendingPartialRef.current = null;
+}
+```
+
+5. At bottom of JSX, before closing wrapper, render the modal conditionally:
+```tsx
+{modalState && (
+  <ExistingContactsModal
+    planId={planId}
+    variant={modalState.variant}
+    districtCount={modalState.districtCount}
+    newCount={modalState.newCount}
+    onClose={() => setModalState(null)}
+  />
+)}
+```
+
+6. Import `ExistingContactsModal` at top of file.
+
+**Not touched:**
+- Find Contacts popover
+- Toast rendering
+- CSV export
+- Enrichment progress polling
+
+### F4. Modal tests
+
+**File:** `src/features/plans/components/__tests__/ExistingContactsModal.test.tsx`
+
+Cases:
+1. Renders `queued-zero` variant with correct title and subline
+2. Renders `partial` variant with status line + skipped message
+3. Renders 3 skeleton rows in loading state
+4. Renders empty state when `plans: []`
+5. Renders error state + retry button when hook errors
+6. Renders first 3 plan rows by default; "See all" toggles remaining
+7. "Show them here" button invalidates `["planContacts", planId]` and calls `onClose`
+8. Escape key calls `onClose`
+9. Backdrop click calls `onClose`
+10. Plan row is a native `<a href="/plans/...">` (preserves middle-click)
+
+Use MSW or direct hook mock for `useContactSources`. Reference `src/features/plans/components/__tests__/ContactsActionBar.test.tsx` for mock patterns.
+
+### F5. ActionBar test extension
+
+**File:** `src/features/plans/components/__tests__/ContactsActionBar.test.tsx`
+
+Add cases:
+1. `queued: 0, skipped: 1` response → modal opens in `queued-zero` variant, NOT the "Nothing to enrich" toast
+2. `queued: 2, skipped: 1` response → no modal on submit, but when `useEnrichProgress` reports completion, modal opens in `partial` variant
+3. `queued: 2, skipped: 0` response → no modal; behavior unchanged (existing tests)
+
+---
+
+## Cross-track integration
+
+After both tracks land:
+
+1. Run `npx vitest run` → all tests pass
+2. Run `npm run build` → type-checks, no errors
+3. Manual smoke (dev server): click Find Contacts on a plan whose districts all have contacts → modal appears with correct content and working actions
+
+## Commit strategy
+
+One commit per track logical unit:
+- `feat(api): GET /api/territory-plans/[id]/contact-sources` (B1 + B2)
+- `feat(plans): ExistingContactsModal replaces dead-end toast on Find Contacts` (F1 + F2 + F3)
+- `test(plans): coverage for ExistingContactsModal + ContactsActionBar modal triggers` (F4 + F5)
+
+All on the worktree branch, rebased if needed before merge.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| `profile` schema field names differ from assumption | B1 step 7: grep existing plan-list endpoint before committing to field name |
+| `usePlanContacts` queryKey drifts from `["planContacts", planId]` | F2 `handleShowHere` imports the exact key constant or reuses the hook's invalidation helper if one exists |
+| Focus trap implementation diverges from existing modals | F2: copy the pattern from `PlanFormModal.tsx` exactly; don't invent |
+| `/plans/{id}` route not the right URL for the workspace | F2: verify via `grep href.*plans/` — already confirmed via `PlanCard.tsx:78` |
+| Partial-completion trigger fires twice on re-render | F3: gate on `pendingPartialRef.current` being non-null; clear immediately after use |

--- a/Docs/superpowers/specs/2026-04-22-find-contacts-existing-options-backend-context.md
+++ b/Docs/superpowers/specs/2026-04-22-find-contacts-existing-options-backend-context.md
@@ -1,0 +1,406 @@
+# Find Contacts — Existing Options Modal (Backend Context)
+
+Feature: when "Find Contacts" returns `queued === 0` (or a partial-overlap response), replace
+the dismissive toast with a modal offering (a) jump to existing contacts in the current plan,
+or (b) navigate to another plan that already surfaces the relevant contacts.
+
+This is a reference doc for planning only — no implementation here.
+
+## 1. Relevant Prisma Models
+
+File: `/Users/astonfurious/The Laboratory/territory-plan/.claude/worktrees/find-contacts-existing-options/prisma/schema.prisma`
+
+### `TerritoryPlan` — lines 473–512
+
+```
+model TerritoryPlan {
+  id          String    @id @default(uuid())
+  name        String    @db.VarChar(255)
+  ownerId     String?   @map("owner_id") @db.Uuid
+  status      String    @default("planning") @db.VarChar(20)   // planning | working | stale | archived
+  fiscalYear  Int       @map("fiscal_year")
+  userId      String?   @map("user_id") @db.Uuid               // creator (distinct from ownerId)
+  createdAt   DateTime  @default(now()) @map("created_at")
+  updatedAt   DateTime  @updatedAt @map("updated_at")
+
+  // Bulk enrichment tracking (written by bulk-enrich route, cleared by enrich-progress)
+  enrichmentStartedAt  DateTime? @map("enrichment_started_at")
+  enrichmentQueued     Int?      @map("enrichment_queued")
+  enrichmentActivityId String?   @map("enrichment_activity_id") @db.Uuid
+
+  districts     TerritoryPlanDistrict[]
+  states        TerritoryPlanState[]
+  collaborators TerritoryPlanCollaborator[]
+  activityLinks ActivityPlan[]
+  ownerUser     UserProfile? @relation("PlanOwner", fields: [ownerId], references: [id])
+}
+```
+
+`enrichmentActivityId` is the UUID of the `Activity` row created at enrichment fire time
+(see bulk-enrich route lines 172–188 and 274–284). `enrichmentStartedAt` is used both for
+concurrency-guarding (10-minute timeout, line 7 of the bulk-enrich route) and as an implicit
+"plan was last enriched at X" signal. There is no explicit `lastEnrichedAt` column on the plan.
+
+### `TerritoryPlanDistrict` — lines 514–533 (the join)
+
+```
+model TerritoryPlanDistrict {
+  planId        String   @map("plan_id")
+  districtLeaid String   @map("district_leaid") @db.VarChar(7)
+  addedAt       DateTime @default(now()) @map("added_at")
+  // Relations
+  plan     TerritoryPlan @relation(fields: [planId], references: [id], onDelete: Cascade)
+  district District      @relation(fields: [districtLeaid], references: [leaid])
+
+  @@id([planId, districtLeaid])
+}
+```
+
+Composite PK on `(planId, districtLeaid)`. This is the table we query to find "other plans
+sharing a leaid with the current plan." No index on `districtLeaid` alone is declared — the PK
+covers `(planId, districtLeaid)`, and Prisma's `@@id` generates a btree usable for `planId` lookups.
+A raw lookup by `districtLeaid` alone will scan; we may need an additional index if the query
+is slow at scale. Flag for reviewer.
+
+### `Contact` — lines 337–359 (leaid-keyed, NOT plan-scoped)
+
+```
+model Contact {
+  id             Int       @id @default(autoincrement())
+  leaid          String    @db.VarChar(7)
+  name           String    @db.VarChar(255)
+  title          String?   @db.VarChar(255)
+  email          String?   @db.VarChar(255)
+  createdAt      DateTime  @default(now()) @map("created_at")
+  lastEnrichedAt DateTime? @map("last_enriched_at")
+  district       District        @relation(fields: [leaid], references: [leaid])
+  schoolContacts SchoolContact[]
+  @@index([leaid])
+}
+```
+
+Contacts live at the district (`leaid`) level, not on plans. Any plan that contains that leaid
+can see the contact via the `/contacts` GET route. This is the key fact enabling the feature:
+if Plan A already enriched leaid `3600150` and Plan B contains `3600150`, Plan B already
+sees those contacts and doesn't need to re-enrich.
+
+### `SchoolContact` — lines 1104–1112 (Principal link)
+
+```
+model SchoolContact {
+  schoolId  String  @map("school_id") @db.VarChar(12)   // ncessch
+  contactId Int     @map("contact_id")
+  school    School  @relation(fields: [schoolId], references: [ncessch], onDelete: Cascade)
+  contact   Contact @relation(fields: [contactId], references: [id], onDelete: Cascade)
+  @@id([schoolId, contactId])
+}
+```
+
+Principals are stored as a `Contact` row (with `title` containing "principal") linked to a
+`School` via `SchoolContact`. The Principal enrichment skip-check (bulk-enrich lines 143–150)
+uses this join + a case-insensitive title match.
+
+### `Activity` — lines 561–625 (contact_enrichment records)
+
+```
+model Activity {
+  id              String   @id @default(uuid())
+  type            String   @db.VarChar(30)              // "contact_enrichment" for our case
+  title           String   @db.VarChar(255)
+  status          String   @default("planned")          // planned | in_progress | completed | cancelled
+  createdByUserId String?  @map("created_by_user_id") @db.Uuid
+  createdAt       DateTime @default(now()) @map("created_at")
+  source          String   @default("manual")           // bulk-enrich sets "system"
+  metadata        Json?                                  // { targetRole, schoolLevels?, queued, skipped, ... }
+  plans           ActivityPlan[]
+}
+```
+
+### `ActivityPlan` — lines 627–636 (the plan join, NOT `PlanActivity`)
+
+```
+model ActivityPlan {
+  activityId String        @map("activity_id")
+  planId     String        @map("plan_id")
+  activity   Activity      @relation(...)
+  plan       TerritoryPlan @relation(...)
+  @@id([activityId, planId])
+  @@index([planId])
+}
+```
+
+There is **no** `PlanActivity` model — the join is `ActivityPlan`.
+
+### `School` (partial) — lines 1011–1079
+
+Relevant fields for Principal mode: `ncessch` (PK), `leaid`, `schoolName`, `schoolLevel`
+(1=Primary, 2=Middle, 3=High, 4=Other), `schoolType`, `schoolStatus` (1=Open), plus address
+fields passed to Clay.
+
+### Contact → plan lineage — how traceable is it?
+
+**There is no direct foreign key from `Contact` to a `TerritoryPlan`.** Lineage is indirect,
+and there are three possible paths to say "this contact was enriched under plan X":
+
+1. **Via `Activity.plans` + timing:** the Activity of type `contact_enrichment` is created
+   with `plans: { create: { planId: id } }` (bulk-enrich lines 186, 282), so you can find
+   enrichment Activities per plan. But the Activity itself does not carry the list of
+   contacts it produced — you'd have to correlate `Contact.createdAt` or
+   `Contact.lastEnrichedAt` with `Activity.createdAt` / the plan's `enrichmentStartedAt`
+   window, which is fuzzy across concurrent runs.
+2. **Via `ActivityContact`:** the schema has an `ActivityContact` join (schema lines 654–662),
+   but the Clay webhook (`/api/webhooks/clay/route.ts` lines 166–294) does not populate it
+   for bulk-enrich — it only writes `Contact` rows and (if `ncessch` is present)
+   `SchoolContact` rows. So `ActivityContact` is not a reliable source of plan lineage for
+   contacts produced by bulk-enrich.
+3. **Via `leaid` overlap** (the pragmatic route used here): any plan whose
+   `TerritoryPlanDistrict` row shares a `districtLeaid` with the current plan, and whose
+   shared districts have at least one `Contact`, is a plausible "contact source" — regardless
+   of which plan originally triggered the enrichment. **This is the proposed query shape
+   below** and the only one that works robustly.
+
+## 2. Existing API Routes
+
+### 2a. `src/app/api/territory-plans/[id]/contacts/bulk-enrich/route.ts`
+
+POST handler. Auth via `getUser()` at line 23. Loads the plan + its district leaids
+(lines 54–57). Two branches keyed on `targetRole === "Principal"`:
+
+**Non-Principal (district-level) branch — lines 246–332:**
+- Groups `Contact` by `leaid` for the plan's leaids (`contact.groupBy`, lines 246–249).
+- `enrichedLeaids` = set of leaids that already have any contact.
+- `leaidsToEnrich` = plan leaids minus enriched.
+- `total = allLeaids.length`, `skipped = enrichedLeaids.size`, `queued = leaidsToEnrich.length`.
+- If `queued === 0`, returns `{ total, skipped, queued: 0 }` immediately (line 257–259) —
+  **this is the response shape that triggers our new modal.**
+- Otherwise: creates `Activity` (type `contact_enrichment`, `plans: { create: { planId: id } }`),
+  updates the plan's `enrichmentStartedAt/Queued/ActivityId`, and fires Clay webhooks in
+  batches of 10 with a 1s pause between batches.
+
+**Principal branch — lines 116–241:**
+- Loads open schools at requested `schoolLevels` across the plan's leaids (lines 117–135).
+- "Already enriched" heuristic: schools with any `SchoolContact` whose Contact has a title
+  matching `/principal/i` (lines 143–150). Noted in a code comment as possibly needing to
+  widen to "any SchoolContact" if production match rate is poor.
+- `total = schools.length`, `skipped = alreadyPrincipalSet.size`, `queued = toEnrich.length`.
+- Same `queued === 0` early return (lines 157–159) and same Activity/plan-update/webhook
+  pattern afterward.
+
+Response shape (both branches): `{ total: number, skipped: number, queued: number }`.
+
+Concurrency guard (lines 80–111): if there's already an active enrichment
+(`enrichmentStartedAt` within 10 minutes AND `enrichmentQueued` non-null), the route may
+return 409 with `{ error, enriched, queued }`. Principal mode refuses outright; district
+mode compares `contact.groupBy` count against `enrichmentQueued` to decide.
+
+### 2b. `src/app/api/territory-plans/[id]/contacts/route.ts`
+
+GET only. Auth via `getUser()` (line 14). Loads plan + `districts: { select: { districtLeaid } }`.
+Fetches all `Contact` rows where `leaid IN (...)`, ordered by `isPrimary DESC, name ASC`,
+including `schoolContacts.school` for Principal linkage.
+
+Email dedup (lines 74–81): builds a `Set<string>` of lower-cased emails as it iterates;
+the first contact per email wins. Contacts with no email are always kept. Because ordering
+is `isPrimary: "desc"` first, primary contacts win the dedup tie.
+
+Returned shape per contact is flattened (id, leaid, salutation, name, title, email, phone,
+isPrimary, linkedinUrl, persona, seniorityLevel, createdAt, lastEnrichedAt, schoolContacts).
+
+**Key for our feature:** this endpoint already exposes all contacts for the plan's districts,
+regardless of which plan originally triggered the enrichment. The "Show them here" modal
+action just needs to `refetch()` this endpoint and/or scroll to it — no new backend work.
+
+### 2c. `src/app/api/territory-plans/[id]/contacts/enrich-progress/route.ts`
+
+GET only. Poll endpoint used by `ContactsActionBar` while an enrichment is in flight.
+Branches on the active Activity's `metadata.targetRole`:
+
+- Principal: counts `SchoolContact` rows where contact.title matches `/principal/i` across
+  the plan's leaids; subtracts the `skipped` recorded at fire time; returns `enriched`.
+- Non-Principal: `contact.groupBy` by `leaid`; subtracts `skipped`; returns `enriched`.
+
+Response: `{ total, enriched, queued }`. Also completes the Activity and clears
+`enrichmentStartedAt/Queued/ActivityId` when `enriched >= queued` or after a 10-minute stall
+(lines 89–115).
+
+### 2d. `src/app/api/webhooks/clay/route.ts`
+
+Supports both GET and POST. Receives enriched contact payloads from Clay and upserts
+`Contact` rows (by `{ leaid, email }`, or `{ leaid, name }` when email is absent). If the
+payload includes a root-level `ncessch` (Principal mode), it also upserts a `SchoolContact`
+join row for each processed contact (lines 286–295).
+
+Note for audit trail: this route **does not write to `ActivityContact`**, so there is no
+direct link from the enrichment Activity to the specific contacts it created. Lineage is
+recoverable only fuzzily via `Contact.createdAt` vs. `Activity.createdAt`.
+
+### 2e. `src/app/api/territory-plans/route.ts`
+
+GET lists plans. Auth via `getUser()`. The comment on line 17 is explicit: *"Show all plans —
+the team shares visibility across plans"* — `whereClause = {}` (line 18). Every authenticated
+user sees every plan. This is important precedent for how we scope the new endpoint.
+
+Each plan in the response already includes `districtLeaids: string[]` (line 101), which means
+a naive client-side solution could fetch `/api/territory-plans` and intersect leaids locally —
+but that pulls every plan and every district for every user. Server-side filtering is better.
+
+## 3. Proposed Endpoint: `GET /api/territory-plans/[id]/contact-sources`
+
+Returns a ranked list of other plans that share at least one leaid with the current plan
+AND have existing contacts on at least one of those shared leaids.
+
+### Auth scoping
+
+Mirror the existing plan-list endpoint (`whereClause = {}`) — team-visible. Precedent:
+`src/app/api/territory-plans/route.ts` line 17 comment, and `src/app/api/territory-plans/[id]/contacts/route.ts`
+line 20 comment: *"Team shares visibility across plans (matches list endpoint)."* The modal
+needs to surface useful alternatives for the rep; hiding teammates' plans would defeat the
+purpose. (Flagged in open questions below — confirm with reviewer.)
+
+### Query shape (Prisma sketch)
+
+Pseudocode, not actual code to commit:
+
+```
+// 1. Load current plan's leaids
+const current = await prisma.territoryPlan.findUnique({
+  where: { id },
+  include: { districts: { select: { districtLeaid: true } } },
+});
+const currentLeaids = current.districts.map(d => d.districtLeaid);
+
+// 2. Find other plans that share ANY of those leaids
+//    (exclude self; optionally exclude archived status)
+const candidates = await prisma.territoryPlan.findMany({
+  where: {
+    id: { not: id },
+    status: { not: "archived" },
+    districts: { some: { districtLeaid: { in: currentLeaids } } },
+  },
+  select: {
+    id: true,
+    name: true,
+    status: true,
+    enrichmentStartedAt: true,
+    updatedAt: true,
+    ownerUser: { select: { id: true, fullName: true, avatarUrl: true } },
+    districts: {
+      where: { districtLeaid: { in: currentLeaids } },
+      select: { districtLeaid: true },
+    },
+  },
+});
+
+// 3. For each candidate, pull contact counts scoped to the shared leaids.
+//    contact.groupBy by leaid with leaid IN (sharedLeaids) gives one row per leaid
+//    that has >=1 contact. Summing _count gives total contact count for those leaids.
+//    Do this once globally (not per-plan) — contacts are leaid-keyed, not plan-keyed,
+//    so plans sharing the same leaid see the same contact count.
+const sharedLeaidSet = new Set(candidates.flatMap(c => c.districts.map(d => d.districtLeaid)));
+const contactCounts = await prisma.contact.groupBy({
+  by: ["leaid"],
+  where: { leaid: { in: Array.from(sharedLeaidSet) } },
+  _count: { _all: true },
+});
+const contactCountByLeaid = new Map(contactCounts.map(r => [r.leaid, r._count._all]));
+
+// 4. Rank candidates by (contactCount across shared leaids DESC, sharedDistrictCount DESC),
+//    then take top 10. Only include candidates with contactCount > 0.
+```
+
+### Response row shape
+
+```
+{
+  planId: string,
+  planName: string,
+  owner: { id, fullName, avatarUrl } | null,
+  status: "planning" | "working" | "stale",     // archived filtered out
+  sharedDistrictCount: number,
+  contactCount: number,                          // sum of contacts across shared leaids
+  lastEnrichedAt: string | null,                 // plan.enrichmentStartedAt ISO, best-effort proxy
+  sharedLeaidSample: string[]                    // optional: first 3 for UI tooltip
+}
+```
+
+Ranking: `contactCount DESC, sharedDistrictCount DESC, updatedAt DESC`. Limit 10.
+
+### Edge cases
+
+- Current plan's own leaids may have contacts that came from no plan at all (imported via a
+  non-bulk-enrich pathway). These are still valid "Show them here" fodder and are already
+  served by route 2b — no new query needed for that action.
+- If every candidate has `contactCount === 0`, the "Open another plan" list is empty and the
+  modal should gracefully degrade to showing only the "Show them here" action (or explain
+  that no other plans have contacts yet).
+- Principal mode wrinkle: a candidate plan may "have contacts" on a shared leaid in the
+  district-superintendent sense but not in the Principal sense. If the triggering action
+  was Principal-mode enrichment, should the ranking only count SchoolContact rows whose
+  title matches `/principal/i`, or any Contact? Flag for reviewer.
+
+## 4. Auth Pattern
+
+`getUser()` is imported from `@/lib/supabase/server` (file:
+`/Users/astonfurious/The Laboratory/territory-plan/.claude/worktrees/find-contacts-existing-options/src/lib/supabase/server.ts`
+lines 55–87). It returns the authenticated Supabase user, respecting admin impersonation via
+the `impersonate_uid` cookie (an admin can masquerade as another user).
+
+Every relevant route uses the same shape:
+
+```
+const user = await getUser();
+if (!user) {
+  return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+}
+```
+
+See bulk-enrich route line 23–27, contacts GET line 14–18, plans list line 11–14. The new
+endpoint should follow this pattern verbatim.
+
+## 5. Test Conventions
+
+- Vitest + jsdom. Tests co-located in `__tests__/` folder next to the route, file name
+  `route.test.ts`.
+- Concrete recent example:
+  `/Users/astonfurious/The Laboratory/territory-plan/.claude/worktrees/find-contacts-existing-options/src/app/api/territory-plans/[id]/contacts/bulk-enrich/__tests__/route.test.ts`
+  (see especially lines 1–65 for the setup pattern).
+- Standard mocks: `@/lib/supabase/server` → `getUser` returns `{ id: "user-1" }`; `@/lib/prisma`
+  → default export is an object with each model's methods mocked via `vi.fn()`.
+- `fetch` is stubbed globally with `vi.stubGlobal("fetch", mockFetch)` when the route fires
+  outbound webhooks.
+- Request factory: `new NextRequest("http://localhost/...", { method: "POST", body: ... })`.
+- Route params are passed as `{ params: Promise.resolve({ id: "plan-1" }) }` (Next.js 16 App
+  Router signature — they must be a Promise).
+- Also relevant: `src/app/api/territory-plans/__tests__/route.test.ts` lines 1–60 for how a
+  GET list endpoint with `territoryPlan.findMany` is mocked, including the `$transaction`
+  pattern if the new endpoint batches queries.
+
+For the new endpoint, expected test cases:
+- Returns 401 without a user.
+- Returns 404 when the plan id doesn't exist.
+- Returns `[]` when no other plan shares any leaid.
+- Returns `[]` when shared plans exist but no shared leaid has contacts.
+- Ranks candidates correctly (contactCount desc, then sharedDistrictCount desc).
+- Excludes the current plan from its own candidates.
+- Excludes archived plans.
+
+## 6. Open Questions / Ambiguities (for reviewer)
+
+1. **Auth scoping — team vs. self?** The existing list and contacts endpoints explicitly
+   show team-wide visibility. Should `/contact-sources` also be team-wide, or restricted to
+   plans where the user is owner / creator / collaborator? Team-wide matches precedent and
+   is probably right, but worth confirming because "open another plan" may feel invasive if
+   it surfaces teammates' WIP plans the user wouldn't otherwise see.
+2. **Archived plans — include or exclude?** The sketch above excludes `status === "archived"`.
+   Is that correct, or could an archived plan still be a legitimate source of existing
+   contact intel?
+3. **Principal vs. district filtering.** When the user triggered Find Contacts in Principal
+   mode and got `queued === 0`, should the "other plans" ranking weight schools-with-principal-
+   SchoolContact only, or count any Contact on the shared leaids? The answer affects both the
+   query and the modal's copy.
+4. **Partial-overlap variant timing.** The request mentions a similar modal after a partial
+   enrichment completes (`skipped > 0 && queued > 0`). That fires on the poll-loop completion
+   event in `ContactsActionBar`, not on the initial POST response. Should
+   `/contact-sources` be called at completion time, or pre-fetched at submit time and cached
+   client-side until completion? Pre-fetch is simpler but risks staleness if another user
+   triggers enrichment on an overlapping plan in the intervening minutes. Flag for planning.

--- a/Docs/superpowers/specs/2026-04-22-find-contacts-existing-options-spec.md
+++ b/Docs/superpowers/specs/2026-04-22-find-contacts-existing-options-spec.md
@@ -1,0 +1,186 @@
+# Feature Spec: Existing-Contacts Options Modal (Find Contacts)
+
+**Date:** 2026-04-22
+**Slug:** find-contacts-existing-options
+**Branch:** worktree-find-contacts-existing-options
+**Trigger screenshot:** plan had NYC DOE; "Find Contacts" returned queued=0; UI dead-ended with a toast while contacts actually existed in the DB.
+
+## Problem
+
+When a user clicks **Find Contacts** on a territory plan and all target districts already have contacts in the `contacts` table, the bulk-enrich endpoint returns `{ queued: 0 }` and the UI shows a dismissive info toast: *"Nothing to enrich — all targets already have contacts."* The user is left with no path forward — they don't know where those contacts are, why this plan's Contacts tab may show zero, or how to reach the enriched data.
+
+The same dead-end occurs in the **partial case**: when some districts are enriched on this run and others are skipped because they already had contacts, the user gets a generic "N found" toast with no acknowledgment of the pre-existing data.
+
+## Requirements
+
+- Replace the dismissive toast with a **modal** that gives the user two concrete paths forward.
+- Two actions, side-by-side, presented together so the user can choose without navigation:
+  1. **Show them here** — refresh the Contacts tab so existing contacts become visible on the current plan.
+  2. **Open another plan** — pick from a list of other plans that share districts with this one and already have contacts on those districts.
+- Handle partial overlap: when enrichment completes and some districts were skipped because they already had contacts, surface the same modal (with a completion-variant header) after the success toast.
+- No data-model changes. Contacts remain leaid-keyed; "pull in" means refresh the current plan's query, not create new associations.
+- Other-plans list is discovered via **district overlap** (not contact→plan lineage), since `Contact` has no direct `planId` linkage. Team-wide visibility, ranked by contact count then recency, capped at 10.
+
+## Visual Design
+
+**Chosen direction:** Split-action modal (Direction A from Stage 2).
+
+### Container
+- `max-w-2xl`, `rounded-2xl shadow-xl`, `bg-white`
+- Backdrop: `bg-black/40`, click-to-dismiss
+- Keyboard: `Esc` closes; `Tab` cycles inside; focus trap on open
+- On open: focus the "Show them here" primary button
+- Per `Documentation/UI Framework/Components/Containers/modal.md`
+
+### Header
+- Variant A title: **"Contacts already exist"**
+- Variant B title: **"Enrichment complete"**
+- Close `×` button (per `_foundations.md`)
+
+### Variant A — queued=0 (dead-end replacement)
+- Subline: *"Contacts for {N} district{s} in this plan are already in the system. They may not be showing on this tab yet."*
+
+### Variant B — partial completion (post-enrichment)
+- Status row (green check): *"Found {queued} new contact{s} for {newCount} district{s}."*
+- Subline: *"{skippedCount} district{s} already had contacts."*
+
+### Body — two columns (stacks vertically below `md:`)
+
+**Left column — "Show them here"**
+- h3: "Show them here"
+- Description: "Refresh the Contacts tab to reveal existing contacts for this plan's districts."
+- Primary button: "Show them here" (`bg-[#403770] text-white rounded-lg px-4 py-2 text-sm font-medium`)
+- Loading state: button spinner while refetch is pending
+- Action: invalidate the plan-contacts query for `planId`, then close modal, then scroll first populated district group into view
+
+**Right column — "Open another plan"**
+- h3: "Open another plan"
+- Description: "These plans share districts and already have contacts."
+- Plan rows (up to 3 visible by default), each clickable → navigates to that plan
+- Row content: plan name · owner display name · `{sharedDistrictCount} district{s} · {contactCount} contacts · Last enriched {relativeDate}`
+- Hover: `bg-[#F7F5FA]`, cursor pointer
+- "See all {N}" link shown if `plans.length > 3`; expands list inline (no new view)
+- Loading state: 3 skeleton rows while `useContactSources` fetches
+- Empty state: "No other plans contain these districts yet." — column becomes informational only
+- Error state: "Couldn't load other plans. [Retry]" (retries the query)
+
+## Component Plan
+
+### New components
+- `src/features/plans/components/ExistingContactsModal.tsx`
+  - Props: `{ planId: string; planName: string; variant: "queued-zero" | "partial"; districtCount: number; newCount?: number; skippedCount?: number; onClose: () => void }`
+  - Follows modal doc: `rounded-2xl`, `bg-black/40`, close button in header
+  - Renders both columns; internally consumes `useContactSources(planId)`
+
+### Existing components to reuse
+- Modal structure pattern from `Documentation/UI Framework/Components/Containers/modal.md`
+- Existing modal references (note: existing modals use `rounded-xl`; new work uses canonical `rounded-2xl`):
+  - `src/features/plans/components/PlanFormModal.tsx`
+  - `src/features/activities/components/ActivityFormModal.tsx`
+- Button patterns from `Documentation/UI Framework/Components/Navigation/buttons.md`
+- Relative-date formatting from `src/features/shared/lib/format.ts`
+
+### Components to modify
+- `src/features/plans/components/ContactsActionBar.tsx`
+  - Replace line 131 `setToast({ message: "Nothing to enrich — all targets already have contacts", ... })` with modal-open
+  - Add state: `const [existingContactsModal, setExistingContactsModal] = useState<ModalState | null>(null)`
+  - In the completion-detection effect (currently lines 88-109), when `progress.enriched >= progress.queued` AND the response had `skipped > 0`, open the modal in `"partial"` variant after the success toast fires
+
+## Backend Design
+
+See: `docs/superpowers/specs/2026-04-22-find-contacts-existing-options-backend-context.md`
+
+### New API route
+`GET /api/territory-plans/[id]/contact-sources`
+
+**File:** `src/app/api/territory-plans/[id]/contact-sources/route.ts`
+
+**Behavior:**
+1. `getUser()` — return 401 if unauthenticated
+2. Fetch current plan's district leaids (via `TerritoryPlan.districts`)
+3. If 0 districts → return `{ plans: [] }`
+4. Query other plans (≠ current plan) where at least one district leaid overlaps AND at least one contact exists for a shared leaid
+5. For each candidate plan, compute:
+   - `sharedDistrictCount` — count of leaids in plan ∩ current plan's leaids
+   - `contactCount` — distinct `Contact.id` count across shared leaids
+   - `lastEnrichedAt` — max of `Contact.lastEnrichedAt` across shared leaids (nullable)
+6. Rank by `contactCount DESC, lastEnrichedAt DESC NULLS LAST`
+7. Limit to top 10
+8. Include `ownerName` via `profile` join on `TerritoryPlan.ownerId`
+
+**Response shape:**
+```ts
+{
+  plans: Array<{
+    id: string;
+    name: string;
+    ownerName: string | null;
+    sharedDistrictCount: number;
+    contactCount: number;
+    lastEnrichedAt: string | null; // ISO
+  }>
+}
+```
+
+**Auth scope:** team-wide (mirrors `/api/territory-plans` list endpoint precedent — both plan list and `/contacts` GET use empty `whereClause` with "team shares visibility across plans" comment).
+
+### New TanStack hook
+`useContactSources(planId)` in `src/features/plans/lib/queries.ts`
+
+- Query key: `['plan-contact-sources', planId]` (stable primitive — per CLAUDE.md performance rules)
+- Enabled when `planId` is truthy
+- Standard fetcher, no polling
+
+### Query-cache invalidation
+`"Show them here"` handler calls:
+```ts
+queryClient.invalidateQueries({ queryKey: ['plan-contacts', planId] });
+```
+(Confirm exact key in impl — check `usePlanContacts` definition in `src/lib/api.ts` or `src/features/plans/lib/queries.ts`.)
+
+## States
+
+| State | Element | Approach |
+|---|---|---|
+| Loading | Right column | 3 skeleton rows |
+| Loading | "Show them here" button | Inline spinner, button disabled |
+| Empty | Right column | "No other plans contain these districts yet." |
+| Error | Right column | "Couldn't load other plans. [Retry]" |
+| Keyboard dismiss | Modal | Esc key closes |
+| Backdrop dismiss | Modal | Click-outside closes |
+| Responsive | Body | Two columns on `md:` and above; stacked single column below |
+
+## Trigger Logic Summary
+
+```
+onSubmit bulkEnrich -> response { total, skipped, queued }
+
+if queued === 0:
+  open modal (variant: "queued-zero", districtCount: skipped)
+
+elif queued > 0 && skipped > 0:
+  setIsEnriching(true)
+  show existing "Looking for N contacts" toast (unchanged)
+  ... on completion (progress.enriched >= progress.queued):
+    show success toast (unchanged)
+    open modal (variant: "partial", newCount: queued, skippedCount: skipped)
+
+elif queued > 0 && skipped === 0:
+  existing flow unchanged (no modal)
+```
+
+## Test Strategy
+
+- **Modal component:** `src/features/plans/components/__tests__/ExistingContactsModal.test.tsx` — both variants, loading / empty / error states, keyboard + backdrop dismiss, button actions
+- **API route:** `src/app/api/territory-plans/[id]/contact-sources/__tests__/route.test.ts` — auth 401, empty districts, no overlap, ranking, limit 10, ownerName join
+- **Integration:** extend `src/features/plans/components/__tests__/ContactsActionBar.test.tsx` — modal opens on queued=0, opens on partial completion, does not open on queued>0 skipped=0
+- **Vitest + Testing Library + jsdom** per CLAUDE.md testing conventions
+
+## Out of Scope
+
+- Root-cause investigation of why the plan's Contacts tab showed 0 in the screenshot despite contacts existing in DB. `"Show them here"` sidesteps it via query invalidation; the actual rendering bug (if any) is a separate follow-up.
+- Any change to how contacts are stored or associated (no new join tables, no copying).
+- Re-enriching districts that already have contacts.
+- Role-specific messaging (copy is role-agnostic). Principal-vs-Superintendent nuance is handled silently — the modal just says "contacts already exist."
+- Changes to `Find Contacts` popover (role picker, school-level filters) itself.
+- Activity-feed integration for "user opened another plan from the modal" — no audit trail change.

--- a/Documentation/.md Files/TECHSTACK.md
+++ b/Documentation/.md Files/TECHSTACK.md
@@ -142,6 +142,10 @@ Used for:
 
 /api/territory-plans        — Plan CRUD
 /api/territory-plans/[id]/districts — Manage districts in plans
+/api/territory-plans/[id]/contacts  — Contacts on a plan (via district leaid)
+/api/territory-plans/[id]/contacts/bulk-enrich — Trigger Clay enrichment
+/api/territory-plans/[id]/contacts/enrich-progress — Poll enrichment state
+/api/territory-plans/[id]/contact-sources — Other plans sharing districts with existing contacts
 
 /api/tiles/[z]/[x]/[y]      — Vector tile server
 /api/metrics/quantiles      — Choropleth breakpoints

--- a/src/app/api/territory-plans/[id]/contact-sources/__tests__/route.test.ts
+++ b/src/app/api/territory-plans/[id]/contact-sources/__tests__/route.test.ts
@@ -1,0 +1,304 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/supabase/server", () => ({
+  getUser: vi.fn().mockResolvedValue({ id: "user-1" }),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    territoryPlan: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+    },
+    contact: {
+      groupBy: vi.fn(),
+    },
+  },
+}));
+
+import prisma from "@/lib/prisma";
+import { getUser } from "@/lib/supabase/server";
+import { GET } from "../route";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockPrisma = vi.mocked(prisma) as any;
+const mockGetUser = vi.mocked(getUser);
+
+function buildRequest(id: string) {
+  return new NextRequest(
+    `http://localhost/api/territory-plans/${id}/contact-sources`,
+    { method: "GET" }
+  );
+}
+
+function call(id: string) {
+  return GET(buildRequest(id), { params: Promise.resolve({ id }) });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetUser.mockResolvedValue({ id: "user-1" } as Awaited<
+    ReturnType<typeof getUser>
+  >);
+});
+
+describe("GET /api/territory-plans/[id]/contact-sources", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValueOnce(null);
+
+    const res = await call("plan-1");
+    const data = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(data).toEqual({ error: "Authentication required" });
+  });
+
+  it("returns 404 when the plan is not found", async () => {
+    mockPrisma.territoryPlan.findUnique.mockResolvedValue(null);
+
+    const res = await call("missing-plan");
+
+    expect(res.status).toBe(404);
+    const data = await res.json();
+    expect(data).toEqual({ error: "Territory plan not found" });
+  });
+
+  it("returns { plans: [] } when the current plan has no districts", async () => {
+    mockPrisma.territoryPlan.findUnique.mockResolvedValue({
+      id: "plan-1",
+      districts: [],
+    });
+
+    const res = await call("plan-1");
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data).toEqual({ plans: [] });
+    // Should short-circuit before querying candidates or contacts
+    expect(mockPrisma.territoryPlan.findMany).not.toHaveBeenCalled();
+    expect(mockPrisma.contact.groupBy).not.toHaveBeenCalled();
+  });
+
+  it("returns { plans: [] } when no other plan shares any district", async () => {
+    mockPrisma.territoryPlan.findUnique.mockResolvedValue({
+      id: "plan-1",
+      districts: [{ districtLeaid: "0100001" }],
+    });
+    mockPrisma.territoryPlan.findMany.mockResolvedValue([]);
+
+    const res = await call("plan-1");
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data).toEqual({ plans: [] });
+    // groupBy should be skipped when no candidates exist
+    expect(mockPrisma.contact.groupBy).not.toHaveBeenCalled();
+  });
+
+  it("returns { plans: [] } when overlapping plans exist but no shared district has contacts", async () => {
+    mockPrisma.territoryPlan.findUnique.mockResolvedValue({
+      id: "plan-1",
+      districts: [{ districtLeaid: "0100001" }],
+    });
+    mockPrisma.territoryPlan.findMany.mockResolvedValue([
+      {
+        id: "plan-2",
+        name: "Other Plan",
+        ownerUser: { id: "user-2", fullName: "Rep Two" },
+        districts: [{ districtLeaid: "0100001" }],
+      },
+    ]);
+    mockPrisma.contact.groupBy.mockResolvedValue([]); // no contacts on that leaid
+
+    const res = await call("plan-1");
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data).toEqual({ plans: [] });
+  });
+
+  it("returns the correctly-shaped row on the single-overlap happy path", async () => {
+    mockPrisma.territoryPlan.findUnique.mockResolvedValue({
+      id: "plan-1",
+      districts: [
+        { districtLeaid: "0100001" },
+        { districtLeaid: "0100002" },
+      ],
+    });
+    mockPrisma.territoryPlan.findMany.mockResolvedValue([
+      {
+        id: "plan-2",
+        name: "Alpha Plan",
+        ownerUser: { id: "user-2", fullName: "Rep Two" },
+        districts: [{ districtLeaid: "0100001" }],
+      },
+    ]);
+    const lastEnriched = new Date("2026-04-01T12:00:00.000Z");
+    mockPrisma.contact.groupBy.mockResolvedValue([
+      {
+        leaid: "0100001",
+        _count: { _all: 5 },
+        _max: { lastEnrichedAt: lastEnriched },
+      },
+    ]);
+
+    const res = await call("plan-1");
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data).toEqual({
+      plans: [
+        {
+          id: "plan-2",
+          name: "Alpha Plan",
+          ownerName: "Rep Two",
+          sharedDistrictCount: 1,
+          contactCount: 5,
+          lastEnrichedAt: "2026-04-01T12:00:00.000Z",
+        },
+      ],
+    });
+    // Excludes self + scopes to current plan's leaids
+    expect(mockPrisma.territoryPlan.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: { not: "plan-1" },
+          districts: {
+            some: { districtLeaid: { in: ["0100001", "0100002"] } },
+          },
+        }),
+      })
+    );
+  });
+
+  it("ranks by contactCount DESC, then lastEnrichedAt DESC NULLS LAST", async () => {
+    mockPrisma.territoryPlan.findUnique.mockResolvedValue({
+      id: "plan-1",
+      districts: [
+        { districtLeaid: "L1" },
+        { districtLeaid: "L2" },
+        { districtLeaid: "L3" },
+      ],
+    });
+    // Candidate A: 12 contacts (L1)
+    // Candidate B: 5 contacts (L2), enriched more recently → should come before C
+    // Candidate C: 5 contacts (L3), enriched earlier
+    mockPrisma.territoryPlan.findMany.mockResolvedValue([
+      {
+        id: "plan-c",
+        name: "Plan C",
+        ownerUser: null,
+        districts: [{ districtLeaid: "L3" }],
+      },
+      {
+        id: "plan-a",
+        name: "Plan A",
+        ownerUser: null,
+        districts: [{ districtLeaid: "L1" }],
+      },
+      {
+        id: "plan-b",
+        name: "Plan B",
+        ownerUser: null,
+        districts: [{ districtLeaid: "L2" }],
+      },
+    ]);
+    mockPrisma.contact.groupBy.mockResolvedValue([
+      {
+        leaid: "L1",
+        _count: { _all: 12 },
+        _max: { lastEnrichedAt: new Date("2026-01-01T00:00:00.000Z") },
+      },
+      {
+        leaid: "L2",
+        _count: { _all: 5 },
+        _max: { lastEnrichedAt: new Date("2026-04-10T00:00:00.000Z") },
+      },
+      {
+        leaid: "L3",
+        _count: { _all: 5 },
+        _max: { lastEnrichedAt: new Date("2026-02-01T00:00:00.000Z") },
+      },
+    ]);
+
+    const res = await call("plan-1");
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.plans.map((p: { id: string }) => p.id)).toEqual([
+      "plan-a",
+      "plan-b",
+      "plan-c",
+    ]);
+    expect(data.plans.map((p: { contactCount: number }) => p.contactCount)).toEqual(
+      [12, 5, 5]
+    );
+  });
+
+  it("caps the response at 10 rows even when more candidates qualify", async () => {
+    mockPrisma.territoryPlan.findUnique.mockResolvedValue({
+      id: "plan-1",
+      districts: [{ districtLeaid: "L1" }],
+    });
+
+    const candidates = Array.from({ length: 15 }, (_, i) => ({
+      id: `plan-${i + 2}`,
+      name: `Plan ${i + 2}`,
+      ownerUser: null,
+      districts: [{ districtLeaid: "L1" }],
+    }));
+    mockPrisma.territoryPlan.findMany.mockResolvedValue(candidates);
+
+    mockPrisma.contact.groupBy.mockResolvedValue([
+      {
+        leaid: "L1",
+        _count: { _all: 3 },
+        _max: { lastEnrichedAt: new Date("2026-04-01T00:00:00.000Z") },
+      },
+    ]);
+
+    const res = await call("plan-1");
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.plans).toHaveLength(10);
+  });
+
+  it("sets ownerName to null when the plan has no owner", async () => {
+    mockPrisma.territoryPlan.findUnique.mockResolvedValue({
+      id: "plan-1",
+      districts: [{ districtLeaid: "L1" }],
+    });
+    mockPrisma.territoryPlan.findMany.mockResolvedValue([
+      {
+        id: "plan-2",
+        name: "Orphan Plan",
+        ownerUser: null,
+        districts: [{ districtLeaid: "L1" }],
+      },
+    ]);
+    mockPrisma.contact.groupBy.mockResolvedValue([
+      {
+        leaid: "L1",
+        _count: { _all: 2 },
+        _max: { lastEnrichedAt: null },
+      },
+    ]);
+
+    const res = await call("plan-1");
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.plans).toEqual([
+      {
+        id: "plan-2",
+        name: "Orphan Plan",
+        ownerName: null,
+        sharedDistrictCount: 1,
+        contactCount: 2,
+        lastEnrichedAt: null,
+      },
+    ]);
+  });
+});

--- a/src/app/api/territory-plans/[id]/contact-sources/route.ts
+++ b/src/app/api/territory-plans/[id]/contact-sources/route.ts
@@ -1,0 +1,162 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { getUser } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/territory-plans/[id]/contact-sources
+//
+// Returns other territory plans that share at least one district leaid with the
+// given plan AND already have at least one Contact row on at least one of those
+// shared leaids. Used by the "Existing contacts" modal on Find Contacts to
+// offer users a path to a plan that already surfaces the relevant contacts.
+//
+// Auth scope: team-wide (mirrors the plan-list + /contacts GET endpoints,
+// which both comment "team shares visibility across plans").
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const user = await getUser();
+
+    if (!user) {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 }
+      );
+    }
+
+    // 1. Load current plan + its district leaids
+    const plan = await prisma.territoryPlan.findUnique({
+      where: { id },
+      include: {
+        districts: {
+          select: { districtLeaid: true },
+        },
+      },
+    });
+
+    if (!plan) {
+      return NextResponse.json(
+        { error: "Territory plan not found" },
+        { status: 404 }
+      );
+    }
+
+    const leaids = plan.districts.map((d) => d.districtLeaid);
+    if (leaids.length === 0) {
+      return NextResponse.json({ plans: [] });
+    }
+
+    // 2. Find candidate other plans sharing >=1 leaid with the current plan.
+    //    Include only the shared districts so we can compute sharedDistrictCount
+    //    locally without a second round-trip.
+    const candidates = await prisma.territoryPlan.findMany({
+      where: {
+        id: { not: id },
+        districts: { some: { districtLeaid: { in: leaids } } },
+      },
+      include: {
+        districts: {
+          where: { districtLeaid: { in: leaids } },
+          select: { districtLeaid: true },
+        },
+        ownerUser: {
+          select: { id: true, fullName: true },
+        },
+      },
+    });
+
+    if (candidates.length === 0) {
+      return NextResponse.json({ plans: [] });
+    }
+
+    // 3. Aggregate contact counts + last-enriched timestamps per leaid, scoped
+    //    to the leaids we care about (the current plan's leaids). Contacts are
+    //    leaid-keyed (not plan-keyed), so any plan containing that leaid sees
+    //    the same contact set.
+    const contactAgg = await prisma.contact.groupBy({
+      by: ["leaid"],
+      where: { leaid: { in: leaids } },
+      _count: { _all: true },
+      _max: { lastEnrichedAt: true },
+    });
+
+    const byLeaid = new Map<
+      string,
+      { count: number; lastEnriched: Date | null }
+    >(
+      contactAgg.map((a) => [
+        a.leaid,
+        { count: a._count._all, lastEnriched: a._max.lastEnrichedAt ?? null },
+      ])
+    );
+
+    // 4. For each candidate, fold shared-leaid stats into the plan row.
+    const enriched = candidates.map((c) => {
+      const sharedLeaids = c.districts.map((d) => d.districtLeaid);
+      let contactCount = 0;
+      let lastEnrichedAt: Date | null = null;
+      for (const leaid of sharedLeaids) {
+        const agg = byLeaid.get(leaid);
+        if (!agg) continue;
+        contactCount += agg.count;
+        if (
+          agg.lastEnriched &&
+          (!lastEnrichedAt || agg.lastEnriched > lastEnrichedAt)
+        ) {
+          lastEnrichedAt = agg.lastEnriched;
+        }
+      }
+      return {
+        id: c.id,
+        name: c.name,
+        ownerName: c.ownerUser?.fullName ?? null,
+        sharedDistrictCount: sharedLeaids.length,
+        contactCount,
+        lastEnrichedAt,
+      };
+    });
+
+    // 5. Drop candidates with no contacts on the shared districts — they can't
+    //    help the user find existing contacts.
+    const withContacts = enriched.filter((r) => r.contactCount > 0);
+
+    // 6. Rank: contactCount DESC, lastEnrichedAt DESC NULLS LAST, name ASC
+    withContacts.sort((a, b) => {
+      if (b.contactCount !== a.contactCount) {
+        return b.contactCount - a.contactCount;
+      }
+      const aTime = a.lastEnrichedAt ? a.lastEnrichedAt.getTime() : -Infinity;
+      const bTime = b.lastEnrichedAt ? b.lastEnrichedAt.getTime() : -Infinity;
+      if (bTime !== aTime) {
+        return bTime - aTime;
+      }
+      return a.name.localeCompare(b.name);
+    });
+
+    // 7. Cap at top 10 and serialize
+    const ranked = withContacts.slice(0, 10);
+
+    return NextResponse.json({
+      plans: ranked.map((p) => ({
+        id: p.id,
+        name: p.name,
+        ownerName: p.ownerName,
+        sharedDistrictCount: p.sharedDistrictCount,
+        contactCount: p.contactCount,
+        lastEnrichedAt: p.lastEnrichedAt
+          ? p.lastEnrichedAt.toISOString()
+          : null,
+      })),
+    });
+  } catch (error) {
+    console.error("Error fetching plan contact sources:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch contact sources" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/territory-plans/[id]/contacts/bulk-enrich/__tests__/route.test.ts
+++ b/src/app/api/territory-plans/[id]/contacts/bulk-enrich/__tests__/route.test.ts
@@ -19,6 +19,7 @@ vi.mock("@/lib/prisma", () => ({
     },
     school: {
       findMany: vi.fn(),
+      count: vi.fn(),
     },
     schoolContact: {
       findMany: vi.fn(),
@@ -169,6 +170,48 @@ describe("POST /bulk-enrich — Principal", () => {
       params: Promise.resolve({ id: "plan-1" }),
     });
     expect(res.status).toBe(400);
+  });
+
+  it("returns reason=no-schools-in-district when Principal finds zero schools and none exist on record", async () => {
+    mockPrisma.school.findMany.mockResolvedValue([]);
+    mockPrisma.school.count.mockResolvedValue(0);
+
+    const res = await POST(buildRequest({ targetRole: "Principal", schoolLevels: [1, 2, 3] }), {
+      params: Promise.resolve({ id: "plan-1" }),
+    });
+    const data = await res.json();
+
+    expect(data).toEqual({ total: 0, skipped: 0, queued: 0, reason: "no-schools-in-district" });
+  });
+
+  it("returns reason=no-schools-at-levels when Principal finds zero at selected levels but schools exist on record", async () => {
+    mockPrisma.school.findMany.mockResolvedValue([]);
+    mockPrisma.school.count.mockResolvedValue(12);
+
+    const res = await POST(buildRequest({ targetRole: "Principal", schoolLevels: [3] }), {
+      params: Promise.resolve({ id: "plan-1" }),
+    });
+    const data = await res.json();
+
+    expect(data).toEqual({ total: 0, skipped: 0, queued: 0, reason: "no-schools-at-levels" });
+  });
+});
+
+describe("POST /bulk-enrich — empty-plan edge case", () => {
+  it("returns reason=no-districts when the plan has zero districts", async () => {
+    mockPrisma.territoryPlan.findUnique.mockResolvedValueOnce({
+      id: "plan-1",
+      enrichmentStartedAt: null,
+      enrichmentQueued: null,
+      districts: [],
+    });
+
+    const res = await POST(buildRequest({ targetRole: "Superintendent" }), {
+      params: Promise.resolve({ id: "plan-1" }),
+    });
+    const data = await res.json();
+
+    expect(data).toEqual({ total: 0, skipped: 0, queued: 0, reason: "no-districts" });
   });
 });
 

--- a/src/app/api/territory-plans/[id]/contacts/bulk-enrich/route.ts
+++ b/src/app/api/territory-plans/[id]/contacts/bulk-enrich/route.ts
@@ -83,7 +83,7 @@ export async function POST(
     }
 
     if (allLeaids.length === 0) {
-      return NextResponse.json({ total: 0, skipped: 0, queued: 0 });
+      return NextResponse.json({ total: 0, skipped: 0, queued: 0, reason: "no-districts" });
     }
 
     const clayWebhookUrl = process.env.CLAY_WEBHOOK_URL;
@@ -155,7 +155,15 @@ export async function POST(
       });
 
       if (schools.length === 0) {
-        return NextResponse.json({ total: 0, skipped: 0, queued: 0 });
+        const anySchoolsOnRecord = await prisma.school.count({
+          where: { leaid: { in: allLeaids } },
+        });
+        return NextResponse.json({
+          total: 0,
+          skipped: 0,
+          queued: 0,
+          reason: anySchoolsOnRecord === 0 ? "no-schools-in-district" : "no-schools-at-levels",
+        });
       }
 
       // NOTE: the "already enriched as principal" heuristic matches title /principal/i.

--- a/src/features/plans/components/ContactsActionBar.tsx
+++ b/src/features/plans/components/ContactsActionBar.tsx
@@ -10,6 +10,7 @@ import {
   useEnrichProgress,
   useExpandRollup,
 } from "@/features/plans/lib/queries";
+import ExistingContactsModal from "./ExistingContactsModal";
 
 interface ContactsActionBarProps {
   planId: string;
@@ -44,9 +45,13 @@ export default function ContactsActionBar({
     type: "info" | "success" | "warning" | "error";
     action?: { label: string; onClick: () => void };
   } | null>(null);
+  const [modalState, setModalState] = useState<
+    { variant: "queued-zero" | "partial"; districtCount: number; newCount?: number } | null
+  >(null);
   const popoverRef = useRef<HTMLDivElement>(null);
   const stallTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastEnrichedRef = useRef<number>(0);
+  const pendingPartialRef = useRef<{ newCount: number; skippedCount: number } | null>(null);
 
   const bulkEnrich = useBulkEnrich();
   const expandRollup = useExpandRollup();
@@ -101,6 +106,14 @@ export default function ContactsActionBar({
       setIsEnriching(false);
       setToast({ message: `Contact enrichment complete — ${progress.enriched} contact${progress.enriched !== 1 ? "s" : ""} found`, type: "success" });
       if (stallTimerRef.current) clearTimeout(stallTimerRef.current);
+      if (pendingPartialRef.current) {
+        setModalState({
+          variant: "partial",
+          districtCount: pendingPartialRef.current.skippedCount,
+          newCount: pendingPartialRef.current.newCount,
+        });
+        pendingPartialRef.current = null;
+      }
       return;
     }
 
@@ -140,8 +153,12 @@ export default function ContactsActionBar({
       });
 
       if (result.queued === 0) {
-        setToast({ message: "Nothing to enrich — all targets already have contacts", type: "info" });
+        setModalState({ variant: "queued-zero", districtCount: result.skipped });
         return;
+      }
+
+      if (result.skipped > 0) {
+        pendingPartialRef.current = { newCount: result.queued, skippedCount: result.skipped };
       }
 
       setIsEnriching(true);
@@ -398,6 +415,16 @@ export default function ContactsActionBar({
           Export CSV
         </button>
       </div>
+
+      {modalState && (
+        <ExistingContactsModal
+          planId={planId}
+          variant={modalState.variant}
+          districtCount={modalState.districtCount}
+          newCount={modalState.newCount}
+          onClose={() => setModalState(null)}
+        />
+      )}
 
       {/* Toast */}
       {toast && (

--- a/src/features/plans/components/ContactsActionBar.tsx
+++ b/src/features/plans/components/ContactsActionBar.tsx
@@ -156,13 +156,20 @@ export default function ContactsActionBar({
         if (result.skipped > 0) {
           setModalState({ variant: "queued-zero", districtCount: result.skipped });
         } else {
-          setToast({
-            message:
+          let message: string;
+          if (result.reason === "no-districts") {
+            message = "No districts to enrich — add districts to this plan first";
+          } else if (result.reason === "no-schools-in-district") {
+            message = "No schools on record for this district";
+          } else if (result.reason === "no-schools-at-levels") {
+            message = "No schools at the selected levels";
+          } else {
+            message =
               selectedRole === "Principal"
-                ? "No schools match the selected levels"
-                : "No districts to enrich — add districts to this plan first",
-            type: "info",
-          });
+                ? "No schools to enrich"
+                : "No contacts to enrich";
+          }
+          setToast({ message, type: "info" });
         }
         return;
       }

--- a/src/features/plans/components/ContactsActionBar.tsx
+++ b/src/features/plans/components/ContactsActionBar.tsx
@@ -153,7 +153,17 @@ export default function ContactsActionBar({
       });
 
       if (result.queued === 0) {
-        setModalState({ variant: "queued-zero", districtCount: result.skipped });
+        if (result.skipped > 0) {
+          setModalState({ variant: "queued-zero", districtCount: result.skipped });
+        } else {
+          setToast({
+            message:
+              selectedRole === "Principal"
+                ? "No schools match the selected levels"
+                : "No districts to enrich — add districts to this plan first",
+            type: "info",
+          });
+        }
         return;
       }
 

--- a/src/features/plans/components/ExistingContactsModal.tsx
+++ b/src/features/plans/components/ExistingContactsModal.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { CheckCircle2, X } from "lucide-react";
+import { useContactSources } from "@/features/plans/lib/queries";
+
+interface ExistingContactsModalProps {
+  planId: string;
+  variant: "queued-zero" | "partial";
+  districtCount: number;
+  newCount?: number;
+  onClose: () => void;
+}
+
+function pluralize(n: number, word: string): string {
+  return `${n} ${word}${n === 1 ? "" : "s"}`;
+}
+
+function relativeDate(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export default function ExistingContactsModal({
+  planId,
+  variant,
+  districtCount,
+  newCount,
+  onClose,
+}: ExistingContactsModalProps) {
+  const queryClient = useQueryClient();
+  const { data, isLoading, isError, refetch } = useContactSources(planId);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [showAll, setShowAll] = useState(false);
+
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const primaryButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    primaryButtonRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+      if (e.key !== "Tab" || !dialogRef.current) return;
+
+      const focusable = dialogRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  const handleShowHere = async () => {
+    setIsRefreshing(true);
+    try {
+      await queryClient.invalidateQueries({ queryKey: ["planContacts", planId] });
+      onClose();
+    } finally {
+      setIsRefreshing(false);
+    }
+  };
+
+  const title = variant === "queued-zero" ? "Contacts already exist" : "Enrichment complete";
+
+  const plans = data?.plans ?? [];
+  const visiblePlans = showAll ? plans : plans.slice(0, 3);
+  const hiddenCount = plans.length - visiblePlans.length;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+      className="fixed inset-0 z-50 flex items-center justify-center"
+    >
+      <div
+        className="absolute inset-0 bg-black/40"
+        onClick={onClose}
+        data-testid="modal-backdrop"
+      />
+
+      <div
+        ref={dialogRef}
+        className="relative bg-white rounded-2xl shadow-xl w-full max-w-2xl mx-4 max-h-[85vh] flex flex-col"
+      >
+        <div className="flex items-center justify-between px-6 py-4 border-b border-[#E2DEEC]">
+          <h2 className="text-lg font-semibold text-[#403770]">{title}</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="p-1 rounded-full text-[#8A80A8] hover:text-[#403770] hover:bg-[#EFEDF5] transition-colors"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="p-6 overflow-y-auto">
+          {variant === "queued-zero" ? (
+            <p className="text-sm text-[#6E6390] mb-6">
+              Contacts for {pluralize(districtCount, "district")} in this plan are already in the
+              system. They may not be showing on this tab yet.
+            </p>
+          ) : (
+            <div className="mb-6 space-y-1.5">
+              <div className="flex items-center gap-2 text-sm text-[#544A78]">
+                <CheckCircle2 className="w-4 h-4 text-[#69B34A] flex-shrink-0" />
+                <span>
+                  Found {pluralize(newCount ?? 0, "new contact")} for{" "}
+                  {pluralize(newCount ?? 0, "district")}.
+                </span>
+              </div>
+              <p className="text-sm text-[#6E6390] pl-6">
+                {pluralize(districtCount, "district")} already had contacts.
+              </p>
+            </div>
+          )}
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div>
+              <h3 className="text-base font-semibold text-[#403770] mb-2">Show them here</h3>
+              <p className="text-sm text-[#6E6390] mb-4">
+                Refresh the Contacts tab to reveal existing contacts for this plan&apos;s districts.
+              </p>
+              <button
+                ref={primaryButtonRef}
+                type="button"
+                onClick={handleShowHere}
+                disabled={isRefreshing}
+                className="px-4 py-2 text-sm font-medium text-white bg-[#403770] rounded-lg hover:bg-[#322a5a] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isRefreshing ? "Refreshing…" : "Show them here"}
+              </button>
+            </div>
+
+            <div>
+              <h3 className="text-base font-semibold text-[#403770] mb-2">Open another plan</h3>
+              <p className="text-sm text-[#6E6390] mb-4">
+                These plans share districts and already have contacts.
+              </p>
+
+              {isLoading && (
+                <div className="space-y-2" data-testid="contact-sources-loading">
+                  {[0, 1, 2].map((i) => (
+                    <div
+                      key={i}
+                      className="animate-pulse bg-[#EFEDF5] h-14 rounded-lg"
+                      data-testid="contact-sources-skeleton"
+                    />
+                  ))}
+                </div>
+              )}
+
+              {isError && (
+                <p className="text-sm text-[#F37167]">
+                  Couldn&apos;t load other plans.{" "}
+                  <button
+                    type="button"
+                    onClick={() => refetch()}
+                    className="underline font-medium text-[#F37167] hover:text-[#d85a50]"
+                  >
+                    Retry
+                  </button>
+                </p>
+              )}
+
+              {!isLoading && !isError && plans.length === 0 && (
+                <p className="text-sm text-[#6E6390]">
+                  No other plans contain these districts yet.
+                </p>
+              )}
+
+              {!isLoading && !isError && plans.length > 0 && (
+                <div className="space-y-2">
+                  {visiblePlans.map((plan) => (
+                    <a
+                      key={plan.id}
+                      href={`/plans/${plan.id}`}
+                      className="block p-3 rounded-lg border border-[#E2DEEC] hover:bg-[#F7F5FA] transition-colors"
+                    >
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="text-sm font-medium text-[#403770] truncate">
+                          {plan.name}
+                        </span>
+                        <span className="text-xs text-[#8A80A8] flex-shrink-0">
+                          {plan.ownerName ?? "Unassigned"}
+                        </span>
+                      </div>
+                      <div className="mt-1 text-xs text-[#6E6390]">
+                        {pluralize(plan.sharedDistrictCount, "district")} ·{" "}
+                        {pluralize(plan.contactCount, "contact")}
+                        {plan.lastEnrichedAt
+                          ? ` · Last enriched ${relativeDate(plan.lastEnrichedAt)}`
+                          : ""}
+                      </div>
+                    </a>
+                  ))}
+                  {hiddenCount > 0 && (
+                    <button
+                      type="button"
+                      onClick={() => setShowAll(true)}
+                      className="text-sm font-medium text-[#403770] hover:text-[#322a5a] underline"
+                    >
+                      See all {plans.length}
+                    </button>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/plans/components/ExistingContactsModal.tsx
+++ b/src/features/plans/components/ExistingContactsModal.tsx
@@ -189,7 +189,7 @@ export default function ExistingContactsModal({
                   <button
                     type="button"
                     onClick={() => refetch()}
-                    className="underline font-medium text-[#F37167] hover:text-[#d85a50]"
+                    className="underline font-medium text-[#F37167] hover:text-[#f58d85]"
                   >
                     Retry
                   </button>

--- a/src/features/plans/components/__tests__/ContactsActionBar.test.tsx
+++ b/src/features/plans/components/__tests__/ContactsActionBar.test.tsx
@@ -269,7 +269,7 @@ describe("ContactsActionBar — ExistingContactsModal triggers", () => {
   });
 
   it("does not open modal when queued=0 and skipped=0 (no-targets path) — shows toast instead", async () => {
-    mockMutateAsync.mockResolvedValueOnce({ total: 0, skipped: 0, queued: 0 });
+    mockMutateAsync.mockResolvedValueOnce({ total: 0, skipped: 0, queued: 0, reason: "no-districts" });
 
     render(
       withQueryClient(
@@ -289,6 +289,56 @@ describe("ContactsActionBar — ExistingContactsModal triggers", () => {
 
     expect(screen.queryByRole("heading", { name: /contacts already exist/i })).not.toBeInTheDocument();
     expect(await screen.findByText(/no districts to enrich/i)).toBeInTheDocument();
+  });
+
+  it("shows 'no schools on record' toast when reason=no-schools-in-district", async () => {
+    mockMutateAsync.mockResolvedValueOnce({
+      total: 0, skipped: 0, queued: 0, reason: "no-schools-in-district",
+    });
+
+    render(
+      withQueryClient(
+        <ContactsActionBar
+          planId="plan-1"
+          planName="Plan"
+          contacts={[]}
+          allDistrictLeaids={["3620580"]}
+        />
+      )
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /find contacts/i }));
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "Principal" } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /start/i }));
+    });
+
+    expect(await screen.findByText(/no schools on record for this district/i)).toBeInTheDocument();
+  });
+
+  it("shows 'no schools at the selected levels' toast when reason=no-schools-at-levels", async () => {
+    mockMutateAsync.mockResolvedValueOnce({
+      total: 0, skipped: 0, queued: 0, reason: "no-schools-at-levels",
+    });
+
+    render(
+      withQueryClient(
+        <ContactsActionBar
+          planId="plan-1"
+          planName="Plan"
+          contacts={[]}
+          allDistrictLeaids={["0100001"]}
+        />
+      )
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /find contacts/i }));
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "Principal" } });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /start/i }));
+    });
+
+    expect(await screen.findByText(/no schools at the selected levels/i)).toBeInTheDocument();
   });
 
   it("does not open modal when queued>0 and skipped=0 (all-new path)", async () => {

--- a/src/features/plans/components/__tests__/ContactsActionBar.test.tsx
+++ b/src/features/plans/components/__tests__/ContactsActionBar.test.tsx
@@ -1,9 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import ContactsActionBar from "../ContactsActionBar";
+
+function withQueryClient(ui: React.ReactElement) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{ui}</QueryClientProvider>;
+}
 
 const mockMutateAsync = vi.fn().mockResolvedValue({ total: 3, skipped: 0, queued: 3 });
 const mockExpandMutateAsync = vi.fn().mockResolvedValue({ rollupsExpanded: [], expandedCount: 0 });
+
+let progressData: { total: number; enriched: number; queued: number } = {
+  total: 0,
+  enriched: 0,
+  queued: 0,
+};
 
 vi.mock("@/features/plans/lib/queries", () => ({
   useBulkEnrich: () => ({
@@ -11,7 +23,13 @@ vi.mock("@/features/plans/lib/queries", () => ({
     isPending: false,
   }),
   useEnrichProgress: () => ({
-    data: { total: 0, enriched: 0, queued: 0 },
+    data: progressData,
+  }),
+  useContactSources: () => ({
+    data: { plans: [] },
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
   }),
   useExpandRollup: () => ({
     mutateAsync: mockExpandMutateAsync,
@@ -25,6 +43,7 @@ describe("ContactsActionBar — Principal popover", () => {
     mockMutateAsync.mockResolvedValue({ total: 3, skipped: 0, queued: 3 });
     mockExpandMutateAsync.mockClear();
     mockExpandMutateAsync.mockResolvedValue({ rollupsExpanded: [], expandedCount: 0 });
+    progressData = { total: 0, enriched: 0, queued: 0 };
   });
 
   it("shows School Level checkboxes when Principal is selected", () => {
@@ -178,5 +197,109 @@ describe("ContactsActionBar — Principal popover", () => {
     await vi.waitFor(() => {
       expect(mockMutateAsync).toHaveBeenCalledTimes(2);
     });
+  });
+});
+
+describe("ContactsActionBar — ExistingContactsModal triggers", () => {
+  beforeEach(() => {
+    mockMutateAsync.mockClear();
+    progressData = { total: 0, enriched: 0, queued: 0 };
+  });
+
+  it("opens modal in queued-zero variant when queued=0 (not the 'Nothing to enrich' toast)", async () => {
+    mockMutateAsync.mockResolvedValueOnce({ total: 2, skipped: 2, queued: 0 });
+
+    render(
+      withQueryClient(
+        <ContactsActionBar
+          planId="plan-1"
+          planName="Plan"
+          contacts={[]}
+          allDistrictLeaids={["0100001", "0100002"]}
+        />
+      )
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /find contacts/i }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /start/i }));
+    });
+
+    expect(await screen.findByRole("heading", { name: /contacts already exist/i })).toBeInTheDocument();
+    expect(screen.queryByText(/nothing to enrich/i)).not.toBeInTheDocument();
+  });
+
+  it("opens modal in partial variant after completion when queued>0 and skipped>0", async () => {
+    mockMutateAsync.mockResolvedValueOnce({ total: 3, skipped: 1, queued: 2 });
+
+    const { rerender } = render(
+      withQueryClient(
+        <ContactsActionBar
+          planId="plan-1"
+          planName="Plan"
+          contacts={[]}
+          allDistrictLeaids={["0100001", "0100002", "0100003"]}
+        />
+      )
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /find contacts/i }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /start/i }));
+    });
+
+    // No modal immediately on submit
+    expect(screen.queryByRole("heading", { name: /enrichment complete/i })).not.toBeInTheDocument();
+
+    // Simulate progress completion
+    progressData = { total: 2, enriched: 2, queued: 2 };
+    rerender(
+      withQueryClient(
+        <ContactsActionBar
+          planId="plan-1"
+          planName="Plan"
+          contacts={[]}
+          allDistrictLeaids={["0100001", "0100002", "0100003"]}
+        />
+      )
+    );
+
+    expect(await screen.findByRole("heading", { name: /enrichment complete/i })).toBeInTheDocument();
+    expect(screen.getByText(/1 district already had contacts/i)).toBeInTheDocument();
+  });
+
+  it("does not open modal when queued>0 and skipped=0 (all-new path)", async () => {
+    mockMutateAsync.mockResolvedValueOnce({ total: 3, skipped: 0, queued: 3 });
+
+    const { rerender } = render(
+      withQueryClient(
+        <ContactsActionBar
+          planId="plan-1"
+          planName="Plan"
+          contacts={[]}
+          allDistrictLeaids={["0100001"]}
+        />
+      )
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /find contacts/i }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /start/i }));
+    });
+
+    progressData = { total: 3, enriched: 3, queued: 3 };
+    rerender(
+      withQueryClient(
+        <ContactsActionBar
+          planId="plan-1"
+          planName="Plan"
+          contacts={[]}
+          allDistrictLeaids={["0100001"]}
+        />
+      )
+    );
+
+    expect(screen.queryByRole("heading", { name: /enrichment complete/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: /contacts already exist/i })).not.toBeInTheDocument();
   });
 });

--- a/src/features/plans/components/__tests__/ContactsActionBar.test.tsx
+++ b/src/features/plans/components/__tests__/ContactsActionBar.test.tsx
@@ -268,6 +268,29 @@ describe("ContactsActionBar — ExistingContactsModal triggers", () => {
     expect(screen.getByText(/1 district already had contacts/i)).toBeInTheDocument();
   });
 
+  it("does not open modal when queued=0 and skipped=0 (no-targets path) — shows toast instead", async () => {
+    mockMutateAsync.mockResolvedValueOnce({ total: 0, skipped: 0, queued: 0 });
+
+    render(
+      withQueryClient(
+        <ContactsActionBar
+          planId="plan-1"
+          planName="Plan"
+          contacts={[]}
+          allDistrictLeaids={[]}
+        />
+      )
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /find contacts/i }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /start/i }));
+    });
+
+    expect(screen.queryByRole("heading", { name: /contacts already exist/i })).not.toBeInTheDocument();
+    expect(await screen.findByText(/no districts to enrich/i)).toBeInTheDocument();
+  });
+
   it("does not open modal when queued>0 and skipped=0 (all-new path)", async () => {
     mockMutateAsync.mockResolvedValueOnce({ total: 3, skipped: 0, queued: 3 });
 

--- a/src/features/plans/components/__tests__/ExistingContactsModal.test.tsx
+++ b/src/features/plans/components/__tests__/ExistingContactsModal.test.tsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import ExistingContactsModal from "../ExistingContactsModal";
+import type { ContactSourcePlan } from "@/features/plans/lib/queries";
+
+type UseContactSourcesResult = {
+  data: { plans: ContactSourcePlan[] } | undefined;
+  isLoading: boolean;
+  isError: boolean;
+  refetch: () => void;
+};
+
+const mockRefetch = vi.fn();
+let mockResult: UseContactSourcesResult = {
+  data: { plans: [] },
+  isLoading: false,
+  isError: false,
+  refetch: mockRefetch,
+};
+
+vi.mock("@/features/plans/lib/queries", () => ({
+  useContactSources: () => mockResult,
+}));
+
+function renderModal(props: Partial<React.ComponentProps<typeof ExistingContactsModal>> = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const defaults = {
+    planId: "plan-1",
+    variant: "queued-zero" as const,
+    districtCount: 3,
+    onClose: vi.fn(),
+  };
+  const merged = { ...defaults, ...props };
+  const utils = render(
+    <QueryClientProvider client={queryClient}>
+      <ExistingContactsModal {...merged} />
+    </QueryClientProvider>
+  );
+  return { ...utils, onClose: merged.onClose, queryClient };
+}
+
+function makePlan(overrides: Partial<ContactSourcePlan> = {}): ContactSourcePlan {
+  return {
+    id: "plan-x",
+    name: "Default Plan",
+    ownerName: "Aston",
+    sharedDistrictCount: 2,
+    contactCount: 5,
+    lastEnrichedAt: "2026-04-20T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("ExistingContactsModal", () => {
+  beforeEach(() => {
+    mockRefetch.mockClear();
+    mockResult = {
+      data: { plans: [] },
+      isLoading: false,
+      isError: false,
+      refetch: mockRefetch,
+    };
+  });
+
+  it("renders queued-zero variant with title and subline", () => {
+    renderModal({ variant: "queued-zero", districtCount: 3 });
+    expect(screen.getByRole("heading", { name: /contacts already exist/i })).toBeInTheDocument();
+    expect(
+      screen.getByText(/contacts for 3 districts in this plan are already in the system/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders partial variant with status line and skipped message", () => {
+    renderModal({ variant: "partial", districtCount: 2, newCount: 4 });
+    expect(screen.getByRole("heading", { name: /enrichment complete/i })).toBeInTheDocument();
+    expect(screen.getByText(/found 4 new contacts for 4 districts\./i)).toBeInTheDocument();
+    expect(screen.getByText(/2 districts already had contacts/i)).toBeInTheDocument();
+  });
+
+  it("renders 3 skeleton rows in loading state", () => {
+    mockResult = { data: undefined, isLoading: true, isError: false, refetch: mockRefetch };
+    renderModal();
+    const skeletons = screen.getAllByTestId("contact-sources-skeleton");
+    expect(skeletons).toHaveLength(3);
+  });
+
+  it("renders empty state when plans: []", () => {
+    mockResult = {
+      data: { plans: [] },
+      isLoading: false,
+      isError: false,
+      refetch: mockRefetch,
+    };
+    renderModal();
+    expect(
+      screen.getByText(/no other plans contain these districts yet/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders error state with Retry that re-fetches", () => {
+    mockResult = { data: undefined, isLoading: false, isError: true, refetch: mockRefetch };
+    renderModal();
+    expect(screen.getByText(/couldn't load other plans/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(mockRefetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders first 3 plan rows by default and expands via See all", () => {
+    const plans = Array.from({ length: 5 }, (_, i) =>
+      makePlan({ id: `plan-${i}`, name: `Plan ${i}` })
+    );
+    mockResult = {
+      data: { plans },
+      isLoading: false,
+      isError: false,
+      refetch: mockRefetch,
+    };
+    renderModal();
+    expect(screen.getByText("Plan 0")).toBeInTheDocument();
+    expect(screen.getByText("Plan 2")).toBeInTheDocument();
+    expect(screen.queryByText("Plan 3")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /see all 5/i }));
+    expect(screen.getByText("Plan 3")).toBeInTheDocument();
+    expect(screen.getByText("Plan 4")).toBeInTheDocument();
+  });
+
+  it("'Show them here' invalidates planContacts query and calls onClose", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const onClose = vi.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ExistingContactsModal
+          planId="plan-42"
+          variant="queued-zero"
+          districtCount={2}
+          onClose={onClose}
+        />
+      </QueryClientProvider>
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /show them here/i }));
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["planContacts", "plan-42"] });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("Escape key calls onClose", () => {
+    const { onClose } = renderModal();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("backdrop click calls onClose", () => {
+    const { onClose } = renderModal();
+    fireEvent.click(screen.getByTestId("modal-backdrop"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("plan row renders as native anchor with /plans/{id} href", () => {
+    const plans = [makePlan({ id: "plan-99", name: "Anchor Plan" })];
+    mockResult = {
+      data: { plans },
+      isLoading: false,
+      isError: false,
+      refetch: mockRefetch,
+    };
+    renderModal();
+    const link = screen.getByRole("link", { name: /anchor plan/i });
+    expect(link.tagName).toBe("A");
+    expect(link).toHaveAttribute("href", "/plans/plan-99");
+  });
+});

--- a/src/features/plans/lib/queries.ts
+++ b/src/features/plans/lib/queries.ts
@@ -263,6 +263,27 @@ export interface BulkEnrichError extends Error {
   body: unknown;
 }
 
+export interface ContactSourcePlan {
+  id: string;
+  name: string;
+  ownerName: string | null;
+  sharedDistrictCount: number;
+  contactCount: number;
+  lastEnrichedAt: string | null;
+}
+
+export function useContactSources(planId: string | null) {
+  return useQuery({
+    queryKey: ["planContactSources", planId],
+    queryFn: () =>
+      fetchJson<{ plans: ContactSourcePlan[] }>(
+        `${API_BASE}/territory-plans/${planId}/contact-sources`
+      ),
+    enabled: !!planId,
+    staleTime: 2 * 60 * 1000,
+  });
+}
+
 export function useBulkEnrich() {
   const queryClient = useQueryClient();
 

--- a/src/features/plans/lib/queries.ts
+++ b/src/features/plans/lib/queries.ts
@@ -328,7 +328,12 @@ export function useBulkEnrich() {
         err.body = body;
         throw err;
       }
-      return body as { total: number; skipped: number; queued: number };
+      return body as {
+        total: number;
+        skipped: number;
+        queued: number;
+        reason?: "no-districts" | "no-schools-in-district" | "no-schools-at-levels";
+      };
     },
     onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: ["planContacts", variables.planId] });


### PR DESCRIPTION
## Summary

Replaces the dead-end "Nothing to enrich" toast on the **Find Contacts** action with a split-action modal offering two concrete paths forward:

- **"Show them here"** — refetches this plan's `/contacts` query so existing contacts surface on the Contacts tab
- **"Open another plan"** — list of other plans sharing districts with this one that already hold contacts

Adds a team-wide `GET /api/territory-plans/[id]/contact-sources` endpoint ranked by `contactCount DESC, lastEnrichedAt DESC, name ASC` (limit 10). Contacts stay leaid-keyed — no data-model changes.

Also distinguishes the three "no-work" cases in bulk-enrich via a new `reason` field so the UI can show an accurate toast:

- `no-districts` — plan has no districts
- `no-schools-in-district` — Principal mode, district has no schools on record (surfaces the NYC DOE rollup problem — see follow-up)
- `no-schools-at-levels` — Principal mode, schools exist but none at selected levels

Modal only opens when `skipped > 0` (real existing contacts) — not when there's nothing to enrich at all.

## Scope

| File | Change |
|------|--------|
| `src/app/api/territory-plans/[id]/contact-sources/route.ts` | NEW — sibling-plan lookup, team-wide, ranked |
| `src/app/api/territory-plans/[id]/contacts/bulk-enrich/route.ts` | Added `reason` field to empty responses |
| `src/features/plans/components/ExistingContactsModal.tsx` | NEW — split-action modal, both variants |
| `src/features/plans/components/ContactsActionBar.tsx` | Replaced dead-end toast, added `reason`-aware toasts, completion-time partial trigger |
| `src/features/plans/lib/queries.ts` | `useContactSources` hook + `ContactSourcePlan` type; updated `useBulkEnrich` response type |
| Tests | 26 new (9 backend + 10 modal + 7 ActionBar) |
| Docs | Spec, plan, backend context, final report, TECHSTACK update |

## Known follow-ups (out of scope)

- **NYC DOE rollup**: the district at `leaid 3620580` has 0 schools attached; NYC schools live under 32 Geographic Districts (`3600076`–`3600123` range). Map selection UI should expose the children — tracked as a separate feature.
- **Partial-variant copy nuance**: `newCount` prop used for both "contacts" and "districts" in the status row. Fine when Clay returns 1 primary per district; may need split props if multi-enrichment per district lands.
- **Archived plans** not filtered from `/contact-sources` candidates — intentional for now; confirm preference.
- **Pre-existing**: `SearchBar.test.tsx` has one failing test unrelated to this change.

## Test plan

- [ ] Open a plan whose districts already have contacts → click Find Contacts → modal appears with "Show them here" and the other-plans list
- [ ] "Show them here" refetches and closes the modal
- [ ] "Open another plan" rows are native anchors (middle-click opens in new tab)
- [ ] Open a plan with 0 districts → click Find Contacts → toast "No districts to enrich" (no modal)
- [ ] Open a plan with NYC DOE (Principal mode) → toast "No schools on record for this district"
- [ ] Open a plan with a partial-overlap (some districts enriched, some not) → enrichment runs → modal appears on completion in `Enrichment complete` variant
- [ ] Vitest: `npx vitest run` (the SearchBar failure is pre-existing)
- [ ] Build: `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)