### PR TITLE
release: vacancy scan coverage fix + state BOE/DOE URLs

### DIFF
--- a/prisma/migrations/20260422_state_ed_agency_urls/migration.sql
+++ b/prisma/migrations/20260422_state_ed_agency_urls/migration.sql
@@ -1,0 +1,7 @@
+-- Add external-reference URL columns to states:
+--   board_of_ed_url  -> State Board of Education homepage (governance body)
+--   dept_of_ed_url   -> State Education Agency / Dept of Ed homepage (operational agency)
+-- Populated via scripts/seed-state-ed-urls.ts.
+
+ALTER TABLE "states" ADD COLUMN IF NOT EXISTS "board_of_ed_url" VARCHAR(500);
+ALTER TABLE "states" ADD COLUMN IF NOT EXISTS "dept_of_ed_url"  VARCHAR(500);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -401,6 +401,10 @@ model State {
   abbrev String @unique @db.VarChar(2) // "CA"
   name   String @db.VarChar(100) // "California"
 
+  // ===== External references =====
+  boardOfEdUrl String? @map("board_of_ed_url") @db.VarChar(500)
+  deptOfEdUrl  String? @map("dept_of_ed_url") @db.VarChar(500)
+
   // ===== Denormalized Aggregates =====
   // Refreshed from districts table via ETL
   totalDistricts     Int      @default(0) @map("total_districts")

--- a/scripts/seed-state-ed-urls.ts
+++ b/scripts/seed-state-ed-urls.ts
@@ -1,0 +1,116 @@
+// Seeds board_of_ed_url and dept_of_ed_url on the `states` table.
+// Run: npx tsx scripts/seed-state-ed-urls.ts
+//
+// Notes on data quality:
+// - BOE = State Board of Education homepage (governance body).
+// - DOE = State Education Agency / Dept-of-Ed homepage (operational agency,
+//   e.g. CDE, NYSED, TEA). This is usually the more useful link for reps.
+// - A few states have no separate State Board (MN, WI); BOE left null.
+// - Territories + BIE populated with their own agency URLs where available.
+// - The "US" rollup row and "IT" (International) are intentionally left null.
+
+import { prisma } from '../src/lib/prisma';
+
+type UrlPair = { boe: string | null; doe: string | null };
+
+const URLS: Record<string, UrlPair> = {
+  // ===== 50 states =====
+  AL: { boe: 'https://www.alabamaachieves.org/state-board-of-education/', doe: 'https://www.alsde.edu' },
+  AK: { boe: 'https://education.alaska.gov/State_Board', doe: 'https://education.alaska.gov' },
+  AZ: { boe: 'https://azsbe.az.gov', doe: 'https://www.azed.gov' },
+  AR: { boe: 'https://dese.ade.arkansas.gov/stateboard', doe: 'https://dese.ade.arkansas.gov' },
+  CA: { boe: 'https://www.cde.ca.gov/be/', doe: 'https://www.cde.ca.gov' },
+  CO: { boe: 'https://ed.cde.state.co.us/cdeboard', doe: 'https://www.cde.state.co.us' },
+  CT: { boe: 'https://portal.ct.gov/SDE/Board/State-Board-of-Education', doe: 'https://portal.ct.gov/SDE' },
+  DE: { boe: 'https://education.delaware.gov/community/governance/state-board-of-education/', doe: 'https://education.delaware.gov' },
+  FL: { boe: 'https://www.fldoe.org/policy/state-board-of-edu/', doe: 'https://www.fldoe.org' },
+  GA: { boe: 'https://sboe.georgia.gov', doe: 'https://www.gadoe.org' },
+  HI: { boe: 'https://boe.hawaii.gov', doe: 'https://www.hawaiipublicschools.org' },
+  ID: { boe: 'https://boardofed.idaho.gov', doe: 'https://www.sde.idaho.gov' },
+  IL: { boe: 'https://www.isbe.net/Pages/state-board.aspx', doe: 'https://www.isbe.net' },
+  IN: { boe: 'https://www.in.gov/sboe/', doe: 'https://www.in.gov/doe/' },
+  IA: { boe: 'https://educate.iowa.gov/boards/state-board-education', doe: 'https://educate.iowa.gov' },
+  KS: { boe: 'https://www.ksde.gov/Board', doe: 'https://www.ksde.gov' },
+  KY: { boe: 'https://www.education.ky.gov/KBE/Pages/default.aspx', doe: 'https://www.education.ky.gov' },
+  LA: { boe: 'https://bese.louisiana.gov', doe: 'https://www.louisianabelieves.com' },
+  ME: { boe: 'https://www.maine.gov/doe/about/leadership/stateboard', doe: 'https://www.maine.gov/doe' },
+  MD: { boe: 'https://marylandpublicschools.org/stateboard/Pages/index.aspx', doe: 'https://marylandpublicschools.org' },
+  MA: { boe: 'https://www.doe.mass.edu/bese/', doe: 'https://www.doe.mass.edu' },
+  MI: { boe: 'https://www.michigan.gov/mde/about-us/state-board', doe: 'https://www.michigan.gov/mde' },
+  MN: { boe: null, doe: 'https://education.mn.gov' }, // No separate state BOE
+  MS: { boe: 'https://www.mdek12.org/sbe', doe: 'https://www.mdek12.org' },
+  MO: { boe: 'https://dese.mo.gov/state-board-education', doe: 'https://dese.mo.gov' },
+  MT: { boe: 'https://bpe.mt.gov/', doe: 'https://opi.mt.gov' }, // Board of Public Education
+  NE: { boe: 'https://www.education.ne.gov/stateboard/', doe: 'https://www.education.ne.gov' },
+  NV: { boe: 'https://doe.nv.gov/boards-commissions-councils/state-board-of-education', doe: 'https://doe.nv.gov' },
+  NH: { boe: 'https://www.education.nh.gov/who-we-are/state-board-of-education', doe: 'https://www.education.nh.gov' },
+  NJ: { boe: 'https://www.nj.gov/education/sboe/', doe: 'https://www.nj.gov/education' },
+  NM: { boe: 'https://web.ped.nm.gov/bureaus/public-education-commission/', doe: 'https://web.ped.nm.gov' },
+  NY: { boe: 'https://www.regents.nysed.gov', doe: 'https://www.nysed.gov' }, // Board of Regents
+  NC: { boe: 'https://www.dpi.nc.gov/about-dpi/state-board-education', doe: 'https://www.dpi.nc.gov' },
+  ND: { boe: 'https://www.nd.gov/dpi/familiescommunity/community/boards-and-committees/state-board-public-school-education', doe: 'https://www.nd.gov/dpi' },
+  OH: { boe: 'https://sboe.ohio.gov/', doe: 'https://education.ohio.gov' }, // Board split off from DEW in 2023
+  OK: { boe: 'https://oklahoma.gov/education/state-board-of-education.html', doe: 'https://sde.ok.gov' },
+  OR: { boe: 'https://www.oregon.gov/ode/about-us/stateboard/pages/default.aspx', doe: 'https://www.oregon.gov/ode' },
+  PA: { boe: 'https://www.pa.gov/en/agencies/stateboard.html', doe: 'https://www.education.pa.gov' },
+  RI: { boe: 'https://ride.ri.gov/board-education', doe: 'https://www.ride.ri.gov' },
+  SC: { boe: 'https://ed.sc.gov/state-board/state-board-of-education/', doe: 'https://ed.sc.gov' },
+  SD: { boe: 'https://boardsandcommissions.sd.gov/Information.aspx?BoardID=32', doe: 'https://doe.sd.gov' }, // Board of Education Standards
+  TN: { boe: 'https://www.tn.gov/sbe', doe: 'https://www.tn.gov/education' },
+  TX: { boe: 'https://sboe.texas.gov/state-board-of-education/sboe-homepage', doe: 'https://tea.texas.gov' },
+  UT: { boe: 'https://www.schools.utah.gov/board', doe: 'https://www.schools.utah.gov' },
+  VT: { boe: 'https://education.vermont.gov/state-board', doe: 'https://education.vermont.gov' },
+  VA: { boe: 'https://www.doe.virginia.gov/data-policy-funding/virginia-board-of-education', doe: 'https://www.doe.virginia.gov' },
+  WA: { boe: 'https://sbe.wa.gov', doe: 'https://ospi.k12.wa.us' },
+  WV: { boe: 'https://wvde.us/board-of-education/', doe: 'https://wvde.us' },
+  WI: { boe: null, doe: 'https://dpi.wi.gov' }, // No state BOE; elected State Superintendent
+  WY: { boe: 'https://wyboardofeducation.org/', doe: 'https://edu.wyoming.gov' },
+
+  // ===== DC =====
+  DC: { boe: 'https://sboe.dc.gov', doe: 'https://osse.dc.gov' },
+
+  // ===== US territories =====
+  PR: { boe: null, doe: 'https://de.pr.gov' },
+  AS: { boe: null, doe: 'https://www.amsamoadoe.com' },
+  GU: { boe: null, doe: 'https://www.gdoe.net' },
+  MP: { boe: null, doe: 'https://www.cnmipss.org' },
+  VI: { boe: null, doe: 'https://www.vide.vi' },
+
+  // ===== Federal =====
+  BI: { boe: null, doe: 'https://www.bie.edu' }, // Bureau of Indian Education
+
+  // Intentionally null: US (rollup), IT (International)
+};
+
+async function main() {
+  // Use raw SQL to avoid Prisma's implicit SELECT after UPDATE, which chokes on
+  // unrelated schema drift (a known issue with the `icp_avg_score` column).
+  const abbrevs = await prisma.$queryRaw<{ abbrev: string }[]>`
+    SELECT abbrev FROM states ORDER BY abbrev ASC
+  `;
+
+  let updated = 0;
+  let skipped = 0;
+  for (const { abbrev } of abbrevs) {
+    const entry = URLS[abbrev];
+    if (!entry) {
+      skipped++;
+      continue;
+    }
+    await prisma.$executeRaw`
+      UPDATE states
+      SET board_of_ed_url = ${entry.boe},
+          dept_of_ed_url  = ${entry.doe}
+      WHERE abbrev = ${abbrev}
+    `;
+    updated++;
+  }
+
+  console.log(`Updated ${updated} states, skipped ${skipped}.`);
+  await prisma.$disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/api/cron/scan-vacancies/route.ts
+++ b/src/app/api/cron/scan-vacancies/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import PQueue from "p-queue";
 import prisma from "@/lib/prisma";
-import { detectPlatform, isStatewideBoard, loadSharedAppliTrackInstances } from "@/features/vacancies/lib/platform-detector";
+import { detectPlatform, isStatewideBoard, loadSharedJobBoardUrls, normalizeJobBoardKey } from "@/features/vacancies/lib/platform-detector";
 import { runScan } from "@/features/vacancies/lib/scan-runner";
+import { buildSiblingCoverageRecords } from "@/features/vacancies/lib/shared-board-coverage";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 300; // 5 min — Vercel Pro limit
@@ -49,8 +50,8 @@ export async function GET(request: NextRequest) {
     const staleDate = new Date();
     staleDate.setDate(staleDate.getDate() - staleDays);
 
-    // Warm shared AppliTrack cache before grouping
-    await loadSharedAppliTrackInstances();
+    // Warm shared job-board cache before grouping
+    await loadSharedJobBoardUrls();
 
     // Find all districts with job board URLs
     const districts = await prisma.district.findMany({
@@ -58,7 +59,7 @@ export async function GET(request: NextRequest) {
       select: { leaid: true, name: true, jobBoardUrl: true },
     });
 
-    // Find which districts were recently scanned
+    // Districts recently scanned (excluded from this run's stale pool)
     const recentScans = await prisma.vacancyScan.groupBy({
       by: ["leaid"],
       where: {
@@ -68,37 +69,55 @@ export async function GET(request: NextRequest) {
     });
     const recentlyScanned = new Set(recentScans.map((s) => s.leaid));
 
+    // Districts that have EVER completed a scan — used to prioritize never-scanned groups
+    const everCompleted = await prisma.vacancyScan.groupBy({
+      by: ["leaid"],
+      where: { status: { in: ["completed", "completed_partial"] } },
+    });
+    const everScanned = new Set(everCompleted.map((s) => s.leaid));
+
     const staleDistricts = districts.filter(
       (d) => d.jobBoardUrl && !recentlyScanned.has(d.leaid)
     );
 
-    // Group by unique job board URL to deduplicate state-wide boards
+    // Group by unique job board URL to deduplicate shared boards
     const urlGroups = new Map<
       string,
-      { url: string; platform: string; districts: typeof staleDistricts }
+      { url: string; platform: string; districts: typeof staleDistricts; hasNeverScanned: boolean }
     >();
 
     for (const d of staleDistricts) {
       const url = d.jobBoardUrl!;
       const platform = detectPlatform(url);
+      const isShared = isStatewideBoard(platform, url);
 
-      // State-wide boards: group by base URL (one scan covers all)
+      // Shared boards: group by normalized URL (one scan covers all)
       // District-scoped: unique key per district
-      const groupKey = isStatewideBoard(platform, url)
-        ? new URL(url).origin + new URL(url).pathname
+      const groupKey = isShared
+        ? normalizeJobBoardKey(url) ?? `district:${d.leaid}`
         : `district:${d.leaid}`;
 
-      if (!urlGroups.has(groupKey)) {
-        urlGroups.set(groupKey, { url, platform, districts: [] });
+      let group = urlGroups.get(groupKey);
+      if (!group) {
+        group = { url, platform, districts: [], hasNeverScanned: false };
+        urlGroups.set(groupKey, group);
       }
-      urlGroups.get(groupKey)!.districts.push(d);
+      group.districts.push(d);
+      if (!everScanned.has(d.leaid)) group.hasNeverScanned = true;
     }
 
-    // Sort: state-wide boards first (high value), then by district count
+    // Sort priority:
+    //   1. Shared boards first (one scan covers many districts)
+    //   2. Groups containing at least one never-scanned district
+    //      (prevents cycling-through-covered starvation; critical for coverage growth)
+    //   3. Larger groups before smaller ones
     const sortedGroups = [...urlGroups.values()].sort((a, b) => {
-      const aStatewide = isStatewideBoard(a.platform, a.url) ? 1 : 0;
-      const bStatewide = isStatewideBoard(b.platform, b.url) ? 1 : 0;
-      if (aStatewide !== bStatewide) return bStatewide - aStatewide;
+      const aShared = isStatewideBoard(a.platform, a.url) ? 1 : 0;
+      const bShared = isStatewideBoard(b.platform, b.url) ? 1 : 0;
+      if (aShared !== bShared) return bShared - aShared;
+      const aNever = a.hasNeverScanned ? 1 : 0;
+      const bNever = b.hasNeverScanned ? 1 : 0;
+      if (aNever !== bNever) return bNever - aNever;
       return b.districts.length - a.districts.length;
     });
 
@@ -125,16 +144,35 @@ export async function GET(request: NextRequest) {
       })
     );
 
+    let siblingCoverageCreated = 0;
+
     await queue.addAll(
       scanJobs.map(({ scan, group, representative }) => async () => {
         await runScan(scan.id);
 
         const result = await prisma.vacancyScan.findUnique({
           where: { id: scan.id },
-          select: { status: true },
+          select: { status: true, platform: true, startedAt: true, completedAt: true },
         });
 
         const isStatewide = isStatewideBoard(group.platform, group.url);
+
+        // For shared boards, create coverage records for sibling districts so
+        // the coverage metric reflects the real number of districts whose
+        // board was checked this run (not just the representative).
+        if (isStatewide && result && group.districts.length > 1) {
+          const siblingRecords = buildSiblingCoverageRecords({
+            districts: group.districts,
+            representativeLeaid: representative.leaid,
+            representativeScan: result,
+            batchId,
+          });
+          if (siblingRecords.length > 0) {
+            await prisma.vacancyScan.createMany({ data: siblingRecords });
+            siblingCoverageCreated += siblingRecords.length;
+          }
+        }
+
         results.push({
           leaid: representative.leaid,
           name: representative.name,
@@ -149,6 +187,11 @@ export async function GET(request: NextRequest) {
       return sum + (isStatewide ? group.districts.length : 1);
     }, 0);
 
+    const neverScannedGroupsPicked = batch.filter((g) => g.hasNeverScanned).length;
+    const neverScannedGroupsRemaining = sortedGroups
+      .slice(batch.length)
+      .filter((g) => g.hasNeverScanned).length;
+
     return NextResponse.json({
       batchId,
       totalStale: staleDistricts.length,
@@ -156,6 +199,9 @@ export async function GET(request: NextRequest) {
       scansRun: batch.length,
       districtsProcessed,
       remaining: Math.max(0, urlGroups.size - batch.length),
+      neverScannedGroupsPicked,
+      neverScannedGroupsRemaining,
+      siblingCoverageCreated,
       results,
     });
   } catch (error) {

--- a/src/features/vacancies/lib/__tests__/platform-detector.test.ts
+++ b/src/features/vacancies/lib/__tests__/platform-detector.test.ts
@@ -1,11 +1,26 @@
-import { describe, it, expect, vi } from "vitest";
-import { detectPlatform, isStatewideBoard, isStatewideBoardAsync } from "../platform-detector";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  detectPlatform,
+  isStatewideBoard,
+  isStatewideBoardAsync,
+  normalizeJobBoardKey,
+  __resetSharedBoardsCache,
+} from "../platform-detector";
 
+const mockFindMany = vi.fn();
 vi.mock("@/lib/prisma", () => ({
   default: {
-    $queryRaw: vi.fn().mockResolvedValue([]),
+    district: {
+      findMany: (...args: unknown[]) => mockFindMany(...args),
+    },
   },
 }));
+
+beforeEach(() => {
+  mockFindMany.mockReset();
+  mockFindMany.mockResolvedValue([]);
+  __resetSharedBoardsCache();
+});
 
 describe("detectPlatform", () => {
   describe("known platforms", () => {
@@ -105,44 +120,117 @@ describe("detectPlatform", () => {
   });
 });
 
-describe("isStatewideBoard", () => {
-  it("returns true for olas", () => {
-    expect(isStatewideBoard("olas")).toBe(true);
+describe("normalizeJobBoardKey", () => {
+  it("lowercases origin and path", () => {
+    expect(normalizeJobBoardKey("https://IOWA.SchoolSpring.com/JOBS")).toBe(
+      "https://iowa.schoolspring.com/jobs"
+    );
   });
 
-  it("returns true for schoolspring", () => {
-    expect(isStatewideBoard("schoolspring")).toBe(true);
+  it("strips trailing slash", () => {
+    expect(normalizeJobBoardKey("https://www.applitrack.com/nesdec/onlineapp/")).toBe(
+      "https://www.applitrack.com/nesdec/onlineapp"
+    );
   });
 
-  it("returns false for applitrack without URL", () => {
+  it("ignores query string and fragment", () => {
+    expect(normalizeJobBoardKey("https://www.schoolspring.com/search?q=sped#top")).toBe(
+      "https://www.schoolspring.com/search"
+    );
+  });
+
+  it("returns root origin for bare domain", () => {
+    expect(normalizeJobBoardKey("https://iowa.schoolspring.com/")).toBe(
+      "https://iowa.schoolspring.com"
+    );
+  });
+
+  it("returns null for invalid URL", () => {
+    expect(normalizeJobBoardKey("not a url")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(normalizeJobBoardKey("")).toBeNull();
+  });
+});
+
+describe("isStatewideBoard (sync)", () => {
+  it("returns false when no URL is provided", () => {
+    expect(isStatewideBoard("olas")).toBe(false);
+    expect(isStatewideBoard("schoolspring")).toBe(false);
     expect(isStatewideBoard("applitrack")).toBe(false);
+    expect(isStatewideBoard("unknown")).toBe(false);
   });
 
-  it("returns false for unknown", () => {
-    expect(isStatewideBoard("unknown")).toBe(false);
+  it("returns false before the shared-boards cache is loaded", () => {
+    expect(isStatewideBoard("schoolspring", "https://iowa.schoolspring.com/")).toBe(false);
+  });
+
+  it("returns true after cache is loaded for a URL shared by 2+ districts", async () => {
+    mockFindMany.mockResolvedValue([
+      { jobBoardUrl: "https://iowa.schoolspring.com/" },
+      { jobBoardUrl: "https://iowa.schoolspring.com/" },
+      { jobBoardUrl: "https://joplin.schoolspring.com/" },
+    ]);
+    await isStatewideBoardAsync("schoolspring", "https://iowa.schoolspring.com/"); // warms cache
+    expect(isStatewideBoard("schoolspring", "https://iowa.schoolspring.com/")).toBe(true);
+    expect(isStatewideBoard("schoolspring", "https://joplin.schoolspring.com/")).toBe(false);
   });
 });
 
 describe("isStatewideBoardAsync", () => {
-  it("returns true for olas without needing cache", async () => {
-    expect(await isStatewideBoardAsync("olas")).toBe(true);
+  it("returns true for a URL shared by 2+ districts", async () => {
+    mockFindMany.mockResolvedValue([
+      { jobBoardUrl: "https://iowa.schoolspring.com/" },
+      { jobBoardUrl: "https://iowa.schoolspring.com/" },
+    ]);
+    expect(await isStatewideBoardAsync("schoolspring", "https://iowa.schoolspring.com/")).toBe(true);
   });
 
-  it("returns true for schoolspring without needing cache", async () => {
-    expect(await isStatewideBoardAsync("schoolspring")).toBe(true);
-  });
-
-  it("returns false for unknown", async () => {
-    expect(await isStatewideBoardAsync("unknown")).toBe(false);
-  });
-
-  it("returns false for applitrack without URL", async () => {
-    expect(await isStatewideBoardAsync("applitrack")).toBe(false);
-  });
-
-  it("returns false for applitrack with a non-shared instance URL", async () => {
+  it("returns false for single-district schoolspring subdomain", async () => {
+    // Verifies the fix: richmondmo.tedk12.com was previously mis-classified as statewide
+    mockFindMany.mockResolvedValue([
+      { jobBoardUrl: "https://richmondmo.tedk12.com/hire/index.aspx" },
+      { jobBoardUrl: "https://other.tedk12.com/hire/index.aspx" },
+    ]);
     expect(
-      await isStatewideBoardAsync("applitrack", "https://www.applitrack.com/nonexistent-instance-xyz/onlineapp/")
+      await isStatewideBoardAsync("schoolspring", "https://richmondmo.tedk12.com/hire/index.aspx")
     ).toBe(false);
+  });
+
+  it("returns false for single-district olas URL", async () => {
+    mockFindMany.mockResolvedValue([
+      { jobBoardUrl: "https://onedistrict.olasjobs.org/" },
+    ]);
+    expect(await isStatewideBoardAsync("olas", "https://onedistrict.olasjobs.org/")).toBe(false);
+  });
+
+  it("returns true for shared applitrack instance URL", async () => {
+    mockFindMany.mockResolvedValue([
+      { jobBoardUrl: "https://www.applitrack.com/nesdec/onlineapp/" },
+      { jobBoardUrl: "https://www.applitrack.com/nesdec/onlineapp/" },
+    ]);
+    expect(
+      await isStatewideBoardAsync("applitrack", "https://www.applitrack.com/nesdec/onlineapp/")
+    ).toBe(true);
+  });
+
+  it("normalizes URL case and trailing slash when matching cache", async () => {
+    mockFindMany.mockResolvedValue([
+      { jobBoardUrl: "https://www.applitrack.com/nesdec/onlineapp/" },
+      { jobBoardUrl: "https://www.applitrack.com/nesdec/onlineapp/" },
+    ]);
+    expect(
+      await isStatewideBoardAsync("applitrack", "https://WWW.applitrack.com/NESDEC/onlineapp")
+    ).toBe(true);
+  });
+
+  it("returns false without URL", async () => {
+    expect(await isStatewideBoardAsync("schoolspring")).toBe(false);
+    expect(await isStatewideBoardAsync("olas")).toBe(false);
+  });
+
+  it("returns false for invalid URL", async () => {
+    expect(await isStatewideBoardAsync("schoolspring", "not a url")).toBe(false);
   });
 });

--- a/src/features/vacancies/lib/__tests__/shared-board-coverage.test.ts
+++ b/src/features/vacancies/lib/__tests__/shared-board-coverage.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { buildSiblingCoverageRecords } from "../shared-board-coverage";
+
+const baseScan = {
+  status: "completed",
+  platform: "schoolspring",
+  startedAt: new Date("2026-04-22T21:00:00Z"),
+  completedAt: new Date("2026-04-22T21:00:10Z"),
+};
+
+describe("buildSiblingCoverageRecords", () => {
+  it("returns one record per non-representative district", () => {
+    const result = buildSiblingCoverageRecords({
+      districts: [{ leaid: "A" }, { leaid: "B" }, { leaid: "C" }],
+      representativeLeaid: "A",
+      representativeScan: baseScan,
+      batchId: "batch-1",
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.leaid).sort()).toEqual(["B", "C"]);
+  });
+
+  it("copies status, platform, and timestamps from the representative", () => {
+    const [record] = buildSiblingCoverageRecords({
+      districts: [{ leaid: "A" }, { leaid: "B" }],
+      representativeLeaid: "A",
+      representativeScan: {
+        status: "completed_partial",
+        platform: "applitrack",
+        startedAt: new Date("2026-04-22T21:00:00Z"),
+        completedAt: new Date("2026-04-22T21:00:05Z"),
+      },
+      batchId: "batch-1",
+    });
+
+    expect(record).toMatchObject({
+      leaid: "B",
+      status: "completed_partial",
+      platform: "applitrack",
+      startedAt: new Date("2026-04-22T21:00:00Z"),
+      completedAt: new Date("2026-04-22T21:00:05Z"),
+      batchId: "batch-1",
+      triggeredBy: "cron",
+    });
+  });
+
+  it("returns empty when the group has only the representative", () => {
+    expect(
+      buildSiblingCoverageRecords({
+        districts: [{ leaid: "A" }],
+        representativeLeaid: "A",
+        representativeScan: baseScan,
+        batchId: "batch-1",
+      })
+    ).toEqual([]);
+  });
+
+  it("does not mark siblings as covered when the representative scan failed", () => {
+    expect(
+      buildSiblingCoverageRecords({
+        districts: [{ leaid: "A" }, { leaid: "B" }],
+        representativeLeaid: "A",
+        representativeScan: {
+          status: "failed",
+          platform: null,
+          startedAt: new Date(),
+          completedAt: null,
+        },
+        batchId: "batch-1",
+      })
+    ).toEqual([]);
+  });
+
+  it("does not mark siblings as covered when representative status is pending", () => {
+    expect(
+      buildSiblingCoverageRecords({
+        districts: [{ leaid: "A" }, { leaid: "B" }],
+        representativeLeaid: "A",
+        representativeScan: {
+          status: "pending",
+          platform: null,
+          startedAt: new Date(),
+          completedAt: null,
+        },
+        batchId: "batch-1",
+      })
+    ).toEqual([]);
+  });
+
+  it("still produces records when the representative is not at index 0", () => {
+    const result = buildSiblingCoverageRecords({
+      districts: [{ leaid: "A" }, { leaid: "B" }, { leaid: "C" }],
+      representativeLeaid: "B",
+      representativeScan: baseScan,
+      batchId: "batch-1",
+    });
+
+    expect(result.map((r) => r.leaid).sort()).toEqual(["A", "C"]);
+  });
+});

--- a/src/features/vacancies/lib/platform-detector.ts
+++ b/src/features/vacancies/lib/platform-detector.ts
@@ -21,39 +21,46 @@ export function detectPlatform(url: string): string {
 }
 
 /**
- * Returns true if the platform hosts listings from multiple districts
- * (state-wide boards or regional consortiums) rather than a single district.
+ * Normalize a job board URL into a stable key for grouping and shared-board
+ * detection. Returns lowercased `origin + pathname` with any trailing slash
+ * stripped, or null if the URL is unparseable.
  *
- * For OLAS and SchoolSpring, always true (they're inherently multi-district).
- * For AppliTrack, true when the URL belongs to a shared/regional instance
- * (multiple districts share the same AppliTrack subdirectory).
+ * Two districts whose URLs share the same normalized key point at the same
+ * board page and should be treated as sharing that board.
  */
-export function isStatewideBoard(platform: string, url?: string): boolean {
-  if (platform === "olas" || platform === "schoolspring") return true;
-
-  // AppliTrack shared instances: the URL path segment after /applitrack.com/
-  // is the instance name. If it appears in our known shared list, it's regional.
-  if (platform === "applitrack" && url) {
-    return isSharedAppliTrack(url);
+export function normalizeJobBoardKey(url: string): string | null {
+  try {
+    const u = new URL(url);
+    const key = (u.origin + u.pathname).toLowerCase();
+    return key.endsWith("/") && key.length > u.origin.length ? key.slice(0, -1) : key;
+  } catch {
+    return null;
   }
-
-  return false;
 }
 
 /**
- * Async version of isStatewideBoard that guarantees the shared AppliTrack
- * instance cache is loaded before checking. Use this in async contexts
- * (scan-runner, cron route) for reliable detection.
+ * Returns true when this URL's normalized key is shared by 2+ districts —
+ * i.e. the URL represents a board that hosts listings from multiple districts.
+ *
+ * Sync check; returns false if the shared-boards cache has not been warmed.
+ * Call `loadSharedJobBoardUrls()` first (the cron route does this at startup).
+ * For contexts where you can await, prefer `isStatewideBoardAsync`.
  */
-export async function isStatewideBoardAsync(platform: string, url?: string): Promise<boolean> {
-  if (platform === "olas" || platform === "schoolspring") return true;
+export function isStatewideBoard(_platform: string, url?: string): boolean {
+  if (!url || !sharedBoardsCache) return false;
+  const key = normalizeJobBoardKey(url);
+  return key ? sharedBoardsCache.has(key) : false;
+}
 
-  if (platform === "applitrack" && url) {
-    await loadSharedAppliTrackInstances();
-    return isSharedAppliTrack(url);
-  }
-
-  return false;
+/**
+ * Async version that guarantees the shared-boards cache is loaded before
+ * checking. Use this in async contexts (scan-runner) for reliable detection.
+ */
+export async function isStatewideBoardAsync(_platform: string, url?: string): Promise<boolean> {
+  if (!url) return false;
+  await loadSharedJobBoardUrls();
+  const key = normalizeJobBoardKey(url);
+  return key && sharedBoardsCache ? sharedBoardsCache.has(key) : false;
 }
 
 /**
@@ -70,41 +77,48 @@ export function getAppliTrackInstance(url: string): string | null {
   }
 }
 
-// Cache of shared AppliTrack instances (loaded from DB on first use)
-let sharedInstancesCache: Set<string> | null = null;
-let sharedInstancesCacheTime = 0;
+// Cache of normalized job-board URL keys that are shared by 2+ districts.
+// Loaded from DB on first use and refreshed after CACHE_TTL_MS.
+let sharedBoardsCache: Set<string> | null = null;
+let sharedBoardsCacheTime = 0;
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 
 /**
- * Load shared AppliTrack instances from DB — instances where 2+ districts
- * share the same base path. Cached for 1 hour.
+ * Load the set of normalized job-board URL keys that are shared across
+ * multiple districts. Cached for 1 hour.
  */
-export async function loadSharedAppliTrackInstances(): Promise<Set<string>> {
+export async function loadSharedJobBoardUrls(): Promise<Set<string>> {
   const now = Date.now();
-  if (sharedInstancesCache && now - sharedInstancesCacheTime < CACHE_TTL_MS) {
-    return sharedInstancesCache;
+  if (sharedBoardsCache && now - sharedBoardsCacheTime < CACHE_TTL_MS) {
+    return sharedBoardsCache;
   }
 
-  // Dynamic import to avoid circular deps
   const prisma = (await import("@/lib/prisma")).default;
+  const districts = await prisma.district.findMany({
+    where: { jobBoardUrl: { not: null } },
+    select: { jobBoardUrl: true },
+  });
 
-  const results: { instance: string }[] = await prisma.$queryRaw`
-    SELECT LOWER(SUBSTRING(job_board_url FROM 'applitrack.com/([^/]+)')) as instance
-    FROM districts
-    WHERE job_board_url LIKE '%applitrack.com%'
-    GROUP BY LOWER(SUBSTRING(job_board_url FROM 'applitrack.com/([^/]+)'))
-    HAVING COUNT(*) > 1
-  `;
+  const counts = new Map<string, number>();
+  for (const d of districts) {
+    if (!d.jobBoardUrl) continue;
+    const key = normalizeJobBoardKey(d.jobBoardUrl);
+    if (!key) continue;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
 
-  sharedInstancesCache = new Set(results.map((r) => r.instance).filter(Boolean));
-  sharedInstancesCacheTime = now;
-  return sharedInstancesCache;
+  const shared = new Set<string>();
+  for (const [key, count] of counts) {
+    if (count > 1) shared.add(key);
+  }
+
+  sharedBoardsCache = shared;
+  sharedBoardsCacheTime = now;
+  return shared;
 }
 
-function isSharedAppliTrack(url: string): boolean {
-  // Synchronous check against cache — if cache isn't loaded yet, return false
-  // (the async loadSharedAppliTrackInstances should be called at scan startup)
-  const instance = getAppliTrackInstance(url);
-  if (!instance || !sharedInstancesCache) return false;
-  return sharedInstancesCache.has(instance);
+/** Test-only: clear the shared-boards cache so each test starts cold. */
+export function __resetSharedBoardsCache(): void {
+  sharedBoardsCache = null;
+  sharedBoardsCacheTime = 0;
 }

--- a/src/features/vacancies/lib/post-processor.ts
+++ b/src/features/vacancies/lib/post-processor.ts
@@ -3,7 +3,6 @@ import type { RawVacancy } from "./parsers/types";
 import { filterExcludedRoles } from "./role-filter";
 import { categorize } from "./categorizer";
 import { generateFingerprint } from "./fingerprint";
-import { isStatewideBoard } from "./platform-detector";
 
 interface ProcessResult {
   vacancyCount: number;
@@ -85,17 +84,14 @@ function normalizeDistrictName(name: string): string {
 
 /**
  * Check whether a vacancy's employer name matches the expected district.
- * Returns true (verified) for district-scoped platforms or when employer matches.
- * Returns false only when a state-wide board provides an employer that clearly
- * doesn't match the target district.
+ * Only called from redistribution paths (isOwnDistrict=false), where the
+ * vacancy came from a shared board and the target district must be verified
+ * by employer-name match.
  */
 function checkDistrictAffinity(
   raw: RawVacancy,
-  platform: string,
   districtName: string | undefined
 ): boolean {
-  // District-specific platforms — always trust
-  if (!isStatewideBoard(platform)) return true;
   // No district name to compare against — benefit of the doubt
   if (!districtName) return true;
   // No employer info available — benefit of the doubt
@@ -217,7 +213,7 @@ export async function processVacancies(
     if (fullmindRelevant) fullmindRelevantCount++;
 
     const datePosted = parseDatePosted(raw.datePosted);
-    const districtVerified = isOwnDistrict || checkDistrictAffinity(raw, platform, districtName);
+    const districtVerified = isOwnDistrict || checkDistrictAffinity(raw, districtName);
 
     // Upsert vacancy
     await prisma.vacancy.upsert({

--- a/src/features/vacancies/lib/shared-board-coverage.ts
+++ b/src/features/vacancies/lib/shared-board-coverage.ts
@@ -1,0 +1,52 @@
+/**
+ * When the cron scans a shared job board (one URL covering multiple districts),
+ * it creates a single `VacancyScan` record for the "representative" district
+ * that is actually fetched. Vacancies for sibling districts are redistributed
+ * via `groupByDistrict` but no scan record is written for them — which makes
+ * the coverage metric undercount shared-board scans.
+ *
+ * This builds the sibling `VacancyScan` rows so that each district whose board
+ * was successfully checked this run gets counted as covered. Returns empty when
+ * the representative scan did not succeed (we don't claim coverage on failure).
+ */
+
+export interface SiblingCoverageInput {
+  districts: Array<{ leaid: string }>;
+  representativeLeaid: string;
+  representativeScan: {
+    status: string;
+    platform: string | null;
+    startedAt: Date;
+    completedAt: Date | null;
+  };
+  batchId: string;
+}
+
+export interface SiblingCoverageRecord {
+  leaid: string;
+  status: string;
+  platform: string | null;
+  startedAt: Date;
+  completedAt: Date | null;
+  triggeredBy: string;
+  batchId: string;
+}
+
+export function buildSiblingCoverageRecords(
+  input: SiblingCoverageInput
+): SiblingCoverageRecord[] {
+  const { status } = input.representativeScan;
+  if (status !== "completed" && status !== "completed_partial") return [];
+
+  return input.districts
+    .filter((d) => d.leaid !== input.representativeLeaid)
+    .map((d) => ({
+      leaid: d.leaid,
+      status,
+      platform: input.representativeScan.platform,
+      startedAt: input.representativeScan.startedAt,
+      completedAt: input.representativeScan.completedAt,
+      triggeredBy: "cron",
+      batchId: input.batchId,
+    }));
+}


### PR DESCRIPTION
Bundled release of two unrelated changes for a single deploy. See separate sections below.

---

## 1. fix(vacancies): unstarve never-scanned districts in cron scheduler

Vacancy coverage had been flat for weeks. The hourly cron was cycling through already-covered districts and never reaching the 7,428 districts whose job boards had never been scanned.

**Root cause** — two compounding issues in the cron's group-selection:

1. **`isStatewideBoard` was over-broad**: every `*.schoolspring.com`, `*.tedk12.com`, and `*.olasjobs.org` URL was classified as "statewide", producing 2,301 SW groups of which 1,944 (84%) were actually single-district subdomains (e.g. `joplin.schoolspring.com`). The cron sort prioritized SW groups first, so those 1,891 mis-tagged groups cycled back into staleness every 7 days and consumed the entire 840-scans/week budget. Never-scanned AppliTrack districts sat at queue position 1,891+.
2. **Shared-board scans only created one `VacancyScan` record** (for the representative district), so the coverage metric undercounted shared-board coverage by `group.size - 1`.

### Fixes

- **Rewrite `isStatewideBoard`** to require a URL and check against a cache of normalized job-board keys shared by ≥2 districts. `loadSharedJobBoardUrls()` generalizes the previous AppliTrack-only approach. Reduces SW groups from 2,301 → ~594.
- **Add `hasNeverScanned` boost** to the cron sort so groups containing a never-scanned district rank above repeat rescans. First never-scanned group moves from queue position 1,891 → 0.
- **Add `buildSiblingCoverageRecords` helper** + wire into cron: after a shared-board scan succeeds, create `VacancyScan` rows for every other district in the group.
- **Remove redundant `isStatewideBoard(platform)` short-circuit** in post-processor; the call site's `isOwnDistrict=false` already establishes redistribution context.

### Before / after (live prod DB)

| Metric | Before | After |
|---|---|---|
| Groups classified "shared" | 2,301 (1,944 misclassified) | 594 (real multi-district) |
| First never-scanned group queue position | 1,891 (unreachable) | 0 |
| Groups with a never-scanned district | starved | 6,759 reachable |
| Top pick | tedk12 single-district subdomain | `wecan.waspa.org` (110 WI districts) |
| Coverage bump per shared-board scan | 1 district | group size |

### Vacancies test plan

- [x] 453 vacancies unit tests pass (36 rewritten, 6 new)
- [x] Type-check clean
- [ ] After deploy: cron response shows `neverScannedGroupsPicked > 0` and `siblingCoverageCreated > 0`
- [ ] After deploy: admin vacancy stats `coveragePct` begins rising within 24h
- [ ] After deploy: spot-check a shared-board scan (`wecan.waspa.org` is the likely first pick) — confirm N `vacancy_scans` rows with the same `batch_id`

---

## 2. feat(states): add State Board + Dept of Ed URL columns

(Originally opened as #128, closed in favor of this bundled release.)

- Adds `board_of_ed_url` and `dept_of_ed_url` columns to the `states` table so reps can jump straight from a state view to the governance body (State Board of Education) or operational agency (SEA) website.
- New seed script at `scripts/seed-state-ed-urls.ts` populates 57 rows (50 states + DC + 5 territories + BIE). Skips the `US` rollup and `IT` (International).
- URLs were verified against live sites — 25 BOE URLs + 3 DOE URLs corrected vs. the initial draft to account for 2023-2026 site migrations (e.g. OH board spun off to `sboe.ohio.gov` in 2023, PA consolidated to `pa.gov`, TX spun off `sboe.texas.gov`, OK moved to `oklahoma.gov`, AL migrated to `alabamaachieves.org`, NM to `web.ped.nm.gov`).

### State BOE/DOE notes

- Migration has already been applied to production via `prisma migrate deploy` (teammate local DBs will catch up on next `prisma migrate dev`).
- `MN` and `WI` have `boardOfEdUrl = null` intentionally — neither has a separate state board.
- Territories (AS, GU, MP, PR, VI) and BIE have DOE only.
- One URL is a calibrated guess: `NM` BOE at `web.ped.nm.gov/bureaus/public-education-commission/`. If it 404s in practice, fall back to PED homepage.
- Out-of-scope observation: pre-existing schema drift — `states.icp_avg_score` is in `schema.prisma` but not in the DB. Worked around in the seed script with raw SQL; worth a separate cleanup.

### State BOE/DOE test plan

- [ ] Verify migration applies cleanly on a fresh local DB (`prisma migrate dev`)
- [ ] Spot-check a handful of BOE links render correctly (CA, TX, NY, OH, PA)
- [ ] Confirm UI consumers (if any added later) handle the `null` BOE cases for MN/WI/territories

🤖 Generated with [Claude Code](https://claude.com/claude-code)