### PR TITLE
feat(resources): add Pricing, Service Model, and Take pages

### DIFF
--- a/src/features/shared/components/views/ResourcesView.tsx
+++ b/src/features/shared/components/views/ResourcesView.tsx
@@ -3,7 +3,10 @@
 import { useState } from "react";
 import DealQualifyingPage from "./resources/DealQualifyingPage";
 import OrgChartPage from "./resources/OrgChartPage";
+import OurServiceModelPage from "./resources/OurServiceModelPage";
+import PricingAndPackagingPage from "./resources/PricingAndPackagingPage";
 import UnderstandingLeaderboardPage from "./resources/UnderstandingLeaderboardPage";
+import UnderstandingTakePage from "./resources/UnderstandingTakePage";
 
 // ── Resource page registry ────────────────────────────────────────────────────
 // Add new pages here — one line per resource. The sidebar groups by category.
@@ -18,6 +21,9 @@ interface ResourcePage {
 const RESOURCE_PAGES: ResourcePage[] = [
   { id: "deal-qualifying", label: "Deal Qualifying", category: "Sales Enablement", component: DealQualifyingPage },
   { id: "understanding-leaderboard", label: "Understanding the Leaderboard", category: "Training", component: UnderstandingLeaderboardPage },
+  { id: "pricing-and-packaging", label: "Pricing & Packaging", category: "Training", component: PricingAndPackagingPage },
+  { id: "understanding-take", label: "Understanding Take", category: "Training", component: UnderstandingTakePage },
+  { id: "our-service-model", label: "Our Service Model", category: "Product", component: OurServiceModelPage },
   { id: "org-chart", label: "Org Chart", category: "Team", component: OrgChartPage },
 ];
 

--- a/src/features/shared/components/views/resources/OurServiceModelPage.tsx
+++ b/src/features/shared/components/views/resources/OurServiceModelPage.tsx
@@ -1,0 +1,731 @@
+"use client";
+
+import {
+  GraduationCap,
+  Sparkles,
+  BookOpen,
+  BookMarked,
+  HelpCircle,
+  LayoutGrid,
+  Check,
+  House,
+  Users,
+  PauseCircle,
+  UsersRound,
+  Accessibility,
+  ClipboardCheck,
+  Info,
+  FileText,
+  BarChart3,
+  NotebookPen,
+  GitBranch,
+  UserCheck,
+} from "lucide-react";
+import type { ComponentType, SVGProps } from "react";
+
+// ── Table of contents ────────────────────────────────────────────────────────
+
+const TOC = [
+  { id: "overview", label: "Overview" },
+  { id: "core-credit-bearing", label: "Core Credit-Bearing" },
+  { id: "supplemental", label: "Supplemental" },
+  { id: "supports-glossary", label: "What Supports Mean" },
+  { id: "comparison-matrix", label: "Comparison Matrix" },
+];
+
+// ── Service data ─────────────────────────────────────────────────────────────
+
+type LucideIcon = ComponentType<SVGProps<SVGSVGElement>>;
+type Tri = "yes" | "no" | "note";
+type TofR = "Required" | "Optional";
+
+type Service = {
+  name: string;
+  icon: LucideIcon;
+  delivery: string[]; // e.g. ["1:1", "SG", "WC"]
+  challenge: string;
+  solution: string;
+  tofr: TofR;
+  lms: Tri;
+  exitTickets: Tri;
+  miniLesson: Tri;
+  swdProgress: Tri;
+  gradebooks: Tri;
+  gradebooksNote?: string;
+  instructionType: "Core Credit-Bearing" | "Supplemental";
+};
+
+const CORE_SERVICES: Service[] = [
+  {
+    name: "Homebound",
+    icon: House,
+    delivery: ["1:1"],
+    challenge:
+      "Mental and physical health challenges, as well as long-term suspension, can prevent students from attending school in a traditional setting. As a result, students often fall behind and require personalized, student-centered instruction.",
+    solution:
+      "Our educators collaborate directly with the teacher of record to deliver instruction fully aligned with the school's curriculum, ensuring students stay on track. When needed, we also provide customized, state-standards-aligned curriculum to meet students at their current level. Our educator pool includes certified teachers experienced in supporting students with disabilities and other specialized needs.",
+    tofr: "Required",
+    lms: "yes",
+    exitTickets: "yes",
+    miniLesson: "yes",
+    swdProgress: "yes",
+    gradebooks: "yes",
+    instructionType: "Core Credit-Bearing",
+  },
+  {
+    name: "Whole Class Virtual Instruction",
+    icon: Users,
+    delivery: ["SG", "WC"],
+    challenge:
+      "Staffing shortages can leave schools unable to offer certain courses or reliant on uncertified educators.",
+    solution:
+      "Fullmind ensures every course is led by a certified educator through high-quality virtual instruction. We specialize in supporting hard-to-staff subject areas so schools can maintain full course offerings.",
+    tofr: "Optional",
+    lms: "yes",
+    exitTickets: "yes",
+    miniLesson: "yes",
+    swdProgress: "yes",
+    gradebooks: "yes",
+    instructionType: "Core Credit-Bearing",
+  },
+  {
+    name: "Credit Recovery",
+    icon: GraduationCap,
+    delivery: ["1:1", "SG", "WC"],
+    challenge:
+      "Dropout rates and academic underperformance increase when students struggle with coursework, absenteeism, or behavioral challenges.",
+    solution:
+      "Our flexible credit recovery program helps students earn missed credits and regain academic progress. Live, state-certified educators provide real-time instruction aligned with the school's curriculum. We track attendance, participation, and progress, keeping schools informed every step of the way.",
+    tofr: "Required",
+    lms: "yes",
+    exitTickets: "yes",
+    miniLesson: "yes",
+    swdProgress: "no",
+    gradebooks: "yes",
+    instructionType: "Core Credit-Bearing",
+  },
+  {
+    name: "Suspension Alternative",
+    icon: PauseCircle,
+    delivery: ["WC", "SG"],
+    challenge:
+      "Rising suspension rates disrupt learning, negatively impact academic progress, and raise concerns around students' mental and emotional wellbeing.",
+    solution:
+      "Our carefully selected educators partner with classroom teachers to ensure students remain on track academically during suspension periods. We also incorporate social-emotional learning supports to promote a smooth and successful transition back into the classroom.",
+    tofr: "Optional",
+    lms: "yes",
+    exitTickets: "yes",
+    miniLesson: "yes",
+    swdProgress: "no",
+    gradebooks: "yes",
+    instructionType: "Core Credit-Bearing",
+  },
+  {
+    name: "Hybrid Staffing",
+    icon: UsersRound,
+    delivery: ["1:1", "SG", "WC"],
+    challenge:
+      "Staffing shortages can prevent schools from fully supporting specialized programs, including services for students with disabilities, resource rooms, and self-contained classrooms.",
+    solution:
+      "Our hybrid educators collaborate closely with school leaders and in-person facilitators, integrating seamlessly into the school team. Together, we ensure students receive consistent, high-quality instruction and support.",
+    tofr: "Optional",
+    lms: "no",
+    exitTickets: "no",
+    miniLesson: "no",
+    swdProgress: "no",
+    gradebooks: "note",
+    gradebooksNote: "School's platform",
+    instructionType: "Core Credit-Bearing",
+  },
+];
+
+const SUPPLEMENTAL_SERVICES: Service[] = [
+  {
+    name: "Tutoring",
+    icon: BookOpen,
+    delivery: ["1:1", "SG", "WC"],
+    challenge:
+      "Some students require additional support or acceleration beyond what classroom teachers can provide within the school day.",
+    solution:
+      "We deliver high-dosage, K–12 tutoring through frequent, data-driven sessions led by certified educators. Programs are customized to each school's goals and designed to accelerate student growth.",
+    tofr: "Optional",
+    lms: "yes",
+    exitTickets: "yes",
+    miniLesson: "yes",
+    swdProgress: "no",
+    gradebooks: "no",
+    instructionType: "Supplemental",
+  },
+  {
+    name: "Resource Room",
+    icon: Accessibility,
+    delivery: ["1:1", "SG", "WC"],
+    challenge:
+      "Shortages of certified special-education teachers make it challenging for schools to meet IEP requirements and ensure FAPE compliance.",
+    solution:
+      "Our educators design instruction aligned to each student's unique IEP goals, providing required accommodations and targeted support. We share regular progress-monitoring updates to ensure transparency and alignment with school teams and families.",
+    tofr: "Optional",
+    lms: "yes",
+    exitTickets: "yes",
+    miniLesson: "yes",
+    swdProgress: "yes",
+    gradebooks: "no",
+    instructionType: "Supplemental",
+  },
+  {
+    name: "Test Prep",
+    icon: ClipboardCheck,
+    delivery: ["1:1", "SG", "WC"],
+    challenge:
+      "Students may struggle on high-stakes assessments due to content gaps, limited familiarity with test structure, or testing anxiety.",
+    solution:
+      "Our educators deliver data-driven instruction to close academic gaps, build confidence, and prepare students for success on high-stakes assessments.",
+    tofr: "Optional",
+    lms: "yes",
+    exitTickets: "yes",
+    miniLesson: "yes",
+    swdProgress: "no",
+    gradebooks: "no",
+    instructionType: "Supplemental",
+  },
+  {
+    name: "Homework Help",
+    icon: HelpCircle,
+    delivery: ["1:1", "SG", "WC"],
+    challenge:
+      "Students may need additional guidance to complete assignments successfully or benefit from extra practice with a certified teacher.",
+    solution:
+      "We provide virtual after-school homework support, where certified educators offer real-time assistance tailored to students' immediate needs.",
+    tofr: "Optional",
+    lms: "yes",
+    exitTickets: "yes",
+    miniLesson: "yes",
+    swdProgress: "no",
+    gradebooks: "no",
+    instructionType: "Supplemental",
+  },
+  {
+    name: "iTutor",
+    icon: Sparkles,
+    delivery: ["1:1"],
+    challenge:
+      "Families often seek supplemental instruction to support students who need additional academic growth or enrichment.",
+    solution:
+      "Our educators create fully customized instruction plans based on each student's needs, helping them build skills, confidence, and measurable academic progress.",
+    tofr: "Optional",
+    lms: "no",
+    exitTickets: "no",
+    miniLesson: "no",
+    swdProgress: "no",
+    gradebooks: "no",
+    instructionType: "Supplemental",
+  },
+];
+
+// ── Shared bits ──────────────────────────────────────────────────────────────
+
+function DeliveryChip({ label }: { label: string }) {
+  return (
+    <span className="inline-block rounded-full bg-[#F7F5FA] text-[#403770] text-[10px] font-semibold uppercase tracking-wider px-2 py-0.5 border border-[#E2DEEC]">
+      {label}
+    </span>
+  );
+}
+
+function TofRPill({ value }: { value: TofR }) {
+  return value === "Required" ? (
+    <span className="inline-flex items-center rounded-full bg-[#403770] text-white text-[10px] font-semibold uppercase tracking-wider px-2 py-0.5">
+      Required
+    </span>
+  ) : (
+    <span className="inline-flex items-center rounded-full bg-[#F7F5FA] text-[#8A80A8] text-[10px] font-semibold uppercase tracking-wider px-2 py-0.5 border border-[#E2DEEC]">
+      Optional
+    </span>
+  );
+}
+
+function TriCell({ value, note }: { value: Tri; note?: string }) {
+  if (value === "yes") return <Check className="w-4 h-4 text-[#69B34A] inline-block" />;
+  if (value === "note")
+    return <span className="text-[11px] italic text-[#8A80A8]">{note ?? "—"}</span>;
+  return <span className="text-[#A69DC0]">—</span>;
+}
+
+function FeatureStripItem({
+  icon: Ic,
+  label,
+  value,
+  note,
+}: {
+  icon: LucideIcon;
+  label: string;
+  value: Tri;
+  note?: string;
+}) {
+  const active = value === "yes";
+  const isNote = value === "note";
+  return (
+    <div
+      className={`flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 ${
+        active
+          ? "bg-[#F7FFF2] border border-[#8AC670]/50"
+          : "bg-[#F7F5FA] border border-[#E2DEEC]"
+      }`}
+    >
+      <Ic className={`w-3.5 h-3.5 ${active ? "text-[#69B34A]" : "text-[#A69DC0]"}`} />
+      <span className={`text-[11px] font-medium ${active ? "text-[#403770]" : "text-[#8A80A8]"}`}>
+        {label}
+      </span>
+      {isNote ? (
+        <span className="text-[10px] italic text-[#8A80A8]">({note})</span>
+      ) : active ? (
+        <Check className="w-3 h-3 text-[#69B34A]" />
+      ) : (
+        <span className="text-[#A69DC0] text-xs leading-none">—</span>
+      )}
+    </div>
+  );
+}
+
+function ServiceCard({ service }: { service: Service }) {
+  const Icon = service.icon;
+  return (
+    <div className="rounded-xl border border-[#E2DEEC] bg-white px-6 py-5">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4 mb-4 flex-wrap">
+        <div className="flex items-center gap-3">
+          <div className="w-9 h-9 rounded-lg bg-[#F7F5FA] flex items-center justify-center flex-shrink-0">
+            <Icon className="w-4 h-4 text-[#403770]" />
+          </div>
+          <h3 className="text-base font-bold text-[#403770]">{service.name}</h3>
+        </div>
+        <div className="flex items-center gap-1.5 flex-wrap">
+          {service.delivery.map((d) => (
+            <DeliveryChip key={d} label={d} />
+          ))}
+        </div>
+      </div>
+
+      {/* Challenge */}
+      <p className="text-[10px] font-semibold text-[#8A80A8] uppercase tracking-wider mb-1.5">
+        The Challenge
+      </p>
+      <p className="text-sm text-[#6E6390] leading-relaxed mb-4">{service.challenge}</p>
+
+      {/* Solution */}
+      <p className="text-[10px] font-semibold text-[#8A80A8] uppercase tracking-wider mb-1.5">
+        How We Solve It
+      </p>
+      <p className="text-sm text-[#6E6390] leading-relaxed mb-5">{service.solution}</p>
+
+      {/* Feature strip */}
+      <div className="border-t border-[#E2DEEC] pt-4">
+        <div className="flex items-center gap-2 mb-2">
+          <span className="text-[10px] font-semibold text-[#8A80A8] uppercase tracking-wider">
+            Teacher of Record
+          </span>
+          <TofRPill value={service.tofr} />
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          <FeatureStripItem icon={FileText} label="LMS" value={service.lms} />
+          <FeatureStripItem icon={ClipboardCheck} label="Exit Tickets" value={service.exitTickets} />
+          <FeatureStripItem icon={NotebookPen} label="Mini Lesson" value={service.miniLesson} />
+          <FeatureStripItem icon={BarChart3} label="SWD Progress" value={service.swdProgress} />
+          <FeatureStripItem
+            icon={GraduationCap}
+            label="Gradebooks"
+            value={service.gradebooks}
+            note={service.gradebooksNote}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Glossary ─────────────────────────────────────────────────────────────────
+
+const GLOSSARY: Array<{ icon: LucideIcon; label: string; desc: string }> = [
+  {
+    icon: Users,
+    label: "Delivery Type",
+    desc: "How students are grouped during instruction: 1:1 (one student with one educator), SG (small group), WC (whole class).",
+  },
+  {
+    icon: GitBranch,
+    label: "Instruction Type",
+    desc: "Either Core Credit-Bearing (earns credit for seat time in a course) or Supplemental (supports the student's existing schedule without granting credit).",
+  },
+  {
+    icon: UserCheck,
+    label: "Teacher of Record",
+    desc: "Whether the service requires a school-side teacher of record to co-own instruction. Required for credit-bearing services; optional for most supplemental services.",
+  },
+  {
+    icon: FileText,
+    label: "LMS",
+    desc: "Fullmind's learning management system. Where lessons, assignments, and materials live for the student and educator.",
+  },
+  {
+    icon: ClipboardCheck,
+    label: "Exit Tickets",
+    desc: "Short end-of-session checks for understanding. Captured in the LMS and used to inform the next session.",
+  },
+  {
+    icon: NotebookPen,
+    label: "Mini Lesson",
+    desc: "A focused, short-form lesson embedded in each session to address a specific skill or standard.",
+  },
+  {
+    icon: BarChart3,
+    label: "SWD Progress Monitoring",
+    desc: "Regular tracking of progress toward IEP goals for students with disabilities, shared with school teams.",
+  },
+  {
+    icon: GraduationCap,
+    label: "Fullmind Gradebooks",
+    desc: "Fullmind-hosted gradebooks for services where grading happens in our platform. For Hybrid Staffing, grading happens on the school's platform instead.",
+  },
+];
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+export default function OurServiceModelPage() {
+  return (
+    <div className="flex gap-10">
+      {/* ── Sticky table of contents ──────────────────────────────────── */}
+      <nav className="hidden xl:block w-44 flex-shrink-0">
+        <div className="sticky top-6">
+          <p className="text-[10px] font-semibold text-[#8A80A8] uppercase tracking-wider mb-3">
+            On this page
+          </p>
+          <div className="space-y-0.5">
+            {TOC.map((item) => (
+              <a
+                key={item.id}
+                href={`#${item.id}`}
+                className="block text-xs text-[#6E6390] hover:text-[#403770] py-1.5 border-l-2 border-transparent hover:border-[#F37167] pl-3 transition-colors duration-100"
+              >
+                {item.label}
+              </a>
+            ))}
+          </div>
+        </div>
+      </nav>
+
+      {/* ── Main content ──────────────────────────────────────────────── */}
+      <div className="flex-1 min-w-0 max-w-4xl">
+        {/* Hero */}
+        <div className="mb-10">
+          <div className="flex items-center gap-4 mb-4">
+            <div className="w-12 h-12 rounded-2xl bg-[#F7F5FA] flex items-center justify-center">
+              <GraduationCap className="w-6 h-6 text-[#403770]" />
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold text-[#403770]">Our Service Model</h1>
+              <p className="text-sm text-[#8A80A8] mt-0.5">
+                How we structure services, what each one solves, and the supports that come with them
+              </p>
+            </div>
+          </div>
+          <div className="rounded-xl bg-gradient-to-r from-[#F7F5FA] to-[#EFEDF5] p-5 border border-[#E2DEEC]">
+            <p className="text-sm text-[#6E6390] leading-relaxed">
+              This page outlines our current service model — the core structures and supports that
+              guide our work. While this reflects our standard approach,{" "}
+              <strong className="text-[#403770]">
+                flexibility remains a cornerstone of our partnerships
+              </strong>
+              . We collaborate closely with each school to adapt processes, tools, and roles so they
+              align with the school&apos;s specific goals, context, and priorities.
+            </p>
+          </div>
+        </div>
+
+        {/* ════════════════════════════════════════════════════════════════ */}
+        {/* OVERVIEW */}
+        {/* ════════════════════════════════════════════════════════════════ */}
+        <section id="overview" className="mb-12 scroll-mt-6">
+          <h2 className="text-lg font-bold text-[#403770] mb-4 flex items-center gap-2">
+            <Sparkles className="w-5 h-5 text-[#403770]" />
+            Built to Adapt to Each School
+          </h2>
+          <p className="text-sm text-[#6E6390] leading-relaxed mb-5">
+            Fullmind organizes services into two high-level buckets:{" "}
+            <strong className="text-[#403770]">Core Credit-Bearing Instruction</strong> (earning
+            credit for seat time and full courses) and{" "}
+            <strong className="text-[#403770]">Supplemental Instruction</strong> (additional
+            support, intervention, and enrichment alongside the student&apos;s normal schedule).
+            Each service has a default model with built-in supports. Each service is also
+            customizable.
+          </p>
+
+          {/* Adaptability callout */}
+          <div className="rounded-xl bg-[#fef1f0] border border-[#f58d85] border-l-4 border-l-[#F37167] px-6 py-5 mb-6">
+            <div className="flex items-start gap-3">
+              <Sparkles className="w-5 h-5 text-[#F37167] flex-shrink-0 mt-0.5" />
+              <div>
+                <p className="text-base font-bold text-[#F37167] mb-1">
+                  Adaptability is central to how we work.
+                </p>
+                <p className="text-sm text-[#6E6390] leading-relaxed">
+                  The structures below are our default. We tailor tools, roles, and
+                  responsibilities to align with each school&apos;s unique needs and priorities.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Two-bucket intro grid */}
+          <div className="grid grid-cols-2 gap-4">
+            <div className="rounded-xl border border-[#E2DEEC] p-5 bg-white">
+              <div className="w-9 h-9 rounded-lg bg-[#F7F5FA] flex items-center justify-center mb-3">
+                <BookOpen className="w-4 h-4 text-[#403770]" />
+              </div>
+              <h3 className="text-sm font-semibold text-[#403770] mb-1">
+                Core Credit-Bearing Instruction
+              </h3>
+              <p className="text-xs text-[#8A80A8] leading-relaxed mb-3">
+                Services that grant credit for seat time in a course. Usually require a teacher of
+                record partnership.
+              </p>
+              <p className="text-[10px] font-semibold text-[#8A80A8] uppercase tracking-wider mb-1">
+                Includes
+              </p>
+              <p className="text-xs text-[#6E6390]">
+                Homebound · Whole Class Virtual Instruction · Credit Recovery · Suspension
+                Alternative · Hybrid Staffing
+              </p>
+            </div>
+            <div className="rounded-xl border border-[#E2DEEC] p-5 bg-white">
+              <div className="w-9 h-9 rounded-lg bg-[#F7F5FA] flex items-center justify-center mb-3">
+                <BookMarked className="w-4 h-4 text-[#403770]" />
+              </div>
+              <h3 className="text-sm font-semibold text-[#403770] mb-1">
+                Supplemental Instruction
+              </h3>
+              <p className="text-xs text-[#8A80A8] leading-relaxed mb-3">
+                Services that support or accelerate the student&apos;s existing schedule — not
+                replacing courses.
+              </p>
+              <p className="text-[10px] font-semibold text-[#8A80A8] uppercase tracking-wider mb-1">
+                Includes
+              </p>
+              <p className="text-xs text-[#6E6390]">
+                Tutoring · Resource Room · Test Prep · Homework Help · iTutor
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <div className="border-t border-[#E2DEEC] mb-12" />
+
+        {/* ════════════════════════════════════════════════════════════════ */}
+        {/* CORE CREDIT-BEARING */}
+        {/* ════════════════════════════════════════════════════════════════ */}
+        <section id="core-credit-bearing" className="mb-12 scroll-mt-6">
+          <h2 className="text-lg font-bold text-[#403770] mb-4 flex items-center gap-2">
+            <BookOpen className="w-5 h-5 text-[#403770]" />
+            Core Credit-Bearing Services
+          </h2>
+          <p className="text-sm text-[#6E6390] leading-relaxed mb-6">
+            Services that deliver full courses and count toward seat-time credit. Each is led by a
+            certified educator.
+          </p>
+
+          <div className="space-y-4">
+            {CORE_SERVICES.map((s) => (
+              <ServiceCard key={s.name} service={s} />
+            ))}
+          </div>
+        </section>
+
+        <div className="border-t border-[#E2DEEC] mb-12" />
+
+        {/* ════════════════════════════════════════════════════════════════ */}
+        {/* SUPPLEMENTAL */}
+        {/* ════════════════════════════════════════════════════════════════ */}
+        <section id="supplemental" className="mb-12 scroll-mt-6">
+          <h2 className="text-lg font-bold text-[#403770] mb-4 flex items-center gap-2">
+            <BookMarked className="w-5 h-5 text-[#403770]" />
+            Supplemental Services
+          </h2>
+          <p className="text-sm text-[#6E6390] leading-relaxed mb-6">
+            Services that support or accelerate students alongside their regular schedule. Not
+            credit-bearing.
+          </p>
+
+          <div className="space-y-4">
+            {SUPPLEMENTAL_SERVICES.map((s) => (
+              <ServiceCard key={s.name} service={s} />
+            ))}
+          </div>
+        </section>
+
+        <div className="border-t border-[#E2DEEC] mb-12" />
+
+        {/* ════════════════════════════════════════════════════════════════ */}
+        {/* GLOSSARY */}
+        {/* ════════════════════════════════════════════════════════════════ */}
+        <section id="supports-glossary" className="mb-12 scroll-mt-6">
+          <h2 className="text-lg font-bold text-[#403770] mb-4 flex items-center gap-2">
+            <Info className="w-5 h-5 text-[#403770]" />
+            What These Supports Mean
+          </h2>
+          <p className="text-sm text-[#6E6390] leading-relaxed mb-6">
+            A quick reference for the features and supports called out on each service.
+          </p>
+
+          <div className="grid grid-cols-2 gap-3">
+            {GLOSSARY.map(({ icon: Ic, label, desc }) => (
+              <div key={label} className="rounded-xl border border-[#E2DEEC] bg-white p-4">
+                <div className="flex items-center gap-2 mb-1.5">
+                  <div className="w-7 h-7 rounded-lg bg-[#F7F5FA] flex items-center justify-center flex-shrink-0">
+                    <Ic className="w-3.5 h-3.5 text-[#403770]" />
+                  </div>
+                  <span className="text-sm font-semibold text-[#403770]">{label}</span>
+                </div>
+                <p className="text-xs text-[#8A80A8] leading-relaxed">{desc}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <div className="border-t border-[#E2DEEC] mb-12" />
+
+        {/* ════════════════════════════════════════════════════════════════ */}
+        {/* COMPARISON MATRIX */}
+        {/* ════════════════════════════════════════════════════════════════ */}
+        <section id="comparison-matrix" className="mb-12 scroll-mt-6">
+          <h2 className="text-lg font-bold text-[#403770] mb-4 flex items-center gap-2">
+            <LayoutGrid className="w-5 h-5 text-[#403770]" />
+            Service Comparison Matrix
+          </h2>
+          <p className="text-sm text-[#6E6390] leading-relaxed mb-5">
+            Quick at-a-glance comparison across all services and supports.
+          </p>
+
+          <div className="border border-[#E2DEEC] rounded-xl overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-[#F7F5FA] text-[10px] font-semibold text-[#8A80A8] uppercase tracking-wider">
+                  <th className="text-left px-3 py-3">Service</th>
+                  <th className="text-left px-3 py-3 w-28">Delivery</th>
+                  <th className="text-left px-3 py-3 w-24">TofR</th>
+                  <th className="text-center px-3 py-3 w-14">LMS</th>
+                  <th className="text-center px-3 py-3 w-16">Exit</th>
+                  <th className="text-center px-3 py-3 w-16">Mini</th>
+                  <th className="text-center px-3 py-3 w-16">SWD</th>
+                  <th className="text-center px-3 py-3 w-28">Gradebooks</th>
+                </tr>
+              </thead>
+              <tbody>
+                {/* Core group header */}
+                <tr className="bg-[#fef1f0]">
+                  <td
+                    colSpan={8}
+                    className="px-3 py-2 text-[10px] font-bold text-[#F37167] uppercase tracking-wider"
+                  >
+                    Core Credit-Bearing
+                  </td>
+                </tr>
+                {CORE_SERVICES.map((s, i) => (
+                  <tr
+                    key={s.name}
+                    className={`border-t border-[#E2DEEC] ${i % 2 === 1 ? "bg-[#F7F5FA]/40" : ""}`}
+                  >
+                    <td className="px-3 py-3 font-medium text-[#403770]">
+                      {s.name === "Suspension Alternative" ? (
+                        <>
+                          Suspension Alternative
+                          <span className="text-xs text-[#8A80A8] font-normal">
+                            {" "}
+                            (Virtual Classroom)
+                          </span>
+                        </>
+                      ) : (
+                        s.name
+                      )}
+                    </td>
+                    <td className="px-3 py-3 text-xs text-[#6E6390]">{s.delivery.join(", ")}</td>
+                    <td className="px-3 py-3">
+                      <TofRPill value={s.tofr} />
+                    </td>
+                    <td className="px-3 py-3 text-center">
+                      <TriCell value={s.lms} />
+                    </td>
+                    <td className="px-3 py-3 text-center">
+                      <TriCell value={s.exitTickets} />
+                    </td>
+                    <td className="px-3 py-3 text-center">
+                      <TriCell value={s.miniLesson} />
+                    </td>
+                    <td className="px-3 py-3 text-center">
+                      <TriCell value={s.swdProgress} />
+                    </td>
+                    <td className="px-3 py-3 text-center">
+                      <TriCell value={s.gradebooks} note={s.gradebooksNote} />
+                    </td>
+                  </tr>
+                ))}
+
+                {/* Supplemental group header */}
+                <tr className="bg-[#fef1f0] border-t border-[#E2DEEC]">
+                  <td
+                    colSpan={8}
+                    className="px-3 py-2 text-[10px] font-bold text-[#F37167] uppercase tracking-wider"
+                  >
+                    Supplemental
+                  </td>
+                </tr>
+                {SUPPLEMENTAL_SERVICES.map((s, i) => (
+                  <tr
+                    key={s.name}
+                    className={`border-t border-[#E2DEEC] ${i % 2 === 1 ? "bg-[#F7F5FA]/40" : ""}`}
+                  >
+                    <td className="px-3 py-3 font-medium text-[#403770]">{s.name}</td>
+                    <td className="px-3 py-3 text-xs text-[#6E6390]">{s.delivery.join(", ")}</td>
+                    <td className="px-3 py-3">
+                      <TofRPill value={s.tofr} />
+                    </td>
+                    <td className="px-3 py-3 text-center">
+                      <TriCell value={s.lms} />
+                    </td>
+                    <td className="px-3 py-3 text-center">
+                      <TriCell value={s.exitTickets} />
+                    </td>
+                    <td className="px-3 py-3 text-center">
+                      <TriCell value={s.miniLesson} />
+                    </td>
+                    <td className="px-3 py-3 text-center">
+                      <TriCell value={s.swdProgress} />
+                    </td>
+                    <td className="px-3 py-3 text-center">
+                      <TriCell value={s.gradebooks} note={s.gradebooksNote} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Legend */}
+          <div className="mt-3 flex items-center gap-4 text-xs text-[#8A80A8]">
+            <div className="flex items-center gap-1.5">
+              <Check className="w-3.5 h-3.5 text-[#69B34A]" />
+              <span>Included</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className="text-[#A69DC0]">—</span>
+              <span>Not included</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className="text-xs italic text-[#8A80A8]">italic</span>
+              <span>Special note</span>
+            </div>
+          </div>
+        </section>
+
+      </div>
+    </div>
+  );
+}

--- a/src/features/shared/components/views/resources/PricingAndPackagingPage.tsx
+++ b/src/features/shared/components/views/resources/PricingAndPackagingPage.tsx
@@ -1,0 +1,987 @@
+"use client";
+
+import {
+  DollarSign,
+  Target,
+  Layers,
+  Calculator,
+  ArrowRightLeft,
+  Scale,
+  Percent,
+  TrendingDown,
+  PlayCircle,
+  FileText,
+  LayoutGrid,
+  ClipboardCheck,
+  Check,
+  Lightbulb,
+  ExternalLink,
+} from "lucide-react";
+
+// ── Table of contents ────────────────────────────────────────────────────────
+
+const TOC = [
+  { id: "overview", label: "Overview" },
+  { id: "services", label: "Services We Offer" },
+  { id: "take", label: "How Take is Calculated" },
+  { id: "mapping", label: "Elevate → Fullmind" },
+  { id: "model-comparison", label: "Pricing Model Comparison" },
+  { id: "discounting", label: "Discounting Guidelines" },
+  { id: "vs-in-person", label: "Fullmind vs. In-Person" },
+  { id: "videos", label: "Videos & Deep Dives" },
+];
+
+// ── Rate card data ───────────────────────────────────────────────────────────
+
+const LIVE_STAFFING = [
+  {
+    role: "Standard Educator — Standard Subject — Full Time",
+    perDay: "$500.23",
+    year180: "$90,040.70",
+    year190: "$95,042.96",
+    desc: "General education instructor for core subjects (math, science, social studies, ELA, elementary). Works 4+ hours per billable day, including prep time (standard day is 6.5 hours).",
+  },
+  {
+    role: "Premium Educator — Standard Subject — Full Time",
+    perDay: "$515.23",
+    year180: "$92,741.92",
+    year190: "$97,894.26",
+    desc: "Instructor with dual certification and/or master's degree. Teaches core subjects. Works 4+ hours per billable day, including prep time.",
+  },
+  {
+    role: "Premium Educator — Premium Subject — Full Time",
+    perDay: "$500.23",
+    year180: "$90,040.70",
+    year190: "$95,042.96",
+    desc: "Instructor with dual certification and/or master's degree. Teaches specialized subjects beyond the four core areas (specific sciences, electives).",
+  },
+  {
+    role: "Specialized Educator — Standard Subject — Full Time",
+    perDay: "$546.36",
+    year180: "$98,345.43",
+    year190: "$103,809.07",
+    desc: "Instructor certified to support SWD, MLL/Bilingual, and AP programs. Teaches core subjects.",
+  },
+  {
+    role: "Specialized Educator — Premium Subject — Full Time",
+    perDay: "$560.93",
+    year180: "$100,967.97",
+    year190: "$106,577.30",
+    desc: "Instructor certified to support SWD, MLL/Bilingual, and AP programs. Teaches specialized subjects.",
+  },
+  {
+    role: "Full Time — School Psychologist",
+    perDay: "$595.11",
+    year180: "$107,120.00",
+    year190: "$113,071.11",
+    desc: "Mental health services tailored to student needs/IEP. Includes individual or group counseling and social work.",
+  },
+];
+
+const INSTRUCTIONAL = [
+  { service: "Homebound + Homebased", oneOne: "$73.16", oneTen: "—", oneThirty: "—", desc: "First-time instruction in specific subject areas for seat-time credit; minimum 10 hours per subject, per student." },
+  { service: "Credit Recovery", oneOne: "$73.16", oneTen: "$157.57", oneThirty: "$281.38", desc: "Instruction for earning credit for seat time. Hours determined by school personnel." },
+  { service: "Tutoring", oneOne: "$73.16", oneTen: "$140.69", oneThirty: "$225.10", desc: "Supplemental remedial or enrichment instruction, during or after school." },
+  { service: "Resource Room", oneOne: "$73.16", oneTen: "$140.69", oneThirty: "$225.10", desc: "Mandated academic support for students with disabilities by a certified special educator." },
+  { service: "Test Prep", oneOne: "$106.92", oneTen: "$168.83", oneThirty: "$230.73", desc: "Individualized synchronous instruction for standardized test prep." },
+  { service: "Homework Help", oneOne: "$73.16", oneTen: "$140.69", oneThirty: "$225.10", desc: "Drop-in help for assignments brought to the session." },
+  { service: "Whole Class Virtual Instruction", oneOne: "—", oneTen: "$168.83", oneThirty: "$281.38", desc: "Structured small-group or whole-class instruction in specific subject areas, potentially for seat-time credit." },
+  { service: "Suspension Alternatives", oneOne: "—", oneTen: "—", oneThirty: "$281.38", desc: "Safe, supportive virtual solution for short-term suspensions (up to 10 school days, up to 15 students per class)." },
+  { service: "Virtual Medical Classroom", oneOne: "—", oneTen: "—", oneThirty: "$281.38", desc: "Virtual instruction for students with medical needs (up to 15 students per class)." },
+];
+
+const ADD_ONS = [
+  { name: "Content", fee: "$11.15", when: "Partner requests Fullmind educator provide content and curriculum for instruction." },
+  { name: "Advanced Placement, College Level, IB", fee: "$22.29", when: "Session delivering AP, college-level, or IB instruction." },
+  { name: "Assessments", fee: "$44.58", when: "Additional pre- or post-testing; recommended for 12+ week programs." },
+  { name: "Co-Teaching", fee: "$78.02", when: "Fullmind educator co-teaches virtually with a district educator." },
+  { name: "Educator Prep", fee: "$83.59", when: "Additional prep time (lesson planning, grading, data analysis). Billed as one hour per four hours of instruction." },
+  { name: "Multilingual Learners", fee: "$55.73", when: "Supporting multilingual learners in Instructional Services." },
+  { name: "Students with Disabilities", fee: "$22.29", when: "Supporting students with disabilities in Instructional Services." },
+];
+
+// ── Elevate mapping data ─────────────────────────────────────────────────────
+
+// Plum chips = main Fullmind services. Coral chips = add-ons / specialty modifiers.
+type ChipKind = "service" | "addOn";
+type Mapping = { elevate: string; fullmind: Array<{ label: string; kind: ChipKind }> };
+type Bucket = { id: string; name: string; items: Mapping[] };
+
+const BUCKETS: Bucket[] = [
+  {
+    id: "whole-class-standard",
+    name: "Whole Class Instruction (Standard Pricing)",
+    items: [
+      {
+        elevate: "Core Subjects, World Languages, Gifted and Talented",
+        fullmind: [
+          { label: "Live Staffing", kind: "service" },
+          { label: "Homebound", kind: "service" },
+          { label: "Whole Class Instruction", kind: "service" },
+          { label: "Credit Recovery", kind: "service" },
+        ],
+      },
+    ],
+  },
+  {
+    id: "whole-class-specialized",
+    name: "Whole Class or Supplemental Instruction — Specialized Credentials",
+    items: [
+      {
+        elevate: "Diverse Learning (SPED + ELL + Bilingual CORE)",
+        fullmind: [
+          { label: "Live Staffing", kind: "service" },
+          { label: "Homebound", kind: "service" },
+          { label: "Whole Class Instruction", kind: "service" },
+          { label: "Credit Recovery", kind: "service" },
+          { label: "Multilingual Learners", kind: "addOn" },
+          { label: "Students with Disabilities", kind: "addOn" },
+        ],
+      },
+      {
+        elevate: "SDI",
+        fullmind: [
+          { label: "Content Add On", kind: "addOn" },
+          { label: "Homebound + Content", kind: "addOn" },
+          { label: "Whole Class + Content", kind: "addOn" },
+          { label: "Students with Disabilities + Content", kind: "addOn" },
+        ],
+      },
+      {
+        elevate: "Case Management",
+        fullmind: [
+          { label: "Live Staffing", kind: "service" },
+          { label: "Homebound", kind: "service" },
+          { label: "Whole Class Instruction", kind: "service" },
+          { label: "Credit Recovery", kind: "service" },
+          { label: "Multilingual Learners", kind: "addOn" },
+        ],
+      },
+      {
+        elevate: "Self Contained",
+        fullmind: [
+          { label: "Live Staffing", kind: "service" },
+          { label: "Homebound", kind: "service" },
+          { label: "Whole Class Instruction", kind: "service" },
+          { label: "Credit Recovery", kind: "service" },
+          { label: "Students with Disabilities", kind: "addOn" },
+        ],
+      },
+    ],
+  },
+  {
+    id: "diverse-learning",
+    name: "Diverse Learning",
+    items: [
+      {
+        elevate: "Resource Room",
+        fullmind: [
+          { label: "Live Staffing", kind: "service" },
+          { label: "Students with Disabilities", kind: "addOn" },
+          { label: "Resource Room", kind: "service" },
+        ],
+      },
+    ],
+  },
+  {
+    id: "supplemental",
+    name: "Supplemental",
+    items: [
+      {
+        elevate: "SG Core Subjects",
+        fullmind: [
+          { label: "Live Staffing", kind: "service" },
+          { label: "Tutoring", kind: "service" },
+        ],
+      },
+      {
+        elevate: "Core Subject Intervention",
+        fullmind: [
+          { label: "Live Staffing", kind: "service" },
+          { label: "Students with Disabilities", kind: "addOn" },
+          { label: "Tutoring", kind: "service" },
+        ],
+      },
+      {
+        elevate: "World Language",
+        fullmind: [
+          { label: "Live Staffing", kind: "service" },
+          { label: "Multilingual Learners", kind: "addOn" },
+          { label: "Tutoring", kind: "service" },
+        ],
+      },
+      {
+        elevate: "Core Enrichment",
+        fullmind: [
+          { label: "Live Staffing", kind: "service" },
+          { label: "Tutoring", kind: "service" },
+        ],
+      },
+      {
+        elevate: "Tailor Made",
+        fullmind: [
+          { label: "Live Staffing", kind: "service" },
+          { label: "Whole Class Instruction", kind: "service" },
+          { label: "Tutoring", kind: "service" },
+        ],
+      },
+    ],
+  },
+  {
+    id: "enrichment",
+    name: "Enrichment",
+    items: [
+      {
+        elevate: "College, Career, & Technology",
+        fullmind: [
+          { label: "Live Staffing", kind: "service" },
+          { label: "Whole Class Instruction", kind: "service" },
+          { label: "Tutoring", kind: "service" },
+          { label: "State Test Prep", kind: "service" },
+        ],
+      },
+    ],
+  },
+  {
+    id: "summer",
+    name: "Summer",
+    items: [
+      {
+        elevate: "Summer Core",
+        fullmind: [
+          { label: "Live Staffing", kind: "service" },
+          { label: "Homebound", kind: "service" },
+          { label: "Whole Class Instruction", kind: "service" },
+          { label: "Credit Recovery", kind: "service" },
+        ],
+      },
+      {
+        elevate: "Summer Enrichment",
+        fullmind: [
+          { label: "Live Staffing", kind: "service" },
+          { label: "Whole Class Instruction", kind: "service" },
+          { label: "Tutoring", kind: "service" },
+        ],
+      },
+    ],
+  },
+  {
+    id: "professional-learning",
+    name: "Professional Learning",
+    items: [
+      {
+        elevate: "Co-Teaching",
+        fullmind: [
+          { label: "Live Staffing", kind: "service" },
+          { label: "Students with Disabilities", kind: "addOn" },
+          { label: "Paramentoring", kind: "service" },
+        ],
+      },
+      {
+        elevate: "Mentorship",
+        fullmind: [{ label: "Paramentoring", kind: "service" }],
+      },
+    ],
+  },
+];
+
+// ── Pricing model matrix ─────────────────────────────────────────────────────
+
+const MODEL_BENEFITS: Array<{ label: string; elevate: boolean; wci: boolean; staffing: boolean }> = [
+  { label: "Consistent high-quality, trained, experienced educators", elevate: true, wci: true, staffing: true },
+  { label: "Teachers enter grades, lesson plan, and differentiate instruction", elevate: true, wci: true, staffing: true },
+  { label: "Pay only for the instruction you need", elevate: true, wci: true, staffing: false },
+  { label: "Teacher participates in PLCs at no extra cost, provides additional intervention services, homework help, etc.", elevate: false, wci: false, staffing: true },
+  { label: "School/district can easily change how the teacher is utilized", elevate: false, wci: false, staffing: true },
+  { label: "Maximize instructional time and resources", elevate: false, wci: false, staffing: true },
+];
+
+// ── Discount tiers ───────────────────────────────────────────────────────────
+
+const DISCOUNT_TIERS = [
+  { length: "30–44 Days", discount: "−0%", color: "#8A80A8", bg: "#F7F5FA" },
+  { length: "45–59 Days", discount: "−5%", color: "#6EA3BE", bg: "#EEF4F9" },
+  { length: "60–89 Days", discount: "−10%", color: "#5B8FAF", bg: "#e8f1f5" },
+  { length: "90–149 Days", discount: "−15%", color: "#F37167", bg: "#FEF2F1" },
+  { length: "150+ Days", discount: "−20%", color: "#D4A843", bg: "#FFF8EE" },
+];
+
+// ── In-person cost comparison ────────────────────────────────────────────────
+
+const COST_COMPARE = [
+  { bucket: "Teacher Salary (13 years avg experience in GA)", inPerson: "$69,196", fullmind: "$95,043.70" },
+  { bucket: "Benefits (pension/retirement, benefits)", inPerson: "$27,354", fullmind: "—" },
+  { bucket: "Class Coverage Stipend (.2 extra pay for planning period/incentives)", inPerson: "$8,000", fullmind: "—" },
+  { bucket: "Substitutes (assuming ~10 days absence)", inPerson: "$1,267", fullmind: "—" },
+  { bucket: "Recruitment, Onboarding & Professional Development", inPerson: "$15,000", fullmind: "—" },
+];
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+export default function PricingAndPackagingPage() {
+  return (
+    <div className="flex gap-10">
+      {/* ── Sticky table of contents ──────────────────────────────────── */}
+      <nav className="hidden xl:block w-44 flex-shrink-0">
+        <div className="sticky top-6">
+          <p className="text-[10px] font-semibold text-[#8A80A8] uppercase tracking-wider mb-3">On this page</p>
+          <div className="space-y-0.5">
+            {TOC.map((item) => (
+              <a
+                key={item.id}
+                href={`#${item.id}`}
+                className="block text-xs text-[#6E6390] hover:text-[#403770] py-1.5 border-l-2 border-transparent hover:border-[#F37167] pl-3 transition-colors duration-100"
+              >
+                {item.label}
+              </a>
+            ))}
+          </div>
+        </div>
+      </nav>
+
+      {/* ── Main content ──────────────────────────────────────────────── */}
+      <div className="flex-1 min-w-0 max-w-4xl">
+        {/* Hero */}
+        <div className="mb-10">
+          <div className="flex items-center gap-4 mb-4">
+            <div className="w-12 h-12 rounded-2xl bg-[#F7F5FA] flex items-center justify-center">
+              <DollarSign className="w-6 h-6 text-[#403770]" />
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold text-[#403770]">Pricing &amp; Packaging at Fullmind</h1>
+              <p className="text-sm text-[#8A80A8] mt-0.5">
+                How we price services, calculate Take, and position against alternatives
+              </p>
+              <p className="text-[10px] text-[#A69DC0] uppercase tracking-wider mt-1">Updated April 21, 2026</p>
+            </div>
+          </div>
+          <div className="rounded-xl bg-gradient-to-r from-[#F7F5FA] to-[#EFEDF5] p-5 border border-[#E2DEEC]">
+            <p className="text-sm text-[#6E6390] leading-relaxed">
+              Fullmind offers certified, live educators to schools and districts. Pricing is a lever
+              that keeps the business healthy, the market accessible, and educators paid
+              competitively — so every role at Fullmind has a stake in how it works. After this page
+              you should know <strong className="text-[#403770]">what services we sell</strong>,{" "}
+              <strong className="text-[#403770]">how they&apos;re priced</strong>,{" "}
+              <strong className="text-[#403770]">how Take is calculated</strong>, and how to position
+              all of this with partners.
+            </p>
+          </div>
+        </div>
+
+        {/* ════════════════════════════════════════════════════════════════ */}
+        {/* OVERVIEW */}
+        {/* ════════════════════════════════════════════════════════════════ */}
+        <section id="overview" className="mb-12 scroll-mt-6">
+          <h2 className="text-lg font-bold text-[#403770] mb-4 flex items-center gap-2">
+            <Target className="w-5 h-5 text-[#403770]" />
+            Why Pricing Matters to You
+          </h2>
+          <p className="text-sm text-[#6E6390] leading-relaxed mb-4">
+            Pricing is a key lever for the health of our business. Ensuring pricing is competitive
+            in the market but accessible for our customers allows us to support students and pay
+            educators competitive rates.
+          </p>
+          <p className="text-sm text-[#6E6390] leading-relaxed mb-6">
+            Everyone at Fullmind is responsible for their role&apos;s ROI. As you read this page,
+            think about how your workstreams touch the pieces covered below.
+          </p>
+
+          <div className="grid grid-cols-3 gap-4">
+            {[
+              { icon: Layers, title: "Know the services", desc: "What Fullmind offers and how each is priced." },
+              { icon: Calculator, title: "Understand Take", desc: "How Take is calculated and why it's the business metric we run on." },
+              { icon: Target, title: "Position with partners", desc: "How to message pricing to new prospects and current Elevate customers." },
+            ].map(({ icon: Ic, title, desc }) => (
+              <div key={title} className="rounded-xl border border-[#E2DEEC] p-5 bg-white">
+                <div className="w-9 h-9 rounded-lg bg-[#F7F5FA] flex items-center justify-center mb-3">
+                  <Ic className="w-4 h-4 text-[#403770]" />
+                </div>
+                <h3 className="text-sm font-semibold text-[#403770] mb-1">{title}</h3>
+                <p className="text-xs text-[#8A80A8] leading-relaxed">{desc}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <div className="border-t border-[#E2DEEC] mb-12" />
+
+        {/* ════════════════════════════════════════════════════════════════ */}
+        {/* SERVICES */}
+        {/* ════════════════════════════════════════════════════════════════ */}
+        <section id="services" className="mb-12 scroll-mt-6">
+          <h2 className="text-lg font-bold text-[#403770] mb-4 flex items-center gap-2">
+            <Layers className="w-5 h-5 text-[#403770]" />
+            Services We Offer
+          </h2>
+          <p className="text-sm text-[#6E6390] leading-relaxed mb-8">
+            Fullmind services fall into three categories:{" "}
+            <strong className="text-[#403770]">Live Staffing</strong>,{" "}
+            <strong className="text-[#403770]">Instructional Services</strong>, and{" "}
+            <strong className="text-[#403770]">Per-Session Add-Ons</strong>. All services are
+            customizable to meet the unique needs of each school and its students.
+          </p>
+
+          {/* Live Staffing */}
+          <h3 className="text-sm font-bold text-[#403770] mb-1">Live Staffing</h3>
+          <p className="text-xs text-[#8A80A8] italic mb-4">
+            Full-time or part-time placements (part-time is a 0.6 multiplier).
+          </p>
+
+          <div className="border border-[#E2DEEC] rounded-xl overflow-hidden mb-4">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-[#F7F5FA] text-[10px] font-semibold text-[#8A80A8] uppercase tracking-wider">
+                  <th className="text-left px-4 py-3">Role</th>
+                  <th className="text-right px-4 py-3 w-24">Price/Day</th>
+                  <th className="text-right px-4 py-3 w-28">180-Day Year</th>
+                  <th className="text-right px-4 py-3 w-28">190-Day Year</th>
+                </tr>
+              </thead>
+              <tbody>
+                {LIVE_STAFFING.map((row, i) => (
+                  <tr
+                    key={row.role}
+                    className={`border-t border-[#E2DEEC] ${i % 2 === 1 ? "bg-[#F7F5FA]/40" : ""}`}
+                  >
+                    <td className="px-4 py-3 align-top">
+                      <div className="font-medium text-[#403770] mb-0.5">{row.role}</div>
+                      <div className="text-xs text-[#8A80A8] leading-relaxed">{row.desc}</div>
+                    </td>
+                    <td className="px-4 py-3 text-right align-top font-semibold text-[#403770] tabular-nums">
+                      {row.perDay}
+                    </td>
+                    <td className="px-4 py-3 text-right align-top font-semibold text-[#403770] tabular-nums">
+                      {row.year180}
+                    </td>
+                    <td className="px-4 py-3 text-right align-top font-semibold text-[#403770] tabular-nums">
+                      {row.year190}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Staffing fee tiles */}
+          <div className="grid grid-cols-2 gap-3 mb-5">
+            {[
+              { label: "Staffing Fee", fee: "$5,627.54", desc: "One-time fee added per teacher, invoiceable up front." },
+              { label: "Return Educator Fee", fee: "$2,813.77", desc: "One-time fee added per teacher, invoiceable up front." },
+            ].map((t) => (
+              <div key={t.label} className="rounded-xl border border-[#E2DEEC] bg-white px-5 py-4">
+                <div className="flex items-baseline justify-between mb-1">
+                  <span className="text-sm font-semibold text-[#403770]">{t.label}</span>
+                  <span className="text-sm font-bold text-[#F37167] tabular-nums">{t.fee}</span>
+                </div>
+                <p className="text-xs text-[#8A80A8] leading-relaxed">{t.desc}</p>
+              </div>
+            ))}
+          </div>
+
+          {/* Instructional Services */}
+          <h3 className="text-sm font-bold text-[#403770] mb-1">Instructional Services</h3>
+          <p className="text-xs text-[#8A80A8] italic mb-4">
+            Hourly rates, priced by group size (1:1, 1:10, 1:30+).
+          </p>
+
+          <div className="border border-[#E2DEEC] rounded-xl overflow-hidden mb-4">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-[#F7F5FA] text-[10px] font-semibold text-[#8A80A8] uppercase tracking-wider">
+                  <th className="text-left px-4 py-3">Service</th>
+                  <th className="text-right px-4 py-3 w-20">1:1</th>
+                  <th className="text-right px-4 py-3 w-20">1:10</th>
+                  <th className="text-right px-4 py-3 w-20">1:30+</th>
+                </tr>
+              </thead>
+              <tbody>
+                {INSTRUCTIONAL.map((row, i) => (
+                  <tr
+                    key={row.service}
+                    className={`border-t border-[#E2DEEC] ${i % 2 === 1 ? "bg-[#F7F5FA]/40" : ""}`}
+                  >
+                    <td className="px-4 py-3 align-top">
+                      <div className="font-medium text-[#403770] mb-0.5">{row.service}</div>
+                      <div className="text-xs text-[#8A80A8] leading-relaxed">{row.desc}</div>
+                    </td>
+                    <td className="px-4 py-3 text-right align-top font-semibold text-[#403770] tabular-nums">
+                      {row.oneOne}
+                    </td>
+                    <td className="px-4 py-3 text-right align-top font-semibold text-[#403770] tabular-nums">
+                      {row.oneTen}
+                    </td>
+                    <td className="px-4 py-3 text-right align-top font-semibold text-[#403770] tabular-nums">
+                      {row.oneThirty}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Group size callout */}
+          <div className="rounded-xl bg-[#e8f1f5] border border-[#8bb5cb] px-5 py-4 mb-10">
+            <div className="flex items-center gap-2 mb-2">
+              <Lightbulb className="w-4 h-4 text-[#6EA3BE]" />
+              <p className="text-sm font-semibold text-[#6EA3BE]">Why prices change by group size</p>
+            </div>
+            <p className="text-sm text-[#6E6390] leading-relaxed">
+              The more students in the group, the more differentiation and data collection the
+              educator has to do. We pay educators more for larger groups to reflect the higher
+              demands — and our pricing reflects that.
+            </p>
+          </div>
+
+          {/* Add-ons */}
+          <h3 className="text-sm font-bold text-[#403770] mb-1">Per-Session Add-Ons</h3>
+          <p className="text-xs text-[#8A80A8] italic mb-4">
+            Fees that stack onto a base service to cover specialized situations.
+          </p>
+
+          <div className="grid grid-cols-2 gap-3">
+            {ADD_ONS.map((a) => (
+              <div key={a.name} className="rounded-xl border border-[#E2DEEC] bg-white px-5 py-4">
+                <div className="flex items-baseline justify-between gap-3 mb-1">
+                  <span className="text-sm font-semibold text-[#403770]">{a.name}</span>
+                  <span className="text-sm font-bold text-[#F37167] tabular-nums flex-shrink-0">{a.fee}</span>
+                </div>
+                <p className="text-xs text-[#8A80A8] leading-relaxed">{a.when}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <div className="border-t border-[#E2DEEC] mb-12" />
+
+        {/* ════════════════════════════════════════════════════════════════ */}
+        {/* TAKE */}
+        {/* ════════════════════════════════════════════════════════════════ */}
+        <section id="take" className="mb-12 scroll-mt-6">
+          <h2 className="text-lg font-bold text-[#403770] mb-4 flex items-center gap-2">
+            <Calculator className="w-5 h-5 text-[#403770]" />
+            How Take is Calculated
+          </h2>
+
+          {/* Formula tile */}
+          <div className="rounded-xl bg-gradient-to-r from-[#F7F5FA] to-[#EFEDF5] border border-[#E2DEEC] py-6 px-5 mb-6 flex items-center justify-center">
+            <div className="flex items-center gap-3 flex-wrap justify-center">
+              <span className="text-lg font-bold text-[#403770]">Take</span>
+              <span className="text-lg font-bold text-[#A69DC0]">=</span>
+              <span className="text-lg font-bold text-[#403770]">Revenue</span>
+              <span className="text-lg font-bold text-[#A69DC0]">−</span>
+              <span className="text-lg font-bold text-[#403770]">Educator Compensation</span>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4 mb-5">
+            <div className="rounded-xl border border-[#E2DEEC] p-5 bg-white">
+              <h3 className="text-sm font-semibold text-[#403770] mb-2">Live Staffing</h3>
+              <p className="text-sm text-[#6E6390] leading-relaxed">
+                Operations targets <strong className="text-[#403770]">40–50%</strong> of sale price
+                for educator compensation, aiming for the bottom of that band and flexing up when a
+                position is hard to staff. In one-off situations, pay can flex up to{" "}
+                <strong className="text-[#403770]">60%</strong> of sale price.
+              </p>
+            </div>
+            <div className="rounded-xl border border-[#E2DEEC] p-5 bg-white">
+              <h3 className="text-sm font-semibold text-[#403770] mb-2">Instructional Services</h3>
+              <p className="text-sm text-[#6E6390] leading-relaxed">
+                Operations maintains pay bands per subject, calculated monthly based on service- and
+                setting-specific margins plus demand/educator pool per certification. Pay bands are
+                revisited monthly and may shift seasonally with student enrollment.
+              </p>
+            </div>
+          </div>
+
+          <div className="rounded-xl border border-[#E2DEEC] border-l-4 border-l-[#F37167] bg-white px-5 py-4">
+            <p className="text-sm text-[#6E6390] leading-relaxed">
+              Want a deeper dive with real examples? See the{" "}
+              <a
+                href="https://docs.google.com/document/d/1Uua3gNggqBWprK-LMzk4RE3wkHpUS1puyL0Wm43WgR8/edit?usp=sharing"
+                target="_blank"
+                rel="noreferrer"
+                className="text-[#F37167] underline hover:text-[#cc5d54]"
+              >
+                historic Take calculations deep-dive
+              </a>
+              .
+            </p>
+          </div>
+        </section>
+
+        <div className="border-t border-[#E2DEEC] mb-12" />
+
+        {/* ════════════════════════════════════════════════════════════════ */}
+        {/* ELEVATE MAPPING */}
+        {/* ════════════════════════════════════════════════════════════════ */}
+        <section id="mapping" className="mb-12 scroll-mt-6">
+          <h2 className="text-lg font-bold text-[#403770] mb-4 flex items-center gap-2">
+            <ArrowRightLeft className="w-5 h-5 text-[#403770]" />
+            Elevate → Fullmind Mapping
+          </h2>
+          <p className="text-sm text-[#6E6390] leading-relaxed mb-6">
+            Every Elevate K-12 product offering is covered by Fullmind — usually with additional
+            options and flexibility. Here&apos;s how Elevate offerings map to the Fullmind services
+            and add-ons that replace or extend them.
+          </p>
+
+          <div className="space-y-6">
+            {BUCKETS.map((bucket) => (
+              <div key={bucket.id}>
+                <p className="text-[10px] font-semibold text-[#8A80A8] uppercase tracking-wider mb-3">
+                  {bucket.name}
+                </p>
+                <div className={`grid gap-3 ${bucket.items.length >= 2 ? "grid-cols-2" : "grid-cols-1"}`}>
+                  {bucket.items.map((item) => (
+                    <div key={item.elevate} className="rounded-xl border border-[#E2DEEC] bg-white px-5 py-4">
+                      <h3 className="text-sm font-semibold text-[#403770] mb-3">{item.elevate}</h3>
+                      <div className="flex flex-wrap gap-1.5">
+                        {item.fullmind.map((chip) => (
+                          <span
+                            key={chip.label}
+                            className={`rounded-full px-3 py-1 text-xs font-medium ${
+                              chip.kind === "service"
+                                ? "bg-[#F7F5FA] text-[#403770] border border-[#E2DEEC]"
+                                : "bg-[#FEF2F1] text-[#F37167] border border-[#f58d85]/40"
+                            }`}
+                          >
+                            {chip.label}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-6 flex items-center gap-3 px-4 py-3 text-xs text-[#8A80A8]">
+            <div className="flex items-center gap-1.5">
+              <span className="inline-block w-3 h-3 rounded-full bg-[#F7F5FA] border border-[#E2DEEC]" />
+              <span>Main service</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className="inline-block w-3 h-3 rounded-full bg-[#FEF2F1] border border-[#f58d85]/40" />
+              <span>Add-on / specialty modifier</span>
+            </div>
+          </div>
+
+          <div className="rounded-xl border border-[#E2DEEC] border-l-4 border-l-[#F37167] bg-white px-5 py-4 mt-4">
+            <p className="text-sm text-[#6E6390] leading-relaxed">
+              Want the full side-by-side breakdown with the problems each service solves? See the{" "}
+              <a
+                href="https://docs.google.com/document/d/1nvPMCzhx4YUxOsq2R_XhomtA9w3nAe491WpNzAcMxPQ/edit?usp=sharing"
+                target="_blank"
+                rel="noreferrer"
+                className="text-[#F37167] underline hover:text-[#cc5d54]"
+              >
+                detailed service breakdown
+              </a>
+              .
+            </p>
+          </div>
+        </section>
+
+        <div className="border-t border-[#E2DEEC] mb-12" />
+
+        {/* ════════════════════════════════════════════════════════════════ */}
+        {/* MODEL COMPARISON */}
+        {/* ════════════════════════════════════════════════════════════════ */}
+        <section id="model-comparison" className="mb-12 scroll-mt-6">
+          <h2 className="text-lg font-bold text-[#403770] mb-4 flex items-center gap-2">
+            <Scale className="w-5 h-5 text-[#403770]" />
+            Pricing Model Comparison
+          </h2>
+          <p className="text-sm text-[#6E6390] leading-relaxed mb-5">
+            Elevate billed per period. Fullmind offers both per-period{" "}
+            <strong className="text-[#403770]">Whole Class Virtual Instruction</strong> and
+            full-time / part-time <strong className="text-[#403770]">Live Staffing</strong>. Each
+            has a different value proposition for the customer.
+          </p>
+
+          <div className="border border-[#E2DEEC] rounded-xl overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-[#F7F5FA] text-[10px] font-semibold text-[#8A80A8] uppercase tracking-wider">
+                  <th className="text-left px-4 py-3">Benefit to the Customer</th>
+                  <th className="text-center px-4 py-3 w-36">Elevate Per Period</th>
+                  <th className="text-center px-4 py-3 w-40">Whole Class Instruction</th>
+                  <th className="text-center px-4 py-3 w-32 bg-[#fef1f0] text-[#F37167]">Live Staffing</th>
+                </tr>
+              </thead>
+              <tbody>
+                {MODEL_BENEFITS.map((row, i) => (
+                  <tr
+                    key={row.label}
+                    className={`border-t border-[#E2DEEC] ${i % 2 === 1 ? "bg-[#F7F5FA]/40" : ""}`}
+                  >
+                    <td className="px-4 py-3 text-[#6E6390]">{row.label}</td>
+                    <td className="px-4 py-3 text-center">
+                      {row.elevate ? (
+                        <Check className="w-4 h-4 text-[#69B34A] inline-block" />
+                      ) : (
+                        <span className="text-[#C2BBD4]">—</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-center">
+                      {row.wci ? (
+                        <Check className="w-4 h-4 text-[#69B34A] inline-block" />
+                      ) : (
+                        <span className="text-[#C2BBD4]">—</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-center bg-[#fef1f0]/40">
+                      {row.staffing ? (
+                        <Check className="w-4 h-4 text-[#69B34A] inline-block" />
+                      ) : (
+                        <span className="text-[#C2BBD4]">—</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <div className="border-t border-[#E2DEEC] mb-12" />
+
+        {/* ════════════════════════════════════════════════════════════════ */}
+        {/* DISCOUNTING */}
+        {/* ════════════════════════════════════════════════════════════════ */}
+        <section id="discounting" className="mb-12 scroll-mt-6">
+          <h2 className="text-lg font-bold text-[#403770] mb-4 flex items-center gap-2">
+            <Percent className="w-5 h-5 text-[#403770]" />
+            Discounting Guidelines
+          </h2>
+          <p className="text-sm text-[#6E6390] leading-relaxed mb-8">
+            Sales reps use two types of discounting to move deals forward.
+          </p>
+
+          {/* Placement length discounts */}
+          <h3 className="text-sm font-bold text-[#403770] mb-1">Placement-Length Discounts</h3>
+          <p className="text-sm text-[#6E6390] leading-relaxed mb-5">
+            We incentivize longer placements because they correlate with higher teacher and student
+            satisfaction, and greater consistency for everyone involved.
+          </p>
+
+          <div className="rounded-xl border border-[#E2DEEC] overflow-hidden mb-10">
+            {DISCOUNT_TIERS.map((tier, i) => (
+              <div
+                key={tier.length}
+                className={`flex items-center gap-4 px-5 py-4 ${i > 0 ? "border-t border-[#E2DEEC]" : ""}`}
+                style={{ backgroundColor: tier.bg }}
+              >
+                <div
+                  className="w-10 h-10 rounded-full flex items-center justify-center text-xs font-bold flex-shrink-0"
+                  style={{ backgroundColor: `${tier.color}20`, color: tier.color }}
+                >
+                  {tier.discount.replace("−", "-")}
+                </div>
+                <div className="flex-1">
+                  <span className="text-sm font-semibold text-[#403770]">{tier.length}</span>
+                </div>
+                <span className="text-sm font-bold tabular-nums" style={{ color: tier.color }}>
+                  {tier.discount}
+                </span>
+              </div>
+            ))}
+          </div>
+
+          {/* Discretionary */}
+          <h3 className="text-sm font-bold text-[#403770] mb-1">Discretionary Discounting</h3>
+          <p className="text-sm text-[#6E6390] leading-relaxed mb-5">
+            For all customers and quotes, sales reps have freedom to use discounting as a
+            regionalization and/or negotiation lever. Our business runs on Take — with an average{" "}
+            <strong className="text-[#403770]">50%</strong> Take on products and services,
+            forecasting Take from sale price is straightforward for everyone.
+          </p>
+
+          <div className="rounded-xl border border-[#E2DEEC] border-l-4 border-l-[#F37167] bg-white px-5 py-4">
+            <p className="text-sm text-[#6E6390] leading-relaxed">
+              <a
+                href="https://go.screenpal.com/watch/cOf2YRnOQRG"
+                target="_blank"
+                rel="noreferrer"
+                className="text-[#F37167] underline hover:text-[#cc5d54]"
+              >
+                Tony Skauge walks through how Take and discretionary discounts connect
+              </a>{" "}
+              and how he uses discretionary discounts when building a proposal.
+            </p>
+          </div>
+        </section>
+
+        <div className="border-t border-[#E2DEEC] mb-12" />
+
+        {/* ════════════════════════════════════════════════════════════════ */}
+        {/* VS IN-PERSON */}
+        {/* ════════════════════════════════════════════════════════════════ */}
+        <section id="vs-in-person" className="mb-12 scroll-mt-6">
+          <h2 className="text-lg font-bold text-[#403770] mb-4 flex items-center gap-2">
+            <TrendingDown className="w-5 h-5 text-[#403770]" />
+            Fullmind vs. In-Person Teacher
+          </h2>
+          <p className="text-sm text-[#6E6390] leading-relaxed mb-5">
+            Here&apos;s how a full-time experienced in-person teacher compares to Fullmind&apos;s
+            pricing. (Example: 13 years of average teaching experience in Georgia.)
+          </p>
+
+          <div className="border border-[#E2DEEC] rounded-xl overflow-hidden mb-6">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-[#F7F5FA] text-[10px] font-semibold text-[#8A80A8] uppercase tracking-wider">
+                  <th className="text-left px-4 py-3">Cost Bucket</th>
+                  <th className="text-right px-4 py-3 w-44">Full-Time In-Person Hire</th>
+                  <th className="text-right px-4 py-3 w-36">Fullmind Pricing</th>
+                </tr>
+              </thead>
+              <tbody>
+                {COST_COMPARE.map((row, i) => (
+                  <tr
+                    key={row.bucket}
+                    className={`border-t border-[#E2DEEC] ${i % 2 === 1 ? "bg-[#F7F5FA]/40" : ""}`}
+                  >
+                    <td className="px-4 py-3 text-[#6E6390]">{row.bucket}</td>
+                    <td className="px-4 py-3 text-right font-semibold text-[#403770] tabular-nums">
+                      {row.inPerson}
+                    </td>
+                    <td className="px-4 py-3 text-right font-semibold text-[#403770] tabular-nums">
+                      {row.fullmind}
+                    </td>
+                  </tr>
+                ))}
+                <tr className="border-t-2 border-[#403770] bg-[#EFEDF5]">
+                  <td className="px-4 py-3 font-bold text-[#403770]">TOTAL</td>
+                  <td className="px-4 py-3 text-right font-bold text-[#403770] tabular-nums">$120,817</td>
+                  <td className="px-4 py-3 text-right font-bold text-[#F37167] tabular-nums">$95,043.70</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          {/* Savings callout */}
+          <div className="rounded-xl bg-[#fef1f0] border border-[#f58d85] px-6 py-5 text-center">
+            <p className="text-2xl font-bold text-[#F37167] tabular-nums mb-1">
+              ~$25,774 savings per full-time hire
+            </p>
+            <p className="text-sm text-[#6E6390]">
+              And Fullmind handles recruitment, PD, absences, and benefits.
+            </p>
+          </div>
+        </section>
+
+        <div className="border-t border-[#E2DEEC] mb-12" />
+
+        {/* ════════════════════════════════════════════════════════════════ */}
+        {/* VIDEOS & DEEP DIVES */}
+        {/* ════════════════════════════════════════════════════════════════ */}
+        <section id="videos" className="mb-12 scroll-mt-6">
+          <h2 className="text-lg font-bold text-[#403770] mb-4 flex items-center gap-2">
+            <PlayCircle className="w-5 h-5 text-[#403770]" />
+            Videos &amp; Deep Dives
+          </h2>
+          <p className="text-sm text-[#6E6390] leading-relaxed mb-6">
+            Hear how your teammates position this with customers, then dive deeper with the linked
+            resources.
+          </p>
+
+          {/* Video 1 */}
+          <div className="mb-6">
+            <div className="flex items-center gap-2 mb-2">
+              <PlayCircle className="w-4 h-4 text-[#F37167]" />
+              <span className="text-sm font-semibold text-[#403770]">Jenn Russart — Pricing Positioning</span>
+            </div>
+            <p className="text-xs text-[#8A80A8] mb-3">
+              Jenn&apos;s initial reaction to Fullmind&apos;s pricing and how she positions it with customers.
+            </p>
+            <div className="aspect-[9/16] max-w-xs mx-auto rounded-xl overflow-hidden border border-[#E2DEEC] bg-[#F7F5FA]">
+              <iframe
+                src="https://drive.google.com/file/d/1b2zIzoU6bYkPSeh_BqTWj4kTKbyfWLSD/preview"
+                className="w-full h-full"
+                allow="autoplay"
+                allowFullScreen
+                loading="lazy"
+                title="Jenn Russart on Pricing Positioning"
+              />
+            </div>
+          </div>
+
+          {/* Video 2 */}
+          <div className="mb-10">
+            <div className="flex items-center gap-2 mb-2">
+              <PlayCircle className="w-4 h-4 text-[#F37167]" />
+              <span className="text-sm font-semibold text-[#403770]">Tony Skauge — Discounting in Proposals</span>
+            </div>
+            <p className="text-xs text-[#8A80A8] mb-3">
+              How Take and discretionary discounts connect, and how Tony uses discretionary discounts when creating a proposal.
+            </p>
+            <div className="aspect-video rounded-xl overflow-hidden border border-[#E2DEEC] bg-[#F7F5FA]">
+              <iframe
+                src="https://go.screenpal.com/player/cOf2YRnOQRG?ff=1&title=0"
+                className="w-full h-full"
+                allow="autoplay; fullscreen"
+                allowFullScreen
+                loading="lazy"
+                title="Tony Skauge on Discounting"
+              />
+            </div>
+          </div>
+
+          <p className="text-[10px] font-semibold text-[#8A80A8] uppercase tracking-wider mb-3">Deep Dives</p>
+
+          <div className="grid grid-cols-2 gap-3 mb-3">
+            <a
+              href="https://docs.google.com/document/d/1Uua3gNggqBWprK-LMzk4RE3wkHpUS1puyL0Wm43WgR8/edit?usp=sharing"
+              target="_blank"
+              rel="noreferrer"
+              className="group rounded-xl border border-[#E2DEEC] bg-white px-5 py-4 hover:border-[#F37167] transition-colors duration-100"
+            >
+              <div className="flex items-center gap-2 mb-2">
+                <Calculator className="w-4 h-4 text-[#403770]" />
+                <span className="text-sm font-semibold text-[#403770]">Historic Take Calculations</span>
+                <ExternalLink className="w-3.5 h-3.5 text-[#A69DC0] ml-auto group-hover:text-[#F37167]" />
+              </div>
+              <p className="text-xs text-[#8A80A8] leading-relaxed">
+                Deep dive into Take with real examples.
+              </p>
+            </a>
+
+            <a
+              href="https://docs.google.com/document/d/1nvPMCzhx4YUxOsq2R_XhomtA9w3nAe491WpNzAcMxPQ/edit?usp=sharing"
+              target="_blank"
+              rel="noreferrer"
+              className="group rounded-xl border border-[#E2DEEC] bg-white px-5 py-4 hover:border-[#F37167] transition-colors duration-100"
+            >
+              <div className="flex items-center gap-2 mb-2">
+                <LayoutGrid className="w-4 h-4 text-[#403770]" />
+                <span className="text-sm font-semibold text-[#403770]">Detailed Service Breakdown</span>
+                <ExternalLink className="w-3.5 h-3.5 text-[#A69DC0] ml-auto group-hover:text-[#F37167]" />
+              </div>
+              <p className="text-xs text-[#8A80A8] leading-relaxed">
+                What common problems each service solves, side-by-side.
+              </p>
+            </a>
+          </div>
+
+          <a
+            href="https://docs.google.com/forms/d/e/1FAIpQLScSEHwePTtEGweVkJJhM_PYz0sjZIdaLO2qjjiB-n-TCdZdAw/viewform?usp=publish-editor"
+            target="_blank"
+            rel="noreferrer"
+            className="group block rounded-xl border border-[#E2DEEC] border-l-4 border-l-[#F37167] bg-white px-5 py-4 hover:border-[#F37167] transition-colors duration-100"
+          >
+            <div className="flex items-center gap-2 mb-2">
+              <ClipboardCheck className="w-4 h-4 text-[#F37167]" />
+              <span className="text-sm font-semibold text-[#403770]">Training Check</span>
+              <ExternalLink className="w-3.5 h-3.5 text-[#A69DC0] ml-auto group-hover:text-[#F37167]" />
+            </div>
+            <p className="text-xs text-[#8A80A8] leading-relaxed">
+              Complete the form to review your understanding of this training.
+            </p>
+          </a>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/features/shared/components/views/resources/UnderstandingTakePage.tsx
+++ b/src/features/shared/components/views/resources/UnderstandingTakePage.tsx
@@ -1,0 +1,802 @@
+"use client";
+
+import {
+  Calculator,
+  Target,
+  DollarSign,
+  Calendar,
+  BarChart3,
+  AlertTriangle,
+  ListChecks,
+  Users,
+  Shield,
+  Lightbulb,
+  ArrowRight,
+} from "lucide-react";
+
+// ── Data ─────────────────────────────────────────────────────────────────────
+
+const TOC = [
+  { id: "benchmarks", label: "Current benchmarks" },
+  { id: "is-rates", label: "IS hourly rates" },
+  { id: "ls-rates", label: "LS daily rates" },
+  { id: "take-in-practice", label: "Take in practice" },
+  { id: "above-fifty", label: "When pay goes above 50%" },
+  { id: "set-up-success", label: "Set the team up for success" },
+  { id: "recruitment-process", label: "Recruitment process" },
+  { id: "guardrails", label: "Pricing guardrails" },
+];
+
+const IS_NY_RATES: Array<[string, string]> = [
+  ["Science", "$36 – $38.50 / hr"],
+  ["Math", "$32 – $36 / hr"],
+  ["Phys Ed / Health", "$29 – $33 / hr"],
+  ["Core / General", "$29 – $33 / hr"],
+  ["SWD", "$33 – $37.40 / hr"],
+  ["SWD (Science)", "$36 – $38.50 / hr"],
+  ["Translators", "$33 / hr"],
+];
+
+const IS_OOS_RATES: Array<[string, string]> = [
+  ["All subjects", "$29 – $33 / hr"],
+  ["Translators", "$33 / hr"],
+];
+
+const IS_GROUP_RATES: Array<[string, string]> = [
+  ["Small Group", "$33 – $36 / hr"],
+  ["Whole Class Virtual Instruction", "$36 – $40 / hr"],
+  ["Virtual Suspension", "$36 – $40 / hr"],
+];
+
+const LS_STATES: Array<{
+  state: string;
+  rows: Array<[string, string, string]>;
+}> = [
+  {
+    state: "New York",
+    rows: [
+      ["Core", "$265 – $275", "$47,700 – $49,500"],
+      ["SWD", "$300", "$54,000"],
+      ["Spanish", "$350", "$63,000"],
+    ],
+  },
+  {
+    state: "South Carolina",
+    rows: [
+      ["SWD", "$250 – $260", "$45,000 – $46,800"],
+      ["Core", "$240 – $250", "$43,200 – $45,000"],
+    ],
+  },
+  {
+    state: "California",
+    rows: [["SWD", "$300 – $320", "$54,000 – $57,600"]],
+  },
+];
+
+const CA_SWD_ROWS: Array<[string, string, string, string, string]> = [
+  ["Barstow Unified", "$135,159.78", "$77,445.00", "$57,714.78", "42.70%"],
+  ["Middleton Unified", "$6,188.70", "$3,150.00", "$3,038.70", "49.10%"],
+  ["Middleton Unified", "$11,981.20", "$6,160.00", "$5,821.20", "48.59%"],
+  ["Konocti Unified", "$32,051.32", "$19,320.00", "$12,731.32", "39.72%"],
+  ["Yuba City Unified", "$92,387.13", "$48,589.26", "$43,797.87", "47.41%"],
+];
+
+const ELMSFORD_ROWS: Array<
+  [string, string, string, string, string, string, string]
+> = [
+  ["1:1 HB", "997", "$70,707.87", "$32.29", "$32,192.31", "$38,515.56", "54.47%"],
+  ["1:1 HB", "500", "$33,275.88", "$34.16", "$17,083.30", "$16,193.58", "48.66%"],
+  ["Small Group", "97", "$11,154.46", "$28.71", "$2,785.16", "$8,369.30", "75.03%"],
+  ["Virtual Suspension", "48", "$29,376.00", "$346.00", "$16,608.00", "$12,768.00", "43.46%"],
+];
+
+const SUCCESS_STEPS: Array<{
+  title: string;
+  body: React.ReactNode;
+}> = [
+  {
+    title: "Start early with the right questions",
+    body: (
+      <>
+        <p className="text-sm text-[#6E6390] leading-relaxed mb-3">
+          Use the req form as your guide to build a checklist:
+        </p>
+        <ul className="space-y-2 pl-4 list-disc marker:text-[#C2BBD4]">
+          <li className="text-sm text-[#6E6390] leading-relaxed">
+            What&apos;s their background check process, and is it state- or school-required?
+          </li>
+          <li className="text-sm text-[#6E6390] leading-relaxed">
+            Are they open to out-of-state educators, or educators willing to seek reciprocity?{" "}
+            <span className="text-[#8A80A8] italic">
+              (Can drop time-to-staff from months to two weeks.)
+            </span>
+          </li>
+          <li className="text-sm text-[#6E6390] leading-relaxed">
+            Full-time or part-time?{" "}
+            <span className="text-[#8A80A8] italic">
+              (Part-time is significantly harder to staff — flag it early.)
+            </span>
+          </li>
+          <li className="text-sm text-[#6E6390] leading-relaxed">
+            Is a Master&apos;s required? Niche certification? AP class? Expect a smaller
+            candidate pool and higher comp.
+          </li>
+        </ul>
+      </>
+    ),
+  },
+  {
+    title: "Log everything in the LMS Opps text box",
+    body: (
+      <p className="text-sm text-[#6E6390] leading-relaxed">
+        Capture the full picture so anyone on Recruitment or Staffing who picks up the
+        opportunity sees the same context you did.
+      </p>
+    ),
+  },
+  {
+    title: "Loop in Recruitment & Staffing early",
+    body: (
+      <p className="text-sm text-[#6E6390] leading-relaxed">
+        Ping{" "}
+        <code className="text-xs font-mono text-[#403770] bg-[#F7F5FA] border border-[#E2DEEC] px-1.5 py-0.5 rounded">
+          #recruiting-and-staffing
+        </code>{" "}
+        in Slack with position details. They can flag difficulty, suggest faster placements,
+        and that insight can inform your pricing strategy from the start.
+      </p>
+    ),
+  },
+];
+
+const RECRUITMENT_STEPS: Array<{ title: string; body: string }> = [
+  {
+    title: "IS / LS flags a gap",
+    body: "They let Recruitment know no one in pool is interested in the assignment.",
+  },
+  {
+    title: "Recruitment gathers JD details",
+    body: "Schedule, grade level, subject, certification, pay rate — anything a candidate might ask about that we have an answer for.",
+  },
+  {
+    title: "Urgent hiring kicks off",
+    body: "JD goes up; we bypass parts of the standard funnel and aim to chat same-day. Apply in the morning → call in the afternoon.",
+  },
+  {
+    title: "Frequent updates to Staffing",
+    body: "Recruitment reports back as candidates move through conversations.",
+  },
+  {
+    title: "Pay signal → pricing signal",
+    body: "In conversations, Recruitment gauges candidate reactions to pay. If pay is a blocker, they inform Staffing and consider tiering up. When an educator becomes active and wants more, that context flows back to Staffing.",
+  },
+];
+
+const GUARDRAILS: Array<{ title: string; body: React.ReactNode }> = [
+  {
+    title: "No Staffing Fee discount",
+    body: (
+      <>
+        Target a list price of at least{" "}
+        <strong className="text-[#403770]">$50,000</strong> for the educator budget.
+        Discounts eat directly into Take.
+      </>
+    ),
+  },
+  {
+    title: "SPED and specialized roles cost more",
+    body: (
+      <>
+        Anything we haven&apos;t done before should be priced with a premium for the
+        unknowns.
+      </>
+    ),
+  },
+  {
+    title: "Tell us early or pay rises",
+    body: (
+      <>
+        If Recruitment finds out late that a role is unusual, we&apos;re usually already
+        urgent-hiring — which pushes pay up.
+      </>
+    ),
+  },
+  {
+    title: "Returners are the first move",
+    body: (
+      <>
+        70–80% of LS educators return year over year. Staffing always goes back to past
+        educators first because they know the work.{" "}
+        <span className="text-[#8A80A8] italic">
+          (SC SPED returners get +3% on pay.)
+        </span>
+      </>
+    ),
+  },
+];
+
+// ── Small sub-components ─────────────────────────────────────────────────────
+
+function RateTable({
+  caption,
+  rows,
+}: {
+  caption: string;
+  rows: Array<[string, string]>;
+}) {
+  return (
+    <div className="border border-[#E2DEEC] rounded-xl overflow-hidden">
+      <div className="bg-[#F7F5FA] px-5 py-2.5 border-b border-[#E2DEEC]">
+        <span className="text-xs font-semibold text-[#403770]">{caption}</span>
+      </div>
+      <table className="w-full text-sm">
+        <tbody>
+          {rows.map(([role, rate], i) => (
+            <tr
+              key={`${role}-${i}`}
+              className={i > 0 ? "border-t border-[#E2DEEC]" : ""}
+            >
+              <td className="px-5 py-2.5 text-[#403770] font-medium">{role}</td>
+              <td className="px-5 py-2.5 text-right text-[#6E6390] tabular-nums">
+                {rate}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ── Page Component ───────────────────────────────────────────────────────────
+
+export default function UnderstandingTakePage() {
+  return (
+    <div className="flex gap-10">
+      {/* ── Sticky table of contents ──────────────────────────────────── */}
+      <nav className="hidden xl:block w-44 flex-shrink-0">
+        <div className="sticky top-6">
+          <p className="text-[10px] font-semibold text-[#8A80A8] uppercase tracking-wider mb-3">
+            On this page
+          </p>
+          <div className="space-y-0.5">
+            {TOC.map((item) => (
+              <a
+                key={item.id}
+                href={`#${item.id}`}
+                className="block text-xs text-[#6E6390] hover:text-[#403770] py-1.5 border-l-2 border-transparent hover:border-[#F37167] pl-3 transition-colors duration-100"
+              >
+                {item.label}
+              </a>
+            ))}
+          </div>
+        </div>
+      </nav>
+
+      {/* ── Main content ──────────────────────────────────────────────── */}
+      <div className="flex-1 min-w-0 max-w-4xl">
+        {/* Hero */}
+        <div className="mb-10">
+          <div className="flex items-center gap-4 mb-4">
+            <div className="w-12 h-12 rounded-2xl bg-[#FEF2F1] flex items-center justify-center">
+              <Calculator className="w-6 h-6 text-[#F37167]" />
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold text-[#403770]">
+                Understanding Take
+              </h1>
+              <p className="text-sm text-[#8A80A8] mt-0.5">
+                How Take is calculated, the comp bands we work within, and how to
+                price deals so recruitment can deliver.
+              </p>
+            </div>
+          </div>
+          <div className="rounded-xl bg-gradient-to-r from-[#F7F5FA] to-[#EFEDF5] p-5 border border-[#E2DEEC]">
+            <p className="text-sm text-[#6E6390] leading-relaxed">
+              <strong className="text-[#403770]">Take = Revenue − COGS</strong>,
+              expressed as a percentage. When calculating teacher compensation and
+              Take, the Staffing Fee is included in the sale price — so waiving or
+              discounting it directly reduces Take. Around 80% of opportunities
+              fall inside our standard rate bands; the rest reflect harder-to-fill
+              certifications, state/subject premiums, or heavier workloads.
+            </p>
+          </div>
+        </div>
+
+        {/* ════════════════════════════════════════════════════════════════ */}
+        {/* CURRENT BENCHMARKS */}
+        {/* ════════════════════════════════════════════════════════════════ */}
+        <section id="benchmarks" className="mb-12 scroll-mt-6">
+          <h2 className="text-lg font-bold text-[#403770] mb-4 flex items-center gap-2">
+            <Target className="w-5 h-5 text-[#F37167]" />
+            Current benchmarks
+          </h2>
+
+          <div className="grid grid-cols-2 gap-4 mb-4">
+            <div className="rounded-xl border border-[#E2DEEC] bg-white p-5">
+              <p className="text-xs font-semibold text-[#8A80A8] uppercase tracking-wider mb-2">
+                2026 Take target
+              </p>
+              <p className="text-3xl font-bold text-[#403770] tabular-nums mb-1">
+                —
+              </p>
+              <p className="text-xs text-[#8A80A8]">
+                Add current 2026 Take target from Ops dashboard
+              </p>
+            </div>
+            <div className="rounded-xl border border-[#E2DEEC] bg-white p-5">
+              <p className="text-xs font-semibold text-[#8A80A8] uppercase tracking-wider mb-2">
+                FY2025-to-date average
+              </p>
+              <p className="text-3xl font-bold text-[#403770] tabular-nums mb-1">
+                —
+              </p>
+              <p className="text-xs text-[#8A80A8]">
+                Add FY2025 average Take from Ops dashboard
+              </p>
+            </div>
+          </div>
+
+          <div className="rounded-xl border-l-4 border-[#F37167] bg-white border border-[#E2DEEC] px-5 py-4">
+            <div className="flex items-start gap-2.5">
+              <Lightbulb className="w-4 h-4 text-[#F37167] mt-0.5 flex-shrink-0" />
+              <p className="text-sm text-[#6E6390] leading-relaxed">
+                These figures come from the live Take dashboard. Update this page
+                when Ops publishes new numbers.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <div className="border-t border-[#E2DEEC] mb-12" />
+
+        {/* ════════════════════════════════════════════════════════════════ */}
+        {/* IS HOURLY RATES */}
+        {/* ════════════════════════════════════════════════════════════════ */}
+        <section id="is-rates" className="mb-12 scroll-mt-6">
+          <h2 className="text-lg font-bold text-[#403770] mb-4 flex items-center gap-2">
+            <DollarSign className="w-5 h-5 text-[#69B34A]" />
+            Standard IS hourly rates
+          </h2>
+          <p className="text-sm text-[#6E6390] leading-relaxed mb-5">
+            Around <strong className="text-[#403770]">80% of IS opportunities</strong>{" "}
+            fall within these rate bands. Anything above typically reflects
+            state/subject scarcity, heavier workloads, or hard-to-place roles.
+          </p>
+
+          <div className="grid grid-cols-1 gap-4 mb-4">
+            <RateTable caption="1:1 New York" rows={IS_NY_RATES} />
+            <div className="grid grid-cols-2 gap-4">
+              <RateTable caption="1:1 Out of State" rows={IS_OOS_RATES} />
+              <RateTable caption="Group assignments" rows={IS_GROUP_RATES} />
+            </div>
+          </div>
+
+          <div className="rounded-xl bg-[#e8f1f5] border border-[#8bb5cb] px-5 py-4">
+            <div className="flex items-start gap-2.5">
+              <Lightbulb className="w-4 h-4 text-[#6EA3BE] mt-0.5 flex-shrink-0" />
+              <p className="text-sm text-[#6E6390] leading-relaxed">
+                Many NY educators return to NY IS positions because the role requires
+                a NY cert — which helps keep Time to Staff low for renewals.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <div className="border-t border-[#E2DEEC] mb-12" />
+
+        {/* ════════════════════════════════════════════════════════════════ */}
+        {/* LS DAILY RATES */}
+        {/* ════════════════════════════════════════════════════════════════ */}
+        <section id="ls-rates" className="mb-12 scroll-mt-6">
+          <h2 className="text-lg font-bold text-[#403770] mb-4 flex items-center gap-2">
+            <Calendar className="w-5 h-5 text-[#6EA3BE]" />
+            Standard Live Staffing daily rates
+          </h2>
+          <p className="text-sm text-[#6E6390] leading-relaxed mb-5">
+            Live Staffing rates are expressed as daily pay. Across all
+            opportunities,{" "}
+            <strong className="text-[#403770]">
+              70–80% of LS educators return the following year.
+            </strong>
+          </p>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {LS_STATES.map((st) => (
+              <div
+                key={st.state}
+                className="rounded-xl border border-[#E2DEEC] bg-white overflow-hidden flex flex-col"
+              >
+                <div className="bg-[#F7F5FA] px-4 py-2.5 border-b border-[#E2DEEC]">
+                  <span className="text-xs font-semibold text-[#403770]">
+                    {st.state}
+                  </span>
+                </div>
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="text-[10px] font-semibold text-[#8A80A8] uppercase tracking-wider">
+                      <th className="text-left px-4 py-2 font-semibold">Role</th>
+                      <th className="text-right px-4 py-2 font-semibold">Daily</th>
+                      <th className="text-right px-4 py-2 font-semibold">List price</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {st.rows.map(([role, rate, price], i) => (
+                      <tr
+                        key={`${st.state}-${role}-${i}`}
+                        className="border-t border-[#E2DEEC]"
+                      >
+                        <td className="px-4 py-2.5 text-[#403770] font-medium">
+                          {role}
+                        </td>
+                        <td className="px-4 py-2.5 text-right text-[#6E6390] tabular-nums">
+                          {rate}
+                        </td>
+                        <td className="px-4 py-2.5 text-right text-[#6E6390] tabular-nums">
+                          {price}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <div className="border-t border-[#E2DEEC] mb-12" />
+
+        {/* ════════════════════════════════════════════════════════════════ */}
+        {/* TAKE IN PRACTICE */}
+        {/* ════════════════════════════════════════════════════════════════ */}
+        <section id="take-in-practice" className="mb-12 scroll-mt-6">
+          <h2 className="text-lg font-bold text-[#403770] mb-4 flex items-center gap-2">
+            <BarChart3 className="w-5 h-5 text-[#D4A843]" />
+            Take in practice
+          </h2>
+          <p className="text-sm text-[#6E6390] leading-relaxed mb-6">
+            Real deals, real Take percentages. Notice how the same pay rate produces
+            different Take depending on sessions booked and how we structure the
+            contract.
+          </p>
+
+          {/* Example A — CA SWD */}
+          <div className="mb-6">
+            <div className="flex items-center gap-2 mb-3">
+              <span className="text-sm font-semibold text-[#403770]">
+                Example A — CA SWD Live Staffing
+              </span>
+              <span className="text-xs font-medium text-[#8A80A8] bg-[#F7F5FA] border border-[#E2DEEC] px-2 py-0.5 rounded-full">
+                pay rate $300–320
+              </span>
+            </div>
+            <div className="border border-[#E2DEEC] rounded-xl overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="bg-[#F7F5FA] text-[10px] font-semibold text-[#8A80A8] uppercase tracking-wider">
+                    <th className="text-left px-5 py-3">School</th>
+                    <th className="text-right px-5 py-3">Revenue</th>
+                    <th className="text-right px-5 py-3">COGS</th>
+                    <th className="text-right px-5 py-3">Take</th>
+                    <th className="text-right px-5 py-3 w-20">Take %</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {CA_SWD_ROWS.map(([school, revenue, cogs, take, pct], i) => (
+                    <tr
+                      key={`ca-${i}`}
+                      className={`border-t border-[#E2DEEC] ${
+                        i % 2 === 1 ? "bg-[#F7F5FA]/40" : ""
+                      }`}
+                    >
+                      <td className="px-5 py-3 font-medium text-[#403770]">
+                        {school}
+                      </td>
+                      <td className="px-5 py-3 text-right text-[#6E6390] tabular-nums">
+                        {revenue}
+                      </td>
+                      <td className="px-5 py-3 text-right text-[#6E6390] tabular-nums">
+                        {cogs}
+                      </td>
+                      <td className="px-5 py-3 text-right text-[#403770] font-semibold tabular-nums">
+                        {take}
+                      </td>
+                      <td className="px-5 py-3 text-right text-[#403770] font-semibold tabular-nums">
+                        {pct}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          {/* Example B — Elmsford */}
+          <div>
+            <div className="flex items-center gap-2 mb-3">
+              <span className="text-sm font-semibold text-[#403770]">
+                Example B — Elmsford School District
+              </span>
+              <span className="text-xs font-medium text-[#8A80A8] bg-[#F7F5FA] border border-[#E2DEEC] px-2 py-0.5 rounded-full">
+                by session type
+              </span>
+            </div>
+            <div className="border border-[#E2DEEC] rounded-xl overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="bg-[#F7F5FA] text-[10px] font-semibold text-[#8A80A8] uppercase tracking-wider">
+                    <th className="text-left px-4 py-3">Session type</th>
+                    <th className="text-right px-4 py-3">Sessions</th>
+                    <th className="text-right px-4 py-3">Session cost</th>
+                    <th className="text-right px-4 py-3">Avg educator $</th>
+                    <th className="text-right px-4 py-3">Educator cost</th>
+                    <th className="text-right px-4 py-3">Gross margin</th>
+                    <th className="text-right px-4 py-3 w-20">Margin %</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {ELMSFORD_ROWS.map(
+                    ([type, sessions, sessCost, avgEd, edCost, gm, pct], i) => (
+                      <tr
+                        key={`elm-${i}`}
+                        className={`border-t border-[#E2DEEC] ${
+                          i % 2 === 1 ? "bg-[#F7F5FA]/40" : ""
+                        }`}
+                      >
+                        <td className="px-4 py-3 font-medium text-[#403770]">
+                          {type}
+                        </td>
+                        <td className="px-4 py-3 text-right text-[#6E6390] tabular-nums">
+                          {sessions}
+                        </td>
+                        <td className="px-4 py-3 text-right text-[#6E6390] tabular-nums">
+                          {sessCost}
+                        </td>
+                        <td className="px-4 py-3 text-right text-[#6E6390] tabular-nums">
+                          {avgEd}
+                        </td>
+                        <td className="px-4 py-3 text-right text-[#6E6390] tabular-nums">
+                          {edCost}
+                        </td>
+                        <td className="px-4 py-3 text-right text-[#403770] font-semibold tabular-nums">
+                          {gm}
+                        </td>
+                        <td className="px-4 py-3 text-right text-[#403770] font-semibold tabular-nums">
+                          {pct}
+                        </td>
+                      </tr>
+                    )
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </section>
+
+        <div className="border-t border-[#E2DEEC] mb-12" />
+
+        {/* ════════════════════════════════════════════════════════════════ */}
+        {/* ABOVE 50% */}
+        {/* ════════════════════════════════════════════════════════════════ */}
+        <section id="above-fifty" className="mb-12 scroll-mt-6">
+          <h2 className="text-lg font-bold text-[#403770] mb-4 flex items-center gap-2">
+            <AlertTriangle className="w-5 h-5 text-[#D4A843]" />
+            When pay goes above 50% of sale price
+          </h2>
+          <p className="text-sm text-[#6E6390] leading-relaxed mb-6">
+            Sometimes we pay more than half the sale price to staff a role. Two
+            historical examples show why — and what we learned.
+          </p>
+
+          <div className="space-y-4">
+            {/* Barstow */}
+            <div className="rounded-xl bg-[#FFF8EE] border border-[#ffd98d] p-5">
+              <div className="flex items-center gap-2 mb-3">
+                <AlertTriangle className="w-4 h-4 text-[#D4A843]" />
+                <span className="text-sm font-bold text-[#403770]">
+                  Barstow — LiveScan compliance gap
+                </span>
+                <span className="text-xs font-medium text-[#8A80A8] bg-white/60 px-2 py-0.5 rounded-full">
+                  Live Staffing · June–Sept 2024
+                </span>
+              </div>
+              <p className="text-sm text-[#6E6390] leading-relaxed mb-3">
+                When Barstow became a customer in June 2024, we didn&apos;t know CA law
+                required LiveScan fingerprinting before hire or placement — our IS
+                assignments hadn&apos;t needed it. That created a compliance gap we
+                weren&apos;t operationally ready for. We couldn&apos;t recruit, hire, or
+                engage educators until LiveScan was set up in August 2024, meaning two
+                months of lost revenue and educators sitting without assignments. We
+                could only recruit candidates already in California, and had to raise
+                pay to staff fully — achieved in September 2024, three months after the
+                relationship began.
+              </p>
+              <div className="rounded-lg bg-white/70 border border-[#f0e2b8] px-4 py-3">
+                <p className="text-xs font-semibold text-[#D4A843] uppercase tracking-wider mb-1">
+                  Outcome
+                </p>
+                <p className="text-sm text-[#6E6390] leading-relaxed">
+                  Barstow is now one of our top-performing customers. LiveScan
+                  compliance is part of onboarding, and background checks are now
+                  addressed in Stage 1 or 2 by the sales rep / AM / PSM.
+                </p>
+              </div>
+            </div>
+
+            {/* Korean */}
+            <div className="rounded-xl bg-[#FFF8EE] border border-[#ffd98d] p-5">
+              <div className="flex items-center gap-2 mb-3">
+                <AlertTriangle className="w-4 h-4 text-[#D4A843]" />
+                <span className="text-sm font-bold text-[#403770]">
+                  Korean IS — hard-to-recruit certification
+                </span>
+                <span className="text-xs font-medium text-[#8A80A8] bg-white/60 px-2 py-0.5 rounded-full">
+                  Instructional Services
+                </span>
+              </div>
+              <p className="text-sm text-[#6E6390] leading-relaxed mb-3">
+                A school partner asked for a Korean-certified educator. Korean sits in
+                the group of &ldquo;challenging&rdquo; world languages — one study showed 78% of
+                aspiring world language educators study Spanish, with Korean barely
+                represented. Sourcing turned up only 35 candidates on LinkedIn and 60
+                on Indeed; just 2 applied. The educator we found started at $40 and
+                came back asking for $50.
+              </p>
+              <div className="rounded-lg bg-white/70 border border-[#f0e2b8] px-4 py-3">
+                <p className="text-xs font-semibold text-[#D4A843] uppercase tracking-wider mb-1">
+                  Outcome
+                </p>
+                <p className="text-sm text-[#6E6390] leading-relaxed">
+                  Given how hard it was to recruit, we went above the sale price to
+                  keep the business and deliver for the school. The lesson: flag rare
+                  certifications at the req stage so comp and pricing can reflect
+                  scarcity from the start.
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <div className="border-t border-[#E2DEEC] mb-12" />
+
+        {/* ════════════════════════════════════════════════════════════════ */}
+        {/* SET THE TEAM UP FOR SUCCESS */}
+        {/* ════════════════════════════════════════════════════════════════ */}
+        <section id="set-up-success" className="mb-12 scroll-mt-6">
+          <h2 className="text-lg font-bold text-[#403770] mb-4 flex items-center gap-2">
+            <ListChecks className="w-5 h-5 text-[#69B34A]" />
+            Set the team up for success
+          </h2>
+          <p className="text-sm text-[#6E6390] leading-relaxed mb-6">
+            The more information you gather up front, and the longer the assignment,
+            the easier it is to staff at a competitive rate — which means more Take.{" "}
+            <strong className="text-[#403770]">
+              The biggest single driver of a large, qualified educator pool is a
+              full-year assignment known before the school year starts.
+            </strong>
+          </p>
+
+          <div className="space-y-3">
+            {SUCCESS_STEPS.map((step, i) => (
+              <div
+                key={step.title}
+                className="rounded-xl border border-[#E2DEEC] bg-white p-5 flex gap-4"
+              >
+                <div className="w-8 h-8 rounded-full bg-[#F37167] flex items-center justify-center flex-shrink-0 text-sm font-bold text-white">
+                  {i + 1}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <h3 className="text-sm font-bold text-[#403770] mb-2">
+                    {step.title}
+                  </h3>
+                  {step.body}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <div className="border-t border-[#E2DEEC] mb-12" />
+
+        {/* ════════════════════════════════════════════════════════════════ */}
+        {/* RECRUITMENT PROCESS */}
+        {/* ════════════════════════════════════════════════════════════════ */}
+        <section id="recruitment-process" className="mb-12 scroll-mt-6">
+          <h2 className="text-lg font-bold text-[#403770] mb-4 flex items-center gap-2">
+            <Users className="w-5 h-5 text-[#403770]" />
+            The recruitment process
+          </h2>
+          <p className="text-sm text-[#6E6390] leading-relaxed mb-4">
+            Recruitment&apos;s goal is a hone-in strategy — keep our educator pool
+            matched to the certifications our top accounts need, so we avoid
+            last-minute recruiting and keep comp appropriate to the market. When we
+            don&apos;t have an educator in pool, here&apos;s what happens.
+          </p>
+
+          <div className="rounded-xl bg-[#F7F5FA] border border-[#E2DEEC] px-5 py-4 mb-6">
+            <p className="text-xs font-semibold text-[#8A80A8] uppercase tracking-wider mb-2">
+              Why we sometimes lack a pool match
+            </p>
+            <ul className="space-y-1.5 pl-4 list-disc marker:text-[#C2BBD4]">
+              <li className="text-sm text-[#6E6390] leading-relaxed">
+                A hard-to-recruit certification{" "}
+                <span className="text-[#8A80A8] italic">
+                  (NY Earth Science, CA Mod/Sev)
+                </span>
+              </li>
+              <li className="text-sm text-[#6E6390] leading-relaxed">
+                A spring request — most educators are either placed or focused on
+                next year
+              </li>
+              <li className="text-sm text-[#6E6390] leading-relaxed">
+                A certification we&apos;ve never filled before — a good problem, it
+                means serving students a new way
+              </li>
+            </ul>
+          </div>
+
+          <div className="relative">
+            {RECRUITMENT_STEPS.map((step, i) => {
+              const isLast = i === RECRUITMENT_STEPS.length - 1;
+              return (
+                <div key={step.title} className="flex gap-4 relative pb-5">
+                  {!isLast && (
+                    <div
+                      className="absolute left-4 top-8 w-px bg-[#E2DEEC]"
+                      style={{ bottom: 0 }}
+                    />
+                  )}
+                  <div className="w-8 h-8 rounded-full bg-white border-2 border-[#F37167] flex items-center justify-center flex-shrink-0 text-xs font-bold text-[#F37167] relative z-10">
+                    {i + 1}
+                  </div>
+                  <div className="flex-1 min-w-0 pt-1">
+                    <h3 className="text-sm font-bold text-[#403770] mb-1">
+                      {step.title}
+                    </h3>
+                    <p className="text-sm text-[#6E6390] leading-relaxed">
+                      {step.body}
+                    </p>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+
+        <div className="border-t border-[#E2DEEC] mb-12" />
+
+        {/* ════════════════════════════════════════════════════════════════ */}
+        {/* GUARDRAILS */}
+        {/* ════════════════════════════════════════════════════════════════ */}
+        <section id="guardrails" className="mb-12 scroll-mt-6">
+          <h2 className="text-lg font-bold text-[#403770] mb-4 flex items-center gap-2">
+            <Shield className="w-5 h-5 text-[#F37167]" />
+            Pricing guardrails
+          </h2>
+          <p className="text-sm text-[#6E6390] leading-relaxed mb-6">
+            A handful of rules that come up enough to be worth repeating.
+          </p>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {GUARDRAILS.map((g) => (
+              <div
+                key={g.title}
+                className="border-l-4 border-[#F37167] bg-white border border-[#E2DEEC] rounded-xl px-5 py-4"
+              >
+                <div className="flex items-start gap-2 mb-1.5">
+                  <ArrowRight className="w-4 h-4 text-[#F37167] mt-0.5 flex-shrink-0" />
+                  <span className="text-sm font-bold text-[#403770]">
+                    {g.title}
+                  </span>
+                </div>
+                <p className="text-sm text-[#6E6390] leading-relaxed pl-6">
+                  {g.body}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **Pricing & Packaging** (Training) — rate cards, Take formula, Elevate→Fullmind mapping, pricing-model comparison, discounting guidelines, vs. in-person cost breakdown. Includes embedded video walkthroughs from Jenn Russart (pricing positioning) and Tony Skauge (discounting in proposals).
- **Our Service Model** (Product — new category) — 10 service cards split between Core Credit-Bearing and Supplemental, each with challenge/solution narrative + feature strip (Teacher of Record, LMS, Exit Tickets, Mini Lesson, SWD Progress, Gradebooks). Includes a glossary of supports and a full comparison matrix.
- **Understanding Take** (Training) — deep dive on how Take is calculated with worked examples.

All three pages follow the wiki layout established in `UnderstandingLeaderboardPage.tsx` — sticky TOC, gradient summary hero, inline sections with dividers, brand-token-only styling.

## Notes
- New "Product" category surfaces in the Resources sidebar (first page there is Our Service Model).
- The Jenn Russart embed uses Google Drive `/preview`; the source file currently has restricted sharing (`usp=drive_link`). For the embed to play for every rep, the file owner needs to set sharing to at least "Anyone at Fullmind with the link." If a rep sees "You need access" in the iframe, that's the fix.
- Tony Skauge's Screenpal embed is fully public and plays inline.

## Test plan
- [ ] Navigate to Resources tab → verify all three pages appear in the sidebar under the right categories (Pricing & Packaging + Understanding Take under Training; Our Service Model under the new Product category)
- [ ] Pricing & Packaging — rate-card tables render with correct numbers; Elevate mapping shows grouped cards with plum/coral chips; pricing-model matrix and vs-in-person table render correctly; both video embeds play (Jenn in portrait 9:16, Tony in 16:9)
- [ ] Our Service Model — 10 service cards render (5 Core, 5 Supplemental); feature strips show green check / muted dash correctly; Hybrid Staffing shows "School's platform" note on Gradebooks; glossary grid is 2-col with 8 cards; comparison matrix has coral-tinted group headers
- [ ] Understanding Take — page renders, TOC anchors scroll correctly
- [ ] Sticky TOC on left visible at ≥1280px; anchor links scroll smoothly with `scroll-mt-6` offset
- [ ] No console errors / no TypeScript errors (`npx tsc --noEmit` clean for these files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)