### PR TITLE
perf(plans): kill modal ghost fetches + index districts.name

### DIFF
--- a/prisma/migrations/20260423140000_add_district_name_index/migration.sql
+++ b/prisma/migrations/20260423140000_add_district_name_index/migration.sql
@@ -1,0 +1,6 @@
+-- Add btree index on districts.name to support ORDER BY and prefix matching
+-- in the district list endpoint. The list endpoint paginates with
+-- `ORDER BY name ASC LIMIT N`, which triggered a full-table sort on ~15-20k
+-- rows on every call (~11s observed in production trace).
+
+CREATE INDEX IF NOT EXISTS "districts_name_idx" ON "districts"("name");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -271,6 +271,7 @@ model District {
   @@index([salesExecutiveId])
   @@index([icpTier])
   @@index([accountType])
+  @@index([name])
   @@map("districts")
 }
 

--- a/src/features/activities/lib/queries.ts
+++ b/src/features/activities/lib/queries.ts
@@ -9,7 +9,7 @@ import type {
 import type { OpportunityResult, CalendarAttendee } from "@/features/activities/lib/outcome-types-api";
 
 // List activities with filtering
-export function useActivities(params: ActivitiesParams = {}) {
+export function useActivities(params: ActivitiesParams = {}, options?: { enabled?: boolean }) {
   const searchParams = new URLSearchParams();
   if (params.planId) searchParams.set("planId", params.planId);
   if (params.districtLeaid) searchParams.set("districtLeaid", params.districtLeaid);
@@ -37,6 +37,7 @@ export function useActivities(params: ActivitiesParams = {}) {
     queryKey: ["activities", params],
     queryFn: () => fetchJson<ActivitiesResponse>(url),
     staleTime: 2 * 60 * 1000, // 2 minutes
+    enabled: options?.enabled,
   });
 }
 

--- a/src/features/districts/lib/queries.ts
+++ b/src/features/districts/lib/queries.ts
@@ -28,7 +28,7 @@ export function useDistricts(params: {
   year?: FiscalYear;
   limit?: number;
   offset?: number;
-}) {
+}, options?: { enabled?: boolean }) {
   const searchParams = new URLSearchParams();
   if (params.state) searchParams.set("state", params.state);
   if (params.status && params.status !== "all")
@@ -47,6 +47,7 @@ export function useDistricts(params: {
         `${API_BASE}/districts?${searchParams}`
       ),
     staleTime: 5 * 60 * 1000, // 5 minutes - district lists don't change often
+    enabled: options?.enabled,
   });
 }
 

--- a/src/features/shared/lib/queries.ts
+++ b/src/features/shared/lib/queries.ts
@@ -71,7 +71,7 @@ export function useRemoveDistrictTag() {
 
 // ===== Contacts =====
 
-export function useContacts(params: { search?: string; limit?: number } = {}) {
+export function useContacts(params: { search?: string; limit?: number } = {}, options?: { enabled?: boolean }) {
   const searchParams = new URLSearchParams();
   if (params.search) searchParams.set("search", params.search);
   if (params.limit) searchParams.set("limit", params.limit.toString());
@@ -83,6 +83,7 @@ export function useContacts(params: { search?: string; limit?: number } = {}) {
     queryKey: ["contacts", params],
     queryFn: () => fetchJson<ContactsResponse>(url),
     staleTime: 2 * 60 * 1000,
+    enabled: options?.enabled,
   });
 }
 

--- a/src/features/tasks/components/TaskDetailModal.tsx
+++ b/src/features/tasks/components/TaskDetailModal.tsx
@@ -71,17 +71,17 @@ export default function TaskDetailModal({ task, isOpen, onClose }: TaskDetailMod
   const linkContacts = useLinkTaskContacts();
   const createPlan = useCreateTerritoryPlan();
 
-  // Data hooks for pickers
-  const { data: plans } = useTerritoryPlans();
-  const { data: activitiesData } = useActivities();
+  // Data hooks for pickers — gated on isOpen to avoid firing on every page load
+  const { data: plans } = useTerritoryPlans({ enabled: isOpen });
+  const { data: activitiesData } = useActivities({}, { enabled: isOpen });
   const { data: districtsData } = useDistricts({
     search: districtSearch || undefined,
     limit: 20,
-  });
+  }, { enabled: isOpen });
   const { data: contactsData } = useContacts({
     search: contactSearch || undefined,
     limit: 20,
-  });
+  }, { enabled: isOpen });
 
   // Reset form when task changes (use prop task for form fields)
   useEffect(() => {

--- a/src/features/tasks/components/TaskFormModal.tsx
+++ b/src/features/tasks/components/TaskFormModal.tsx
@@ -68,15 +68,15 @@ export default function TaskFormModal({
   const createTask = useCreateTask();
   const createPlan = useCreateTerritoryPlan();
   const { data: plans } = useTerritoryPlans({ enabled: isOpen });
-  const { data: activitiesData } = useActivities();
+  const { data: activitiesData } = useActivities({}, { enabled: isOpen });
   const { data: districtsData } = useDistricts({
     search: districtSearch || undefined,
     limit: 20,
-  });
+  }, { enabled: isOpen });
   const { data: contactsData } = useContacts({
     search: contactSearch || undefined,
     limit: 20,
-  });
+  }, { enabled: isOpen });
 
   // Reset form when modal opens
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Plans tab network trace showed `/api/districts?limit=20` taking ~11s on page load — a ghost call from always-mounted modals in `ProfileSidebar` / `PlanCard` / `TasksView`. `TaskFormModal` and `TaskDetailModal` called `useDistricts` / `useActivities` / `useContacts` without `enabled:isOpen`, so they fired on every page load even while closed.
- Gated those three hooks on `isOpen`, mirroring the pattern already used for `useTerritoryPlans` in the same file and for all three hooks in `ActivityFormModal`. Added a backward-compatible optional `options` arg to the hooks (no existing caller breaks).
- Added a btree index on `districts.name`. The list endpoint uses `ORDER BY name ASC` and supports `name ILIKE` search, but no index touched `name` — forcing a full-table sort on ~15-20k rows every call. Index already applied to production DB manually via Supabase SQL editor.

## Test plan

- [x] `tsc --noEmit` — no new errors from any file touched (unrelated news-table errors are pre-existing, pending `prisma generate` on a separate branch)
- [x] `vitest run PlansTable.test.tsx TasksTable.test.tsx` — 29/29 pass
- [x] Local dev trace confirms `/api/districts?limit=20` no longer fires on the Plans tab
- [ ] Verify on production after deploy: Plans tab Network trace should no longer show `districts?limit=20`; any modal that legitimately calls it should resolve in well under a second

## Follow-ups (not in scope)

- `/api/territory-plans` aggregation refactor — the route returns 91KB of deeply-nested relations to compute a few scalar sums. Highest-value remaining win.
- Kill sidebar/layout ghost calls — `leaderboard`, `dashboard`, `activities`, `events?status=pending` still fire on every tab from global layout components, not from modals.
- Dedup + speed up `profile` + `me` endpoints (two near-identical calls, both ~3s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)