### PR TITLE
feat(cron): wire up daily opportunity snapshot

### DIFF
--- a/prisma/migrations/20260427124201_add_opportunity_snapshots/migration.sql
+++ b/prisma/migrations/20260427124201_add_opportunity_snapshots/migration.sql
@@ -1,0 +1,45 @@
+-- Migration: add_opportunity_snapshots
+--
+-- Creates the opportunity_snapshots table used by /api/cron/pipeline-snapshot
+-- to capture daily point-in-time copies of each opportunity's key fields.
+-- One row per (opportunity_id, snapshot_date) — the unique constraint plus
+-- ON CONFLICT DO UPDATE in the cron route makes same-day re-runs idempotent.
+--
+-- Uses IF NOT EXISTS clauses because this table was already created out-of-band
+-- in production prior to this migration landing. Fresh databases will create
+-- it; production no-ops.
+
+CREATE TABLE IF NOT EXISTS "opportunity_snapshots" (
+  "id"                      BIGSERIAL PRIMARY KEY,
+  "snapshot_date"           DATE NOT NULL,
+  "opportunity_id"          TEXT NOT NULL,
+  "stage"                   TEXT,
+  "net_booking_amount"      DECIMAL(15, 2),
+  "minimum_purchase_amount" DECIMAL(15, 2),
+  "maximum_budget"          DECIMAL(15, 2),
+  "school_yr"               TEXT,
+  "sales_rep_id"            UUID,
+  "district_lea_id"         VARCHAR(7),
+  "close_date"              TIMESTAMPTZ,
+  "expiration"              TIMESTAMPTZ,
+  "captured_at"             TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'opportunity_snapshots_opportunity_id_snapshot_date_key'
+  ) THEN
+    ALTER TABLE "opportunity_snapshots"
+      ADD CONSTRAINT "opportunity_snapshots_opportunity_id_snapshot_date_key"
+      UNIQUE ("opportunity_id", "snapshot_date");
+  END IF;
+END$$;
+
+CREATE INDEX IF NOT EXISTS "opportunity_snapshots_snapshot_date_idx"
+  ON "opportunity_snapshots"("snapshot_date");
+CREATE INDEX IF NOT EXISTS "opportunity_snapshots_school_yr_snapshot_date_idx"
+  ON "opportunity_snapshots"("school_yr", "snapshot_date");
+CREATE INDEX IF NOT EXISTS "opportunity_snapshots_opportunity_id_idx"
+  ON "opportunity_snapshots"("opportunity_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1252,6 +1252,32 @@ model Opportunity {
   @@map("opportunities")
 }
 
+// Daily snapshot of every opportunity's key fields. Written by the
+// /api/cron/pipeline-snapshot route. Lets us answer "what did pipeline look
+// like N days ago" without replaying the audit log. One row per opp per
+// snapshot_date; unique constraint prevents duplicates within a single day.
+model OpportunitySnapshot {
+  id                    BigInt    @id @default(autoincrement())
+  snapshotDate          DateTime  @map("snapshot_date") @db.Date
+  opportunityId         String    @map("opportunity_id") @db.Text
+  stage                 String?   @db.Text
+  netBookingAmount      Decimal?  @map("net_booking_amount") @db.Decimal(15, 2)
+  minimumPurchaseAmount Decimal?  @map("minimum_purchase_amount") @db.Decimal(15, 2)
+  maximumBudget         Decimal?  @map("maximum_budget") @db.Decimal(15, 2)
+  schoolYr              String?   @map("school_yr") @db.Text
+  salesRepId            String?   @map("sales_rep_id") @db.Uuid
+  districtLeaId         String?   @map("district_lea_id") @db.VarChar(7)
+  closeDate             DateTime? @map("close_date") @db.Timestamptz
+  expiration            DateTime? @map("expiration") @db.Timestamptz
+  capturedAt            DateTime  @default(now()) @map("captured_at") @db.Timestamptz
+
+  @@unique([opportunityId, snapshotDate])
+  @@index([snapshotDate])
+  @@index([schoolYr, snapshotDate])
+  @@index([opportunityId])
+  @@map("opportunity_snapshots")
+}
+
 // ===== Sessions =====
 // Individual session records synced from OpenSearch.
 // Linked to opportunities by opportunity_id.

