### PR TITLE
Add Canva org chart as Team resource (link + inline embed)

### DIFF
--- a/src/features/shared/components/views/resources/OrgChartPage.tsx
+++ b/src/features/shared/components/views/resources/OrgChartPage.tsx
@@ -1,9 +1,12 @@
 "use client";
 
-import { ExternalLink, Users } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 
 const CANVA_ORG_CHART_URL =
   "https://www.canva.com/design/DAHENoDrpIo/JyiNr7r6qjNs2U7mtpQwMw/edit";
+
+const CANVA_EMBED_URL =
+  "https://www.canva.com/design/DAHENoDrpIo/PAZw4HMc-e81me7Q46wOlQ/view?embed";
 
 export default function OrgChartPage() {
   return (
@@ -18,34 +21,39 @@ export default function OrgChartPage() {
         </p>
       </header>
 
-      <div className="rounded-lg border border-[#E2DEEC] bg-white p-6">
-        <div className="flex items-start gap-4">
-          <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg bg-[#FEF2F1]">
-            <Users className="h-5 w-5 text-[#F37167]" />
-          </div>
-          <div className="flex-1">
-            <h2 className="text-base font-semibold text-[#403770]">
-              Open the live org chart
-            </h2>
-            <p className="mt-1 text-sm leading-relaxed text-[#6E6390]">
-              The current Fullmind organizational chart is kept up to date in
-              Canva. Open it to find anyone at the company, see reporting
-              structure, and identify who leads each team.
-            </p>
-            <a
-              href={CANVA_ORG_CHART_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="mt-4 inline-flex items-center gap-2 rounded-md bg-[#F37167] px-4 py-2 text-sm font-medium text-white transition-colors duration-100 hover:bg-[#E85D52] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#F37167] focus-visible:ring-offset-2"
-            >
-              Open in Canva
-              <ExternalLink className="h-4 w-4" />
-            </a>
-          </div>
-        </div>
+      <div
+        className="relative w-full overflow-hidden rounded-lg"
+        style={{
+          paddingTop: "100%",
+          boxShadow: "0 2px 8px 0 rgba(63,69,81,0.16)",
+        }}
+      >
+        <iframe
+          src={CANVA_EMBED_URL}
+          loading="lazy"
+          allowFullScreen
+          allow="fullscreen"
+          title="Fullmind Org Chart"
+          className="absolute left-0 top-0 h-full w-full border-0"
+        />
       </div>
 
-      <p className="mt-4 text-xs text-[#8A80A8]">
+      <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+        <p className="text-xs text-[#8A80A8]">
+          Designed by Amy Warner · Kept current in Canva
+        </p>
+        <a
+          href={CANVA_ORG_CHART_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 rounded-md bg-[#F37167] px-4 py-2 text-sm font-medium text-white transition-colors duration-100 hover:bg-[#E85D52] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#F37167] focus-visible:ring-offset-2"
+        >
+          Open in Canva
+          <ExternalLink className="h-4 w-4" />
+        </a>
+      </div>
+
+      <p className="mt-6 text-xs text-[#8A80A8]">
         Questions about structure or updates? Reach out to the team lead listed
         on the chart.
       </p>


### PR DESCRIPTION
## Summary
- Adds a **Fullmind Org Chart** page under Resources → Team as an interim stand-in for the paused Rippling-API org chart integration.
- Surfaces the existing Canva-maintained org chart via an inline iframe embed (1:1, lazy-loaded) so reps can scan reporting structure without leaving the app.
- Keeps an "Open in Canva" coral button as a secondary action for editors / full-screen viewing.

## Test plan
- [ ] Navigate to Resources → Team → Fullmind Org Chart — page loads, header is styled with plum tokens.
- [ ] Canva iframe renders the live design and is interactive (pan / zoom inside the embed).
- [ ] "Open in Canva" button opens the edit URL in a new tab with `noopener noreferrer`.
- [ ] Embed degrades gracefully (no layout shift) on slow connections thanks to `loading="lazy"`.
- [ ] No Tailwind grays introduced; only Fullmind plum/coral tokens used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)