--- a/src/app/api/cron/pipeline-snapshot/route.ts
+++ b/src/app/api/cron/pipeline-snapshot/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60; // well under Vercel Pro 300s cap
+
+const CRON_SECRET = process.env.CRON_SECRET;
+
+/**
+ * GET /api/cron/pipeline-snapshot
+ *
+ * Writes one row per opportunity to opportunity_snapshots for the current
+ * snapshot_date. Runs daily (see vercel.json). Re-running on the same day is
+ * safe — the unique (opportunity_id, snapshot_date) constraint combined with
+ * ON CONFLICT DO UPDATE means the row is refreshed, not duplicated.
+ *
+ * Auth: CRON_SECRET via Authorization: Bearer ... or ?secret=... query param.
+ */
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get("authorization");
+  const { searchParams } = new URL(request.url);
+  const secretParam = searchParams.get("secret");
+
+  const provided = authHeader?.replace(/^Bearer\s+/i, "") ?? secretParam;
+  if (!CRON_SECRET || provided !== CRON_SECRET) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const startedAt = Date.now();
+  const today = new Date();
+  today.setUTCHours(0, 0, 0, 0);
+
+  // Pull only the fields we snapshot. school_yr filter excludes completed
+  // cycles to keep volume bounded; adjust as needed.
+  const opps = await prisma.opportunity.findMany({
+    where: {
+      schoolYr: { in: ["2024-25", "2025-26", "2026-27", "2027-28"] },
+    },
+    select: {
+      id: true,
+      stage: true,
+      netBookingAmount: true,
+      minimumPurchaseAmount: true,
+      maximumBudget: true,
+      schoolYr: true,
+      salesRepId: true,
+      districtLeaId: true,
+      closeDate: true,
+      expiration: true,
+    },
+  });
+
+  // Upsert so a second run on the same day updates rather than duplicates.
+  let inserted = 0;
+  const CHUNK = 500;
+  for (let i = 0; i < opps.length; i += CHUNK) {
+    const chunk = opps.slice(i, i + CHUNK);
+    await prisma.$transaction(
+      chunk.map((o) =>
+        prisma.opportunitySnapshot.upsert({
+          where: {
+            opportunityId_snapshotDate: {
+              opportunityId: o.id,
+              snapshotDate: today,
+            },
+          },
+          create: {
+            opportunityId: o.id,
+            snapshotDate: today,
+            stage: o.stage,
+            netBookingAmount: o.netBookingAmount,
+            minimumPurchaseAmount: o.minimumPurchaseAmount,
+            maximumBudget: o.maximumBudget,
+            schoolYr: o.schoolYr,
+            salesRepId: o.salesRepId,
+            districtLeaId: o.districtLeaId,
+            closeDate: o.closeDate,
+            expiration: o.expiration,
+          },
+          update: {
+            stage: o.stage,
+            netBookingAmount: o.netBookingAmount,
+            minimumPurchaseAmount: o.minimumPurchaseAmount,
+            maximumBudget: o.maximumBudget,
+            schoolYr: o.schoolYr,
+            salesRepId: o.salesRepId,
+            districtLeaId: o.districtLeaId,
+            closeDate: o.closeDate,
+            expiration: o.expiration,
+            capturedAt: new Date(),
+          },
+        })
+      )
+    );
+    inserted += chunk.length;
+  }
+
+  const elapsedMs = Date.now() - startedAt;
+  return NextResponse.json({
+    snapshotDate: today.toISOString().slice(0, 10),
+    oppsSnapshotted: inserted,
+    elapsedMs,
+  });
+}

--- a/vercel.json
+++ b/vercel.json
@@ -9,6 +9,10 @@
       "schedule": "0 6 * * *"
     },
     {
+      "path": "/api/cron/pipeline-snapshot?secret=${CRON_SECRET}",
+      "schedule": "0 7 * * *"
+    },
+    {
       "path": "/api/cron/leaderboard-slack-post?secret=${CRON_SECRET}",
       "schedule": "0 13 * * 1-5"
     },


### PR DESCRIPTION
## Summary
- Adds `/api/cron/pipeline-snapshot` route + `OpportunitySnapshot` Prisma model + `vercel.json` cron at `0 7 * * *` (daily, 02:00 CT).
- The cron was originally drafted on `feat/db-readiness-query-tool` but never landed on `main`, so it has never fired in production. This PR ports the snapshot bits (without the unrelated audit log / notes / attachments work from that commit) so it can ship standalone.
- Migration uses `CREATE TABLE IF NOT EXISTS` because the table was already created out-of-band in production (one manual snapshot row exists from 2026-04-20, plus a fresh one from 2026-04-27 captured today). Fresh databases will create it normally; production no-ops.

## Why daily
Snapshot volume is small (~2,400 opps × 12 cols ≈ a few hundred KB/day), and a daily cadence makes pipeline-movement reports much more useful than weekly.

## Test plan
- [ ] CI build passes (`prisma generate && next build`)
- [ ] After merge: confirm Vercel registers the new cron entry (Project Settings → Crons)
- [ ] Tomorrow morning: confirm a 2026-04-28 row appears in `opportunity_snapshots` shortly after 07:00 UTC
- [ ] Re-run within the same day returns 200 and updates rather than duplicates (verified by ON CONFLICT clause)
- [ ] If `prisma migrate deploy` ever runs against prod, the IF NOT EXISTS clauses make it a no-op against the existing table

🤖 Generated with [Claude Code](https://claude.com/claude-code)