### PR TITLE
feat(filters): inline editable min/max inputs on RangeFilter

### DIFF
--- a/Docs/superpowers/2026-04-27-filter-min-max-inputs-final-report.md
+++ b/Docs/superpowers/2026-04-27-filter-min-max-inputs-final-report.md
@@ -1,0 +1,185 @@
+# Code Review — RangeFilter inline min/max inputs
+
+**Date:** 2026-04-27
+**Branch:** `worktree-filter-min-max-inputs`
+**Spec:** `Docs/superpowers/specs/2026-04-27-filter-min-max-inputs-spec.md`
+**Plan:** `Docs/superpowers/plans/2026-04-27-filter-min-max-inputs-plan.md`
+**Recommendation:** READY FOR REVIEW
+
+## One-line summary
+
+Single-component change is well-scoped, fully spec-compliant, all consumers
+mechanically updated, 12 tests pass; one subtle Escape-after-typing timing
+that works in jsdom and almost certainly in real browsers but warrants a
+single manual smoke check.
+
+## Issue counts
+
+- Critical: 0
+- Important: 0
+- Suggestions: 3
+
+## Strengths
+
+- Clean separation between slider state (`lo`/`hi`) and typed input state
+  (`loInput`/`hiInput`), with focus-tracked guards (`loFocused`/`hiFocused`)
+  preventing the slider sync `useEffect` from clobbering in-progress typing.
+  See `RangeFilter.tsx:75-94`.
+- Spec compliance is complete: clamping, swap, step bypass, decimal handling,
+  bounds-reset removal, Escape revert, prefix/suffix adornments, aria labels,
+  `inputMode` derived from `step` — all implemented.
+- The plan suggested keeping `formatValue` on the interface for backward
+  compatibility; the implementation went one better and removed it entirely
+  along with the `formatCompact` default. This is a beneficial deviation —
+  consumers were all updated cleanly so no compat shim is needed.
+- All 5 dropdowns (`DistrictsDropdown`, `DemographicsDropdown`,
+  `FinanceDropdown`, `AcademicsDropdown`, `FullmindDropdown`) plus the
+  internal `FinancialRangeFilter` wrapper were updated mechanically with no
+  drift — every `formatValue={(v) => '$' + formatCompact(v)}` became
+  `prefix="$"`, every `formatValue={(v) => v + '%'}` became `suffix="%"`,
+  and unused `formatCompact` named imports were dropped (verified via grep —
+  no consumer imports `formatCompact` from `RangeFilter` anymore).
+- Tests are well-targeted across the 12 cases the plan called for, plus
+  swap-with-existing-filter (`RangeFilter.test.tsx:133-145`), decimal
+  rounding (`:147-155`), and decimal preservation when `step < 1`
+  (`:157-174`). Test setup mocks the Zustand store consistently with the
+  pattern in this codebase.
+- TypeScript: strict typing throughout, no `any`, no `@ts-ignore`. Naming
+  matches the spec/plan exactly (`commitLo`, `commitHi`, `loFocused`,
+  `hiFocused`, `parseTyped`, `applyImmediate`, `scheduleApply`).
+- Styling consistency preserved: inactive `text-[#A69DC0]`, active
+  `text-plum font-medium`, focus ring `focus:ring-1 focus:ring-plum/30`,
+  hover border `hover:border-[#D4CFE2]` — all match existing dropdown chrome
+  conventions and the documented Fullmind tokens (no Tailwind grays).
+
+## Plan deviations (all beneficial)
+
+- `formatValue` prop fully removed from `RangeFilterProps` rather than kept
+  optional (plan §1.1 said "kept for backward compat"). Since every consumer
+  was updated, removal is cleaner. Confirmed no remaining `formatValue`
+  references anywhere in `src/`.
+- `formatCompact` is still exported from `RangeFilter.tsx:17-25` but no
+  longer imported by any consumer. The plan's risk note worried
+  `FinancialRangeFilter` would still need it, but that wrapper now uses
+  `prefix="$"`. See Suggestion 1.
+
+## Suggestions (nice-to-have, none blocking)
+
+### S1 — `formatCompact` is a now-unused export
+
+`RangeFilter.tsx:17-25` defines and exports `formatCompact`, but no consumer
+imports it (verified via `grep -rn "formatCompact" src/`). It's also unused
+inside the file now that `formatValue` is gone. Either:
+
+- Remove it (cleanest), or
+- Move it to `src/features/shared/lib/format.ts` alongside the existing
+  `formatCompactNumber` (which has slightly different semantics — `14832`
+  becomes `"14.8K"` there but `"15K"` here, so they aren't drop-in
+  replacements).
+
+Low priority — dead exports don't hurt runtime, just clutter the API
+surface.
+
+### S2 — Escape-after-typing relies on subtle React event timing
+
+`RangeFilter.tsx:276-283` (and `:305-312` for max input):
+
+```tsx
+onKeyDown={(e) => {
+  if (e.key === "Enter") {
+    e.currentTarget.blur();
+  } else if (e.key === "Escape") {
+    setLoInput(String(lo));
+    e.currentTarget.blur();
+  }
+}}
+```
+
+The Escape branch calls `setLoInput(String(lo))` then synchronously calls
+`blur()`. The `onBlur` handler then calls `commitLo()`, which reads
+`loInput` from its closure. Whether `commitLo` sees the freshly-set `"0"`
+or the still-typed `"9999"` depends on whether React has flushed the
+keydown handler's state updates before invoking the synthetically-fired
+blur handler.
+
+I verified empirically in jsdom: `commitLo` reads the post-`setLoInput`
+value `"0"`, so `parseTyped` returns 0, the bounds-reset logic kicks in,
+no `onApply` is called, and `input.value` correctly shows `"0"`. The 12th
+test (`Escape reverts unsaved input`) confirms this. React 18+ also
+generally flushes discrete events before nested DOM-method-triggered
+events, so real browsers should behave the same. **Worth one explicit
+manual smoke test** to confirm Escape behavior in Chrome/Safari before
+ship — if it ever regresses, the hardening fix is a `skipNextCommit` ref:
+
+```tsx
+const skipNextCommitRef = useRef(false);
+// Escape branch:
+skipNextCommitRef.current = true;
+setLoInput(String(lo));
+e.currentTarget.blur();
+// commitLo entry:
+if (skipNextCommitRef.current) { skipNextCommitRef.current = false; return; }
+```
+
+Don't add this preemptively — current code is correct in jsdom and the
+ref-based pattern adds noise. Just noting for future debugging if the
+behavior ever flakes.
+
+### S3 — Test for `clamps a value above max` accidentally exercises bounds-reset
+
+`RangeFilter.test.tsx:111-121` types `999999999` into the max input,
+blurs, and asserts `input.value === "200000"`. Because the row starts
+inactive and `lo` defaults to `min=0`, the post-clamp state is
+`(0, 200000) === (min, max)`, which triggers the remove-filter branch
+rather than calling `onApply`. The comment at `:118-120` acknowledges
+this. To exercise pure clamping behavior (verify `onApply` is called
+with the clamped value), add a variant where the row already has an
+active sub-range:
+
+```tsx
+storeState.searchFilters = [{ id: "f", column: "enrollment", op: "between", value: [50, 100] }];
+// type 999999999 in max input → onApply should be called with (50, 200000)
+```
+
+The existing test's intent is a touch ambiguous between "clamping works"
+and "clamp + bounds-reset works." The `swap` test at `:133-145` already
+covers the `onApply`-with-clamped-value path indirectly, so this is
+purely a clarity nitpick.
+
+## Files reviewed
+
+Absolute paths:
+
+- `/Users/astonfurious/The Laboratory/territory-plan/.claude/worktrees/filter-min-max-inputs/src/features/map/components/SearchBar/controls/RangeFilter.tsx`
+- `/Users/astonfurious/The Laboratory/territory-plan/.claude/worktrees/filter-min-max-inputs/src/features/map/components/SearchBar/controls/__tests__/RangeFilter.test.tsx`
+- `/Users/astonfurious/The Laboratory/territory-plan/.claude/worktrees/filter-min-max-inputs/src/features/map/components/SearchBar/AcademicsDropdown.tsx`
+- `/Users/astonfurious/The Laboratory/territory-plan/.claude/worktrees/filter-min-max-inputs/src/features/map/components/SearchBar/DemographicsDropdown.tsx`
+- `/Users/astonfurious/The Laboratory/territory-plan/.claude/worktrees/filter-min-max-inputs/src/features/map/components/SearchBar/DistrictsDropdown.tsx`
+- `/Users/astonfurious/The Laboratory/territory-plan/.claude/worktrees/filter-min-max-inputs/src/features/map/components/SearchBar/FinanceDropdown.tsx`
+- `/Users/astonfurious/The Laboratory/territory-plan/.claude/worktrees/filter-min-max-inputs/src/features/map/components/SearchBar/FullmindDropdown.tsx`
+- `/Users/astonfurious/The Laboratory/territory-plan/.claude/worktrees/filter-min-max-inputs/Docs/superpowers/specs/2026-04-27-filter-min-max-inputs-spec.md`
+- `/Users/astonfurious/The Laboratory/territory-plan/.claude/worktrees/filter-min-max-inputs/Docs/superpowers/plans/2026-04-27-filter-min-max-inputs-plan.md`
+
+## Verification artifacts
+
+- 12/12 RangeFilter tests pass (re-ran during review)
+- The 15 pre-existing test failures elsewhere in the suite are unrelated
+  to this change (DB-dependent API tests + a SearchBar test missing fetch
+  mock; `SearchBar/index.tsx` is unchanged from main on this branch)
+- `npm run build` succeeds per the implementer's verification
+- `grep -rn "formatValue" src/` returns zero hits (full removal verified)
+- `grep -rn "formatCompact" src/` returns only the unused export at
+  `RangeFilter.tsx:17` and an unrelated definition in
+  `FlippablePlanCard.tsx` (different file, different function)
+
+## Security / perf
+
+- No XSS: `prefix`/`suffix` are rendered as plain text inside `<span>`
+  elements, never via `dangerouslySetInnerHTML` (`RangeFilter.tsx:260,
+  286, 289, 315`). Safe even if a future caller passes untrusted strings,
+  though current call sites are all hardcoded literals.
+- Perf: re-render count is identical to the pre-change behavior; the two
+  added `useState` slots (`loInput`, `hiInput`) and two boolean focus
+  flags don't introduce extra subscriptions to the Zustand store. The
+  existing narrow selectors (`s.searchFilters`, `s.removeSearchFilter`)
+  are preserved.

--- a/Docs/superpowers/plans/2026-04-27-filter-min-max-inputs-plan.md
+++ b/Docs/superpowers/plans/2026-04-27-filter-min-max-inputs-plan.md
@@ -1,0 +1,131 @@
+# Implementation Plan: RangeFilter inline min/max number inputs
+
+**Date:** 2026-04-27
+**Slug:** filter-min-max-inputs
+**Branch:** worktree-filter-min-max-inputs
+**Spec:** `Docs/superpowers/specs/2026-04-27-filter-min-max-inputs-spec.md`
+
+## Scope
+
+Single-component frontend change. No backend, no schema, no API, no store
+changes. The shared `RangeFilter` component is consumed by 5 dropdowns —
+modifying it once propagates everywhere.
+
+## File touch list
+
+| File | Change |
+|---|---|
+| `src/features/map/components/SearchBar/controls/RangeFilter.tsx` | **Modified.** Replace static value labels with editable inputs. Add `prefix` and `suffix` optional props for currency / percent adornments. Add typing/blur/Enter/Escape handlers. |
+| `src/features/map/components/SearchBar/DistrictsDropdown.tsx` | **Modified.** Pass `prefix="$"` to currency rows (Pipeline, Bookings, Invoicing, Expenditure / Pupil, Total/Federal/State/Local Revenue, Tech Spending, Title I Revenue, ESSER, Median Household Income, SPED Expenditure / Student); pass `suffix="%"` to percent rows (ELL, SWD, Poverty, Graduation, Math, Reading, Chronic Absenteeism, Enrollment Trend). Drop `formatValue` for these — adornment lives outside the input. |
+| `src/features/map/components/SearchBar/DemographicsDropdown.tsx` | **Modified.** Same prop swap as above for the rows it owns. |
+| `src/features/map/components/SearchBar/FinanceDropdown.tsx` | **Modified.** Same prop swap. |
+| `src/features/map/components/SearchBar/AcademicsDropdown.tsx` | **Modified.** Same prop swap. |
+| `src/features/map/components/SearchBar/FullmindDropdown.tsx` | **Modified.** Same prop swap (Pipeline / Bookings / Invoicing). |
+| `src/features/map/components/SearchBar/controls/__tests__/RangeFilter.test.tsx` | **New.** Vitest + Testing Library tests covering typing, blur/Enter/Escape, clamping, swap, step bypass. |
+
+## Task ordering
+
+### Task 1 — Modify `RangeFilter.tsx`
+
+1. Add to `RangeFilterProps`:
+   - `prefix?: string` — rendered before the input as a non-editable adornment (e.g., `"$"`).
+   - `suffix?: string` — rendered after the input as a non-editable adornment (e.g., `"%"`).
+   - `formatValue` stays for backward compatibility but is no longer used inside the component (kept so existing call sites continue compiling without diff churn; actual currency / percent presentation moves to `prefix` / `suffix`). Mark internally as unused.
+2. Add local input state separate from `lo` / `hi`:
+   - `loInput: string`, `hiInput: string` — strings, mirror committed `lo` / `hi` whenever those change externally (slider drag, external clear).
+3. Replace the two `<span>` value labels with two `<input>` elements:
+   - `type="text"`, `inputMode={step < 1 ? "decimal" : "numeric"}`
+   - `aria-label={\`${label} minimum\`}` / maximum
+   - `className` matches today's label color/size (`text-[10px] tabular-nums`) plus input affordances: `bg-transparent`, `w-16`, `px-1.5`, `py-0.5`, `rounded`, `border border-transparent hover:border-[#D4CFE2]`, `focus:outline-none focus:ring-1 focus:ring-plum/30 focus:border-plum/30`
+   - Active-state plum text reuses today's `text-plum font-medium` conditional
+4. Wire handlers:
+   - `onChange` → updates `loInput` / `hiInput` only
+   - `onFocus` → `e.currentTarget.select()`
+   - `onBlur` → call `commitLo` / `commitHi`
+   - `onKeyDown`:
+     - `Enter` → `e.currentTarget.blur()` (triggers blur commit)
+     - `Escape` → revert input to last committed value, blur
+5. `commitLo` / `commitHi` behavior:
+   - Parse via `Number(input)`. If `NaN` or empty → revert input string to current `lo` / `hi`, no apply.
+   - Round to integer if `step >= 1`.
+   - Clamp to `[min, max]`.
+   - For `commitLo`: if parsed > current `hi`, swap (set `lo = hi`, `hi = parsed`); else `setLo(parsed)`.
+   - For `commitHi`: mirror.
+   - Sync the input string to the committed numeric value.
+   - Call `scheduleApply` (existing function — keep its `min/max → removeFilter` behavior).
+6. Render adornments:
+   - Each input wrapped in a flex container; if `prefix`, render `<span>` before input; if `suffix`, render after.
+   - Adornments use the same color/state classes as the input text.
+7. Live sync during slider drag:
+   - When the slider changes `lo` / `hi`, the `useEffect` that already syncs to `existingValues` is enough — extend it to also reset `loInput` / `hiInput` strings.
+   - When the user is *focused* on an input, do **not** overwrite their typing. Track focus via two booleans (`loFocused`, `hiFocused`).
+
+### Task 2 — Update consumers
+
+For each of the 5 dropdowns, audit every `<RangeFilter>` call:
+- If the call has `formatValue={(v) => \`$${formatCompact(v)}\`}` → replace with `prefix="$"` and drop `formatValue`.
+- If the call has `formatValue={(v) => \`${v}%\`}` → replace with `suffix="%"` and drop `formatValue`.
+- Calls with no `formatValue` stay as-is.
+- The `formatCompact` import stays only where still used elsewhere in the file (it isn't used outside RangeFilter calls — once removed from the calls, drop the import to keep lint clean).
+
+Concrete map per file:
+- **DistrictsDropdown.tsx**: `FullmindContent` Pipeline/Bookings/Invoicing → `prefix="$"`. `FinanceContent` all 8 rows → `prefix="$"`. `DemographicsContent`: ELL/SWD/Poverty rows have no formatValue today (none of the percent rows in this file pass it), but Median Household Income → `prefix="$"`, Enrollment Trend → `suffix="%"`. `AcademicsContent`: 4 percent rows → `suffix="%"`, SPED Expenditure → `prefix="$"`, others as-is. (Confirm by re-reading the file before editing.)
+- **DemographicsDropdown.tsx**: Median Household Income → `prefix="$"`, Enrollment Trend → `suffix="%"`. Other rows already had no formatValue.
+- **FinanceDropdown.tsx**: every currency row → `prefix="$"`.
+- **AcademicsDropdown.tsx**: percent rows → `suffix="%"`, currency rows → `prefix="$"`.
+- **FullmindDropdown.tsx**: Pipeline / Bookings / Invoicing → `prefix="$"`.
+
+Drop unused `formatCompact` imports.
+
+### Task 3 — Add component tests
+
+`src/features/map/components/SearchBar/controls/__tests__/RangeFilter.test.tsx`:
+- `renders min and max inputs alongside the slider`
+- `typing in min input does not apply until blur`
+- `pressing Enter commits the typed value`
+- `Escape reverts unsaved input`
+- `typing 137 in a step=500 row commits 137 (bypasses step)`
+- `typing a value above max clamps to max`
+- `typing a min greater than current max swaps lo and hi`
+- `slider drag updates input value when input is not focused`
+- `prefix and suffix adornments render outside the input`
+- `setting both inputs back to bounds removes the filter`
+
+Mock the Zustand store via the existing test pattern (read `SearchBar.test.tsx`
+and `FilterMultiSelect.test.tsx` first to match conventions).
+
+### Task 4 — Verification
+
+- `npx vitest run src/features/map/components/SearchBar/controls/__tests__/RangeFilter.test.tsx`
+- `npx vitest run` — full suite, ensure no regressions in `SearchBar.test.tsx`
+- `npm run build` — must succeed
+
+### Task 5 — Manual smoke (Stage 8)
+
+Open `/` in dev, click Districts dropdown, expand each section, verify:
+- Each row shows two inputs underneath the slider (was static text)
+- Typing 137 in Enrollment min, blurring → filter pill shows `Enrollment 137-200000`
+- Slider drag still works, inputs update live
+- `$` and `%` adornments render where expected
+- Escape reverts mid-type changes
+- Resetting both inputs to bounds removes the filter (matching today's slider reset behavior)
+
+## Dependencies & ordering
+
+Task 1 must complete before Task 2 (consumers reference new props).
+Task 3 can run in parallel with Task 2 once Task 1 lands.
+Task 4 runs after 1-3.
+Task 5 runs last.
+
+## Risk notes
+
+- `formatCompact` exported from RangeFilter — kept exported even though no
+  longer used internally, since `FullmindContent`'s `FinancialRangeFilter`
+  wrapper passes it explicitly. Verify by grepping `formatCompact` usage.
+- Slider thumb at typed value 137 in a step=500 slider: native `<input
+  type="range">` rounds the displayed thumb position to the nearest step. The
+  underlying state stores 137 exactly. Visual jitter is expected and OK —
+  document this in a single-line comment in `RangeFilter.tsx`.
+- Backward compatibility: `formatValue` prop kept optional in the interface
+  to avoid call-site churn during refactor; we just don't use it for inputs.
+  The currently-rendered "value labels" disappear since they become inputs.

--- a/Docs/superpowers/specs/2026-04-27-filter-min-max-inputs-spec.md
+++ b/Docs/superpowers/specs/2026-04-27-filter-min-max-inputs-spec.md
@@ -1,0 +1,117 @@
+# Feature Spec: RangeFilter inline min/max number inputs
+
+**Date:** 2026-04-27
+**Slug:** filter-min-max-inputs
+**Branch:** worktree-filter-min-max-inputs
+
+## Requirements
+
+Reps using the District Filters dropdown today have to drag dual-thumb sliders
+to set min/max for histogram-style filters (Enrollment, ELL %, SWD %, Poverty %,
+Median Income, Enrollment Trend, all Finance rows, all Academics rows, and the
+Fullmind FY-aware Pipeline / Bookings / Invoicing rows). The sliders use a
+coarse `step` (e.g., Enrollment step = 500), which prevents reps from selecting
+a precise sub-range like 100–200 inside the 0–500 bucket.
+
+Replace the static `formatValue(lo)` / `formatValue(hi)` text labels under
+each slider with editable number inputs so reps can type any integer (or
+decimal where the row's step < 1) inside the row's `[min, max]` range.
+
+## Visual Design
+
+- Approved approach: **edit-in-place — replace the two static value labels
+  beneath each slider with `<input>` elements occupying the same screen
+  positions and visual weight**
+- The dropdown chrome, section headers, slider track, slider thumbs, and
+  active-state plum tint stay exactly as today
+- Currency rows (`$`) and percent rows (`%`) render a small adornment outside
+  the input rather than embedding it; raw integers live inside the input
+
+### Per-row layout
+
+```
+Enrollment                                  [Remove]
+●━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━●
+[      0]                          [ 200000]
+```
+
+- Left input left-aligned; right input right-aligned (mirrors today)
+- Each input ~64px wide, `text-[10px] tabular-nums`
+- Active filter: plum text matching today's active label color
+- Focus ring: `focus:ring-1 focus:ring-plum/30`
+- Placeholder shows the bound (`placeholder="0"` / `placeholder="200000"`)
+- Click selects all text for fast overwrite
+
+### Key architectural decisions
+
+- **Single component change.** The shared `RangeFilter` is consumed by
+  `DistrictsDropdown`, `DemographicsDropdown`, and `FinancialRangeFilter`
+  (an FY-aware wrapper). Modifying it once propagates to every row.
+- **Inputs do not affect slider step.** Slider step controls drag granularity
+  only; typed values bypass step entirely.
+- **Apply on blur / Enter, not while typing.** Slider drag stays debounced as
+  today (300ms); typed entries commit on blur or Enter. This avoids partial
+  values like `1` flashing as a filter while the user types `150`.
+
+## Component Plan
+
+- **Existing components to reuse:**
+  - `RangeFilter` (`src/features/map/components/SearchBar/controls/RangeFilter.tsx`) — modified in place
+  - `formatCompact` — exported as today, still used by callers passing it to the slider value labels (now used only for adornments / pill display, not inside inputs)
+- **New components:** none
+- **Components to extend:** none — `FinancialRangeFilter`,
+  `DemographicsDropdown`, `DistrictsDropdown` consume `RangeFilter` via props
+  and inherit the change for free
+
+## Backend Design
+
+**No backend changes.** The store's `searchFilters` already supports `between`
+ops with arbitrary `[number, number]` values; the existing
+`addSearchFilter` / `updateSearchFilter` / `removeSearchFilter` actions remain
+untouched. SQL filtering downstream of `searchFilters` already accepts
+non-step values.
+
+## States
+
+- **Inactive (no filter set):** inputs render min and max in muted plum text;
+  no plum background ring on the row
+- **Active (filter set):** inputs render `lo` / `hi` in plum; row gets the
+  existing `bg-plum/5 ring-1 ring-plum/15` treatment
+- **Focused:** plum focus ring on the input; no other visual change
+- **Drag in progress:** inputs reflect the slider's live value
+- **Mid-typing:** inputs hold the typed string locally; no validation flash;
+  no filter mutation
+- **Invalid on blur:** revert to last valid applied value silently
+- **lo > hi after typing:** swap so the smaller value is min and larger is max
+
+## Validation rules
+
+Run on blur or Enter:
+
+1. Parse via `Number(...)`. If `NaN` or empty string → revert to last valid.
+2. Clamp to `[min, max]` of the row.
+3. If `step < 1`, accept decimals; else round/parseInt to integers.
+4. If `lo > hi`, swap.
+5. If both equal `min` and `max` (i.e., the user reset to bounds) →
+   call `removeSearchFilter` (matches today's slider behavior).
+6. Otherwise → call `onApply(column, lo, hi)`.
+
+## Accessibility
+
+- `aria-label="${label} minimum"` / `"${label} maximum"` per input
+- `inputMode="numeric"` (or `"decimal"` for step < 1)
+- `type="text"` (not `type="number"`) to avoid native spinners and to keep
+  parsing under our control
+- Escape key restores last applied value and blurs
+
+## Out of Scope
+
+- Any change to slider step granularity (e.g., making Enrollment step = 1
+  for the slider itself). Step keeps its current behavior; typed input
+  bypasses it.
+- Replacing the dual-thumb slider with anything else.
+- Format-aware input parsing (e.g., typing `"200K"` and parsing back to
+  200000). Inputs accept raw integers/decimals only.
+- New filter ops, new store fields, new API routes.
+- Visual changes to filter pills, the section header chevron, or the
+  collapsible section behavior.

--- a/src/features/map/components/SearchBar/AcademicsDropdown.tsx
+++ b/src/features/map/components/SearchBar/AcademicsDropdown.tsx
@@ -2,7 +2,7 @@
 
 import { useRef, useEffect } from "react";
 import { useMapV2Store } from "@/features/map/lib/store";
-import RangeFilter, { formatCompact } from "./controls/RangeFilter";
+import RangeFilter from "./controls/RangeFilter";
 
 
 interface AcademicsDropdownProps {
@@ -46,13 +46,13 @@ export default function AcademicsDropdown({ onClose }: AcademicsDropdownProps) {
       </div>
 
       <div className="space-y-3">
-        <RangeFilter label="Graduation Rate %" column="graduationRate" min={0} max={100} step={1} onApply={handleApply} />
-        <RangeFilter label="Math Proficiency %" column="mathProficiency" min={0} max={100} step={1} onApply={handleApply} />
-        <RangeFilter label="Reading Proficiency %" column="readProficiency" min={0} max={100} step={1} onApply={handleApply} />
-        <RangeFilter label="Chronic Absenteeism %" column="chronicAbsenteeismRate" min={0} max={100} step={1} onApply={handleApply} />
+        <RangeFilter label="Graduation Rate %" column="graduationRate" min={0} max={100} step={1} suffix="%" onApply={handleApply} />
+        <RangeFilter label="Math Proficiency %" column="mathProficiency" min={0} max={100} step={1} suffix="%" onApply={handleApply} />
+        <RangeFilter label="Reading Proficiency %" column="readProficiency" min={0} max={100} step={1} suffix="%" onApply={handleApply} />
+        <RangeFilter label="Chronic Absenteeism %" column="chronicAbsenteeismRate" min={0} max={100} step={1} suffix="%" onApply={handleApply} />
         <RangeFilter label="Student-Teacher Ratio" column="studentTeacherRatio" min={0} max={50} step={0.5} onApply={handleApply} />
         <RangeFilter label="Teacher FTE" column="teachersFte" min={0} max={10000} step={10} onApply={handleApply} />
-        <RangeFilter label="SPED Expenditure / Student" column="spedExpenditurePerStudent" min={0} max={50000} step={500} formatValue={(v) => `$${formatCompact(v)}`} onApply={handleApply} />
+        <RangeFilter label="SPED Expenditure / Student" column="spedExpenditurePerStudent" min={0} max={50000} step={500} prefix="$" onApply={handleApply} />
       </div>
     </div>
   );

--- a/src/features/map/components/SearchBar/DemographicsDropdown.tsx
+++ b/src/features/map/components/SearchBar/DemographicsDropdown.tsx
@@ -2,7 +2,7 @@
 
 import { useRef, useEffect } from "react";
 import { useMapV2Store } from "@/features/map/lib/store";
-import RangeFilter, { formatCompact } from "./controls/RangeFilter";
+import RangeFilter from "./controls/RangeFilter";
 
 
 interface DemographicsDropdownProps {
@@ -47,11 +47,11 @@ export default function DemographicsDropdown({ onClose }: DemographicsDropdownPr
 
       <div className="space-y-3">
         <RangeFilter label="Enrollment" column="enrollment" min={0} max={200000} step={500} onApply={handleApply} />
-        <RangeFilter label="ELL %" column="ell_percent" min={0} max={100} step={1} onApply={handleApply} />
-        <RangeFilter label="SWD %" column="sped_percent" min={0} max={100} step={1} onApply={handleApply} />
-        <RangeFilter label="Poverty %" column="free_lunch_percent" min={0} max={100} step={1} onApply={handleApply} />
-        <RangeFilter label="Median Household Income" column="medianHouseholdIncome" min={0} max={250000} step={5000} formatValue={(v) => `$${formatCompact(v)}`} onApply={handleApply} />
-        <RangeFilter label="Enrollment Trend (3yr)" column="enrollmentTrend3yr" min={-50} max={50} step={0.5} formatValue={(v) => `${v}%`} onApply={handleApply} />
+        <RangeFilter label="ELL %" column="ell_percent" min={0} max={100} step={1} suffix="%" onApply={handleApply} />
+        <RangeFilter label="SWD %" column="sped_percent" min={0} max={100} step={1} suffix="%" onApply={handleApply} />
+        <RangeFilter label="Poverty %" column="free_lunch_percent" min={0} max={100} step={1} suffix="%" onApply={handleApply} />
+        <RangeFilter label="Median Household Income" column="medianHouseholdIncome" min={0} max={250000} step={5000} prefix="$" onApply={handleApply} />
+        <RangeFilter label="Enrollment Trend (3yr)" column="enrollmentTrend3yr" min={-50} max={50} step={0.5} suffix="%" onApply={handleApply} />
       </div>
     </div>
   );

--- a/src/features/map/components/SearchBar/DistrictsDropdown.tsx
+++ b/src/features/map/components/SearchBar/DistrictsDropdown.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useRef, useEffect } from "react";
 import { useMapV2Store, type ExploreFilter } from "@/features/map/lib/store";
-import RangeFilter, { formatCompact } from "./controls/RangeFilter";
+import RangeFilter from "./controls/RangeFilter";
 import ToggleChips from "./controls/ToggleChips";
 import FilterMultiSelect from "./controls/FilterMultiSelect";
 
@@ -242,7 +242,8 @@ function FinancialRangeFilter({
   min,
   max,
   step,
-  formatValue,
+  prefix,
+  suffix,
   onApply,
 }: {
   label: string;
@@ -251,7 +252,8 @@ function FinancialRangeFilter({
   min: number;
   max: number;
   step: number;
-  formatValue: (v: number) => string;
+  prefix?: string;
+  suffix?: string;
   onApply: (column: string, min: number, max: number, fy: string) => void;
 }) {
   const [fy, setFy] = useState(defaultFy);
@@ -275,7 +277,8 @@ function FinancialRangeFilter({
         min={min}
         max={max}
         step={step}
-        formatValue={formatValue}
+        prefix={prefix}
+        suffix={suffix}
         onApply={(col, lo, hi) => onApply(col, lo, hi, fy)}
       />
     </div>
@@ -325,9 +328,9 @@ function FullmindContent({
         }}
       />
 
-      <FinancialRangeFilter label="Pipeline" column="open_pipeline" defaultFy={defaultFy} min={0} max={500000} step={5000} formatValue={(v) => `$${formatCompact(v)}`} onApply={handleFinancialRangeApply} />
-      <FinancialRangeFilter label="Bookings" column="closed_won_bookings" defaultFy={defaultFy} min={0} max={500000} step={5000} formatValue={(v) => `$${formatCompact(v)}`} onApply={handleFinancialRangeApply} />
-      <FinancialRangeFilter label="Invoicing" column="invoicing" defaultFy={defaultFy} min={0} max={500000} step={5000} formatValue={(v) => `$${formatCompact(v)}`} onApply={handleFinancialRangeApply} />
+      <FinancialRangeFilter label="Pipeline" column="open_pipeline" defaultFy={defaultFy} min={0} max={500000} step={5000} prefix="$" onApply={handleFinancialRangeApply} />
+      <FinancialRangeFilter label="Bookings" column="closed_won_bookings" defaultFy={defaultFy} min={0} max={500000} step={5000} prefix="$" onApply={handleFinancialRangeApply} />
+      <FinancialRangeFilter label="Invoicing" column="invoicing" defaultFy={defaultFy} min={0} max={500000} step={5000} prefix="$" onApply={handleFinancialRangeApply} />
 
       <FilterMultiSelect
         label="Tags"
@@ -392,14 +395,14 @@ function CompetitorsContent({
 function FinanceContent({ handleRangeApply }: { handleRangeApply: (column: string, min: number, max: number) => void }) {
   return (
     <>
-      <RangeFilter label="Expenditure / Pupil" column="expenditurePerPupil" min={0} max={50000} step={500} formatValue={(v) => `$${formatCompact(v)}`} onApply={handleRangeApply} />
-      <RangeFilter label="Total Revenue" column="totalRevenue" min={0} max={2000000000} step={10000000} formatValue={(v) => `$${formatCompact(v)}`} onApply={handleRangeApply} />
-      <RangeFilter label="Federal Revenue" column="federalRevenue" min={0} max={500000000} step={5000000} formatValue={(v) => `$${formatCompact(v)}`} onApply={handleRangeApply} />
-      <RangeFilter label="State Revenue" column="stateRevenue" min={0} max={1000000000} step={10000000} formatValue={(v) => `$${formatCompact(v)}`} onApply={handleRangeApply} />
-      <RangeFilter label="Local Revenue" column="localRevenue" min={0} max={1000000000} step={10000000} formatValue={(v) => `$${formatCompact(v)}`} onApply={handleRangeApply} />
-      <RangeFilter label="Tech Spending" column="techSpending" min={0} max={50000000} step={500000} formatValue={(v) => `$${formatCompact(v)}`} onApply={handleRangeApply} />
-      <RangeFilter label="Title I Revenue" column="titleIRevenue" min={0} max={50000000} step={500000} formatValue={(v) => `$${formatCompact(v)}`} onApply={handleRangeApply} />
-      <RangeFilter label="ESSER Funding" column="esserFundingTotal" min={0} max={100000000} step={1000000} formatValue={(v) => `$${formatCompact(v)}`} onApply={handleRangeApply} />
+      <RangeFilter label="Expenditure / Pupil" column="expenditurePerPupil" min={0} max={50000} step={500} prefix="$" onApply={handleRangeApply} />
+      <RangeFilter label="Total Revenue" column="totalRevenue" min={0} max={2000000000} step={10000000} prefix="$" onApply={handleRangeApply} />
+      <RangeFilter label="Federal Revenue" column="federalRevenue" min={0} max={500000000} step={5000000} prefix="$" onApply={handleRangeApply} />
+      <RangeFilter label="State Revenue" column="stateRevenue" min={0} max={1000000000} step={10000000} prefix="$" onApply={handleRangeApply} />
+      <RangeFilter label="Local Revenue" column="localRevenue" min={0} max={1000000000} step={10000000} prefix="$" onApply={handleRangeApply} />
+      <RangeFilter label="Tech Spending" column="techSpending" min={0} max={50000000} step={500000} prefix="$" onApply={handleRangeApply} />
+      <RangeFilter label="Title I Revenue" column="titleIRevenue" min={0} max={50000000} step={500000} prefix="$" onApply={handleRangeApply} />
+      <RangeFilter label="ESSER Funding" column="esserFundingTotal" min={0} max={100000000} step={1000000} prefix="$" onApply={handleRangeApply} />
     </>
   );
 }
@@ -408,11 +411,11 @@ function DemographicsContent({ handleRangeApply }: { handleRangeApply: (column: 
   return (
     <>
       <RangeFilter label="Enrollment" column="enrollment" min={0} max={200000} step={500} onApply={handleRangeApply} />
-      <RangeFilter label="ELL %" column="ell_percent" min={0} max={100} step={1} onApply={handleRangeApply} />
-      <RangeFilter label="SWD %" column="sped_percent" min={0} max={100} step={1} onApply={handleRangeApply} />
-      <RangeFilter label="Poverty %" column="free_lunch_percent" min={0} max={100} step={1} onApply={handleRangeApply} />
-      <RangeFilter label="Median Household Income" column="medianHouseholdIncome" min={0} max={250000} step={5000} formatValue={(v) => `$${formatCompact(v)}`} onApply={handleRangeApply} />
-      <RangeFilter label="Enrollment Trend (3yr)" column="enrollmentTrend3yr" min={-50} max={50} step={0.5} formatValue={(v) => `${v}%`} onApply={handleRangeApply} />
+      <RangeFilter label="ELL %" column="ell_percent" min={0} max={100} step={1} suffix="%" onApply={handleRangeApply} />
+      <RangeFilter label="SWD %" column="sped_percent" min={0} max={100} step={1} suffix="%" onApply={handleRangeApply} />
+      <RangeFilter label="Poverty %" column="free_lunch_percent" min={0} max={100} step={1} suffix="%" onApply={handleRangeApply} />
+      <RangeFilter label="Median Household Income" column="medianHouseholdIncome" min={0} max={250000} step={5000} prefix="$" onApply={handleRangeApply} />
+      <RangeFilter label="Enrollment Trend (3yr)" column="enrollmentTrend3yr" min={-50} max={50} step={0.5} suffix="%" onApply={handleRangeApply} />
     </>
   );
 }
@@ -420,13 +423,13 @@ function DemographicsContent({ handleRangeApply }: { handleRangeApply: (column: 
 function AcademicsContent({ handleRangeApply }: { handleRangeApply: (column: string, min: number, max: number) => void }) {
   return (
     <>
-      <RangeFilter label="Graduation Rate %" column="graduationRate" min={0} max={100} step={1} onApply={handleRangeApply} />
-      <RangeFilter label="Math Proficiency %" column="mathProficiency" min={0} max={100} step={1} onApply={handleRangeApply} />
-      <RangeFilter label="Reading Proficiency %" column="readProficiency" min={0} max={100} step={1} onApply={handleRangeApply} />
-      <RangeFilter label="Chronic Absenteeism %" column="chronicAbsenteeismRate" min={0} max={100} step={1} onApply={handleRangeApply} />
+      <RangeFilter label="Graduation Rate %" column="graduationRate" min={0} max={100} step={1} suffix="%" onApply={handleRangeApply} />
+      <RangeFilter label="Math Proficiency %" column="mathProficiency" min={0} max={100} step={1} suffix="%" onApply={handleRangeApply} />
+      <RangeFilter label="Reading Proficiency %" column="readProficiency" min={0} max={100} step={1} suffix="%" onApply={handleRangeApply} />
+      <RangeFilter label="Chronic Absenteeism %" column="chronicAbsenteeismRate" min={0} max={100} step={1} suffix="%" onApply={handleRangeApply} />
       <RangeFilter label="Student-Teacher Ratio" column="studentTeacherRatio" min={0} max={50} step={0.5} onApply={handleRangeApply} />
       <RangeFilter label="Teacher FTE" column="teachersFte" min={0} max={10000} step={10} onApply={handleRangeApply} />
-      <RangeFilter label="SPED Expenditure / Student" column="spedExpenditurePerStudent" min={0} max={50000} step={500} formatValue={(v) => `$${formatCompact(v)}`} onApply={handleRangeApply} />
+      <RangeFilter label="SPED Expenditure / Student" column="spedExpenditurePerStudent" min={0} max={50000} step={500} prefix="$" onApply={handleRangeApply} />
     </>
   );
 }

--- a/src/features/map/components/SearchBar/FinanceDropdown.tsx
+++ b/src/features/map/components/SearchBar/FinanceDropdown.tsx
@@ -2,7 +2,7 @@
 
 import { useRef, useEffect } from "react";
 import { useMapV2Store } from "@/features/map/lib/store";
-import RangeFilter, { formatCompact } from "./controls/RangeFilter";
+import RangeFilter from "./controls/RangeFilter";
 
 
 interface FinanceDropdownProps {
@@ -46,14 +46,14 @@ export default function FinanceDropdown({ onClose }: FinanceDropdownProps) {
       </div>
 
       <div className="space-y-3">
-        <RangeFilter label="Expenditure / Pupil" column="expenditurePerPupil" min={0} max={50000} step={500} formatValue={(v) => `$${formatCompact(v)}`} onApply={handleApply} />
-        <RangeFilter label="Total Revenue" column="totalRevenue" min={0} max={2000000000} step={10000000} formatValue={(v) => `$${formatCompact(v)}`} onApply={handleApply} />
-        <RangeFilter label="Federal Revenue" column="federalRevenue" min={0} max={500000000} step={5000000} formatValue={(v) => `$${formatCompact(v)}`} onApply={handleApply} />
-        <RangeFilter label="State Revenue" column="stateRevenue" min={0} max={1000000000} step={10000000} formatValue={(v) => `$${formatCompact(v)}`} onApply={handleApply} />
-        <RangeFilter label="Local Revenue" column="localRevenue" min={0} max={1000000000} step={10000000} formatValue={(v) => `$${formatCompact(v)}`} onApply={handleApply} />
-        <RangeFilter label="Tech Spending" column="techSpending" min={0} max={50000000} step={500000} formatValue={(v) => `$${formatCompact(v)}`} onApply={handleApply} />
-        <RangeFilter label="Title I Revenue" column="titleIRevenue" min={0} max={50000000} step={500000} formatValue={(v) => `$${formatCompact(v)}`} onApply={handleApply} />
-        <RangeFilter label="ESSER Funding" column="esserFundingTotal" min={0} max={100000000} step={1000000} formatValue={(v) => `$${formatCompact(v)}`} onApply={handleApply} />
+        <RangeFilter label="Expenditure / Pupil" column="expenditurePerPupil" min={0} max={50000} step={500} prefix="$" onApply={handleApply} />
+        <RangeFilter label="Total Revenue" column="totalRevenue" min={0} max={2000000000} step={10000000} prefix="$" onApply={handleApply} />
+        <RangeFilter label="Federal Revenue" column="federalRevenue" min={0} max={500000000} step={5000000} prefix="$" onApply={handleApply} />
+        <RangeFilter label="State Revenue" column="stateRevenue" min={0} max={1000000000} step={10000000} prefix="$" onApply={handleApply} />
+        <RangeFilter label="Local Revenue" column="localRevenue" min={0} max={1000000000} step={10000000} prefix="$" onApply={handleApply} />
+        <RangeFilter label="Tech Spending" column="techSpending" min={0} max={50000000} step={500000} prefix="$" onApply={handleApply} />
+        <RangeFilter label="Title I Revenue" column="titleIRevenue" min={0} max={50000000} step={500000} prefix="$" onApply={handleApply} />
+        <RangeFilter label="ESSER Funding" column="esserFundingTotal" min={0} max={100000000} step={1000000} prefix="$" onApply={handleApply} />
       </div>
     </div>
   );

--- a/src/features/map/components/SearchBar/FullmindDropdown.tsx
+++ b/src/features/map/components/SearchBar/FullmindDropdown.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect } from "react";
 import { useMapV2Store } from "@/features/map/lib/store";
-import RangeFilter, { formatCompact } from "./controls/RangeFilter";
+import RangeFilter from "./controls/RangeFilter";
 import ToggleChips from "./controls/ToggleChips";
 import FilterSelect from "./controls/FilterSelect";
 import FilterMultiSelect from "./controls/FilterMultiSelect";
@@ -93,9 +93,9 @@ export default function FullmindDropdown({ onClose }: FullmindDropdownProps) {
           />
         )}
 
-        <RangeFilter label={`${fyLabel} Pipeline Value`} column={`${selectedFY}_open_pipeline_value`} min={0} max={500000} step={5000} formatValue={(v) => `$${formatCompact(v)}`} onApply={(col, lo, hi) => addFilter(col, "between", [lo, hi])} />
-        <RangeFilter label={`${fyLabel} Bookings`} column={`${selectedFY}_closed_won_net_booking`} min={0} max={500000} step={5000} formatValue={(v) => `$${formatCompact(v)}`} onApply={(col, lo, hi) => addFilter(col, "between", [lo, hi])} />
-        <RangeFilter label={`${fyLabel} Invoicing`} column={`${selectedFY}_net_invoicing`} min={0} max={500000} step={5000} formatValue={(v) => `$${formatCompact(v)}`} onApply={(col, lo, hi) => addFilter(col, "between", [lo, hi])} />
+        <RangeFilter label={`${fyLabel} Pipeline Value`} column={`${selectedFY}_open_pipeline_value`} min={0} max={500000} step={5000} prefix="$" onApply={(col, lo, hi) => addFilter(col, "between", [lo, hi])} />
+        <RangeFilter label={`${fyLabel} Bookings`} column={`${selectedFY}_closed_won_net_booking`} min={0} max={500000} step={5000} prefix="$" onApply={(col, lo, hi) => addFilter(col, "between", [lo, hi])} />
+        <RangeFilter label={`${fyLabel} Invoicing`} column={`${selectedFY}_net_invoicing`} min={0} max={500000} step={5000} prefix="$" onApply={(col, lo, hi) => addFilter(col, "between", [lo, hi])} />
 
         {plans.length > 0 && (
           <FilterMultiSelect

--- a/src/features/map/components/SearchBar/controls/RangeFilter.tsx
+++ b/src/features/map/components/SearchBar/controls/RangeFilter.tsx
@@ -14,16 +14,6 @@ interface RangeFilterProps {
   onApply: (column: string, min: number, max: number) => void;
 }
 
-export function formatCompact(v: number): string {
-  const abs = Math.abs(v);
-  if (abs >= 1_000_000_000) return `${(v / 1_000_000_000).toFixed(1)}B`;
-  if (abs >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
-  if (abs >= 10_000) return `${Math.round(v / 1_000)}K`;
-  if (abs >= 1_000) return `${(v / 1_000).toFixed(1)}K`;
-  if (Number.isInteger(v)) return String(v);
-  return v.toFixed(1);
-}
-
 const thumbCls = [
   "absolute w-full appearance-none bg-transparent pointer-events-none",
   "[&::-webkit-slider-runnable-track]:bg-transparent",

--- a/src/features/map/components/SearchBar/controls/RangeFilter.tsx
+++ b/src/features/map/components/SearchBar/controls/RangeFilter.tsx
@@ -9,7 +9,8 @@ interface RangeFilterProps {
   min: number;
   max: number;
   step?: number;
-  formatValue?: (v: number) => string;
+  prefix?: string;
+  suffix?: string;
   onApply: (column: string, min: number, max: number) => void;
 }
 
@@ -57,7 +58,8 @@ export default function RangeFilter({
   min,
   max,
   step = 1,
-  formatValue = formatCompact,
+  prefix,
+  suffix,
   onApply,
 }: RangeFilterProps) {
   const searchFilters = useMapV2Store((s) => s.searchFilters);
@@ -72,19 +74,22 @@ export default function RangeFilter({
 
   const [lo, setLo] = useState(existingValues ? existingValues[0] : min);
   const [hi, setHi] = useState(existingValues ? existingValues[1] : max);
+  const [loInput, setLoInput] = useState(String(existingValues ? existingValues[0] : min));
+  const [hiInput, setHiInput] = useState(String(existingValues ? existingValues[1] : max));
+  const [loFocused, setLoFocused] = useState(false);
+  const [hiFocused, setHiFocused] = useState(false);
   const applyTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const filterRef = useRef(existingFilter);
   filterRef.current = existingFilter;
 
-  // Sync when filter changes externally (cleared from pills, etc.)
+  // Sync when filter changes externally (cleared from pills, etc.) or when slider moves while inputs aren't focused.
   useEffect(() => {
-    if (existingValues) {
-      setLo(existingValues[0]);
-      setHi(existingValues[1]);
-    } else {
-      setLo(min);
-      setHi(max);
-    }
+    const nextLo = existingValues ? existingValues[0] : min;
+    const nextHi = existingValues ? existingValues[1] : max;
+    setLo(nextLo);
+    setHi(nextHi);
+    if (!loFocused) setLoInput(String(nextLo));
+    if (!hiFocused) setHiInput(String(nextHi));
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [existingFilter?.id, existingValues?.[0], existingValues?.[1], min, max]);
 
@@ -101,16 +106,75 @@ export default function RangeFilter({
     }, 300);
   };
 
-  const handleLo = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const applyImmediate = (newLo: number, newHi: number) => {
+    clearTimeout(applyTimer.current);
+    if (newLo === min && newHi === max) {
+      if (filterRef.current) removeSearchFilter(filterRef.current.id);
+    } else {
+      onApply(column, newLo, newHi);
+    }
+  };
+
+  const handleSliderLo = (e: React.ChangeEvent<HTMLInputElement>) => {
     const v = Math.min(Number(e.target.value), hi);
     setLo(v);
+    if (!loFocused) setLoInput(String(v));
     scheduleApply(v, hi);
   };
 
-  const handleHi = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleSliderHi = (e: React.ChangeEvent<HTMLInputElement>) => {
     const v = Math.max(Number(e.target.value), lo);
     setHi(v);
+    if (!hiFocused) setHiInput(String(v));
     scheduleApply(lo, v);
+  };
+
+  const parseTyped = (raw: string): number | null => {
+    const trimmed = raw.trim();
+    if (trimmed === "") return null;
+    const n = Number(trimmed);
+    if (!Number.isFinite(n)) return null;
+    return step < 1 ? n : Math.round(n);
+  };
+
+  const commitLo = () => {
+    const parsed = parseTyped(loInput);
+    if (parsed === null) {
+      setLoInput(String(lo));
+      return;
+    }
+    const clamped = Math.max(min, Math.min(max, parsed));
+    let nextLo = clamped;
+    let nextHi = hi;
+    if (clamped > hi) {
+      nextLo = hi;
+      nextHi = clamped;
+    }
+    setLo(nextLo);
+    setHi(nextHi);
+    setLoInput(String(nextLo));
+    setHiInput(String(nextHi));
+    applyImmediate(nextLo, nextHi);
+  };
+
+  const commitHi = () => {
+    const parsed = parseTyped(hiInput);
+    if (parsed === null) {
+      setHiInput(String(hi));
+      return;
+    }
+    const clamped = Math.max(min, Math.min(max, parsed));
+    let nextLo = lo;
+    let nextHi = clamped;
+    if (clamped < lo) {
+      nextLo = clamped;
+      nextHi = lo;
+    }
+    setLo(nextLo);
+    setHi(nextHi);
+    setLoInput(String(nextLo));
+    setHiInput(String(nextHi));
+    applyImmediate(nextLo, nextHi);
   };
 
   const handleRemove = () => {
@@ -121,6 +185,20 @@ export default function RangeFilter({
   const range = max - min || 1;
   const loPC = ((lo - min) / range) * 100;
   const hiPC = ((hi - min) / range) * 100;
+  const inputMode = step < 1 ? "decimal" : "numeric";
+
+  const inputCls = [
+    "w-16 px-1.5 py-0.5 text-[10px] tabular-nums rounded",
+    "bg-transparent border border-transparent",
+    "hover:border-[#D4CFE2]",
+    "focus:outline-none focus:ring-1 focus:ring-plum/30 focus:border-plum/30",
+    isActive ? "text-plum font-medium" : "text-[#A69DC0]",
+  ].join(" ");
+
+  const adornmentCls = [
+    "text-[10px] tabular-nums",
+    isActive ? "text-plum font-medium" : "text-[#A69DC0]",
+  ].join(" ");
 
   return (
     <div
@@ -146,7 +224,7 @@ export default function RangeFilter({
         )}
       </div>
 
-      {/* Dual-thumb range slider */}
+      {/* Slider step bounds drag granularity; typed input bypasses step. */}
       <div className="relative h-5 flex items-center">
         <div className="absolute inset-x-0 h-1 rounded-full bg-[#E2DEEC]" />
         <div
@@ -161,7 +239,8 @@ export default function RangeFilter({
           max={max}
           step={step}
           value={lo}
-          onChange={handleLo}
+          onChange={handleSliderLo}
+          aria-label={`${label} slider minimum`}
           className={`${thumbCls} z-10`}
         />
         <input
@@ -170,27 +249,71 @@ export default function RangeFilter({
           max={max}
           step={step}
           value={hi}
-          onChange={handleHi}
+          onChange={handleSliderHi}
+          aria-label={`${label} slider maximum`}
           className={`${thumbCls} z-20`}
         />
       </div>
 
-      {/* Value labels */}
-      <div className="flex justify-between">
-        <span
-          className={`text-[10px] tabular-nums ${
-            isActive ? "text-plum font-medium" : "text-[#A69DC0]"
-          }`}
-        >
-          {formatValue(lo)}
-        </span>
-        <span
-          className={`text-[10px] tabular-nums ${
-            isActive ? "text-plum font-medium" : "text-[#A69DC0]"
-          }`}
-        >
-          {formatValue(hi)}
-        </span>
+      <div className="flex justify-between items-center">
+        <div className="flex items-center gap-0.5">
+          {prefix && <span className={adornmentCls}>{prefix}</span>}
+          <input
+            type="text"
+            inputMode={inputMode}
+            value={loInput}
+            aria-label={`${label} minimum`}
+            placeholder={String(min)}
+            onChange={(e) => setLoInput(e.target.value)}
+            onFocus={(e) => {
+              setLoFocused(true);
+              e.currentTarget.select();
+            }}
+            onBlur={() => {
+              setLoFocused(false);
+              commitLo();
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.currentTarget.blur();
+              } else if (e.key === "Escape") {
+                setLoInput(String(lo));
+                e.currentTarget.blur();
+              }
+            }}
+            className={inputCls}
+          />
+          {suffix && <span className={adornmentCls}>{suffix}</span>}
+        </div>
+        <div className="flex items-center gap-0.5">
+          {prefix && <span className={adornmentCls}>{prefix}</span>}
+          <input
+            type="text"
+            inputMode={inputMode}
+            value={hiInput}
+            aria-label={`${label} maximum`}
+            placeholder={String(max)}
+            onChange={(e) => setHiInput(e.target.value)}
+            onFocus={(e) => {
+              setHiFocused(true);
+              e.currentTarget.select();
+            }}
+            onBlur={() => {
+              setHiFocused(false);
+              commitHi();
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.currentTarget.blur();
+              } else if (e.key === "Escape") {
+                setHiInput(String(hi));
+                e.currentTarget.blur();
+              }
+            }}
+            className={`${inputCls} text-right`}
+          />
+          {suffix && <span className={adornmentCls}>{suffix}</span>}
+        </div>
       </div>
     </div>
   );

--- a/src/features/map/components/SearchBar/controls/__tests__/RangeFilter.test.tsx
+++ b/src/features/map/components/SearchBar/controls/__tests__/RangeFilter.test.tsx
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import RangeFilter from "../RangeFilter";
+
+type MockFilter = {
+  id: string;
+  column: string;
+  op: string;
+  value: [number, number];
+};
+
+const storeState: { searchFilters: MockFilter[]; removeSearchFilter: ReturnType<typeof vi.fn> } = {
+  searchFilters: [],
+  removeSearchFilter: vi.fn(),
+};
+
+vi.mock("@/features/map/lib/store", () => {
+  const useMapV2Store = (selector: (s: typeof storeState) => unknown) => selector(storeState);
+  (useMapV2Store as unknown as { getState: () => typeof storeState }).getState = () => storeState;
+  return { useMapV2Store };
+});
+
+const baseProps = {
+  label: "Enrollment",
+  column: "enrollment",
+  min: 0,
+  max: 200000,
+  step: 500,
+};
+
+beforeEach(() => {
+  storeState.searchFilters = [];
+  storeState.removeSearchFilter.mockReset();
+  vi.useRealTimers();
+});
+
+const getMinInput = () => screen.getByLabelText("Enrollment minimum") as HTMLInputElement;
+const getMaxInput = () => screen.getByLabelText("Enrollment maximum") as HTMLInputElement;
+
+describe("RangeFilter — input rendering", () => {
+  it("renders editable min and max inputs alongside the slider", () => {
+    render(<RangeFilter {...baseProps} onApply={vi.fn()} />);
+    expect(getMinInput()).toBeTruthy();
+    expect(getMaxInput()).toBeTruthy();
+    expect(screen.getByLabelText("Enrollment slider minimum")).toBeTruthy();
+    expect(screen.getByLabelText("Enrollment slider maximum")).toBeTruthy();
+  });
+
+  it("renders prefix and suffix adornments", () => {
+    const { container } = render(
+      <RangeFilter {...baseProps} prefix="$" suffix="%" onApply={vi.fn()} />
+    );
+    const text = container.textContent ?? "";
+    // Prefix and suffix appear twice (once per input pair)
+    expect((text.match(/\$/g) ?? []).length).toBeGreaterThanOrEqual(2);
+    expect((text.match(/%/g) ?? []).length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("RangeFilter — typing commits", () => {
+  it("does not apply while typing", () => {
+    const onApply = vi.fn();
+    render(<RangeFilter {...baseProps} onApply={onApply} />);
+    const input = getMinInput();
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "1" } });
+    fireEvent.change(input, { target: { value: "13" } });
+    fireEvent.change(input, { target: { value: "137" } });
+    expect(onApply).not.toHaveBeenCalled();
+  });
+
+  it("commits on blur and bypasses step (137 in a step=500 row)", () => {
+    const onApply = vi.fn();
+    render(<RangeFilter {...baseProps} onApply={onApply} />);
+    const input = getMinInput();
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "137" } });
+    fireEvent.blur(input);
+    expect(onApply).toHaveBeenCalledWith("enrollment", 137, 200000);
+  });
+
+  it("commits on Enter", () => {
+    const onApply = vi.fn();
+    render(<RangeFilter {...baseProps} onApply={onApply} />);
+    const input = getMinInput();
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "1500" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    // Enter triggers blur via e.currentTarget.blur() — the blur handler commits.
+    fireEvent.blur(input);
+    expect(onApply).toHaveBeenCalledWith("enrollment", 1500, 200000);
+  });
+
+  it("Escape reverts unsaved input", () => {
+    const onApply = vi.fn();
+    render(<RangeFilter {...baseProps} onApply={onApply} />);
+    const input = getMinInput();
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "9999" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+    fireEvent.blur(input);
+    expect(input.value).toBe("0");
+    // The blur after Escape sees the reverted value (0) which equals min and current lo (0),
+    // so applyImmediate sees min===min, max===max → removeSearchFilter (or no-op when not active)
+    // — either way, onApply itself is not called with an applied range.
+    expect(onApply).not.toHaveBeenCalled();
+  });
+});
+
+describe("RangeFilter — clamping and swap", () => {
+  it("clamps a value above max", () => {
+    const onApply = vi.fn();
+    render(<RangeFilter {...baseProps} onApply={onApply} />);
+    const input = getMaxInput();
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "999999999" } });
+    fireEvent.blur(input);
+    // When clamped to max and lo is still 0, both bounds match defaults → filter not applied
+    // (matches existing slider reset-to-bounds behavior). Verify the input shows the clamped max.
+    expect(input.value).toBe("200000");
+  });
+
+  it("clamps a negative min to range min", () => {
+    const onApply = vi.fn();
+    render(<RangeFilter {...baseProps} onApply={onApply} />);
+    const input = getMinInput();
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "-500" } });
+    fireEvent.blur(input);
+    expect(input.value).toBe("0");
+  });
+
+  it("swaps lo and hi when typed min exceeds current max", () => {
+    const onApply = vi.fn();
+    storeState.searchFilters = [
+      { id: "f1", column: "enrollment", op: "between", value: [0, 100] },
+    ];
+    render(<RangeFilter {...baseProps} onApply={onApply} />);
+    const minInput = getMinInput();
+    fireEvent.focus(minInput);
+    fireEvent.change(minInput, { target: { value: "5000" } });
+    fireEvent.blur(minInput);
+    // Typed lo (5000) > current hi (100) → swap so lo=100, hi=5000
+    expect(onApply).toHaveBeenCalledWith("enrollment", 100, 5000);
+  });
+
+  it("rounds typed decimals to integers when step >= 1", () => {
+    const onApply = vi.fn();
+    render(<RangeFilter {...baseProps} onApply={onApply} />);
+    const input = getMinInput();
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "137.6" } });
+    fireEvent.blur(input);
+    expect(onApply).toHaveBeenCalledWith("enrollment", 138, 200000);
+  });
+
+  it("preserves decimals when step < 1", () => {
+    const onApply = vi.fn();
+    render(
+      <RangeFilter
+        label="Enrollment"
+        column="enrollment"
+        min={-50}
+        max={50}
+        step={0.5}
+        onApply={onApply}
+      />
+    );
+    const input = getMinInput();
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "-12.5" } });
+    fireEvent.blur(input);
+    expect(onApply).toHaveBeenCalledWith("enrollment", -12.5, 50);
+  });
+});
+
+describe("RangeFilter — bounds-reset behavior", () => {
+  it("removes the filter when both inputs return to bounds", () => {
+    const onApply = vi.fn();
+    storeState.searchFilters = [
+      { id: "active", column: "enrollment", op: "between", value: [100, 5000] },
+    ];
+    render(<RangeFilter {...baseProps} onApply={onApply} />);
+    const minInput = getMinInput();
+    fireEvent.focus(minInput);
+    fireEvent.change(minInput, { target: { value: "0" } });
+    fireEvent.blur(minInput);
+    const maxInput = getMaxInput();
+    fireEvent.focus(maxInput);
+    fireEvent.change(maxInput, { target: { value: "200000" } });
+    fireEvent.blur(maxInput);
+    expect(storeState.removeSearchFilter).toHaveBeenCalledWith("active");
+  });
+});

--- a/src/features/map/components/SearchBar/controls/__tests__/RangeFilter.test.tsx
+++ b/src/features/map/components/SearchBar/controls/__tests__/RangeFilter.test.tsx
@@ -120,6 +120,19 @@ describe("RangeFilter — clamping and swap", () => {
     expect(input.value).toBe("200000");
   });
 
+  it("clamps and applies via onApply when an active sub-range exists", () => {
+    const onApply = vi.fn();
+    storeState.searchFilters = [
+      { id: "f1", column: "enrollment", op: "between", value: [50, 100] },
+    ];
+    render(<RangeFilter {...baseProps} onApply={onApply} />);
+    const input = getMaxInput();
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "999999999" } });
+    fireEvent.blur(input);
+    expect(onApply).toHaveBeenCalledWith("enrollment", 50, 200000);
+  });
+
   it("clamps a negative min to range min", () => {
     const onApply = vi.fn();
     render(<RangeFilter {...baseProps} onApply={onApply} />);


### PR DESCRIPTION
## Summary
Replace the static min/max value labels beneath every histogram-bar filter row in the District Filters panel with editable numeric inputs, so reps can type any integer (or decimal where step < 1) inside each row's `[min, max]` range. Typed values bypass the slider's coarse step granularity (e.g., type `137` inside an Enrollment 0-500 step bucket).

The shared `RangeFilter` component is consumed by 5 dropdowns (`DistrictsDropdown`, `DemographicsDropdown`, `FinanceDropdown`, `AcademicsDropdown`, `FullmindDropdown`), so this single component change improves every histogram bar across Demographics, Finance, Academics, and Fullmind sections — reps no longer have to drag a slider to set a precise value.

A new `prefix` / `suffix` prop pair on RangeFilter replaces the per-row `formatValue` closures for currency (`$`) and percent (`%`) adornments. Adornments render outside the input, so the input itself shows raw integers — predictable to type, no parser required.

## Behavior
- Type → input state updates locally; nothing applies until commit
- **Blur or Enter** → validate, clamp to `[min, max]`, swap if `lo > hi`, then apply via existing `between` filter op
- **Escape** → revert in-progress edit, blur
- Slider drag still works as before (300ms debounce); inputs mirror the slider value when not focused
- Resetting both inputs back to bounds removes the filter — matches existing slider reset-to-bounds behavior

## Test plan
- [ ] Open http://localhost:3005, click the **Districts** dropdown, expand a section
- [ ] Verify two editable inputs replace the static labels under each slider
- [ ] In Enrollment, type `137` in min, blur → filter pill says `Enrollment 137-200000` (bypassing 500 step)
- [ ] Drag a slider thumb → both inputs update live
- [ ] In a $ row (e.g., Pipeline), confirm `$` adornment renders to the left of each input
- [ ] In a % row (e.g., ELL %), confirm `%` adornment renders to the right of each input
- [ ] Press Escape mid-typing → input reverts to last applied value
- [ ] Reset both inputs to bounds → filter disappears

## Verification
- 13/13 new vitest cases pass — `RangeFilter.test.tsx`
- `npm run build` clean
- TypeScript strict, no `any` / `@ts-ignore`

## Spec / plan / review
- Spec: `Docs/superpowers/specs/2026-04-27-filter-min-max-inputs-spec.md`
- Plan: `Docs/superpowers/plans/2026-04-27-filter-min-max-inputs-plan.md`
- Code review: `Docs/superpowers/2026-04-27-filter-min-max-inputs-final-report.md` — READY FOR REVIEW, 0 critical, 0 important, 3 suggestions (2 addressed inline, 1 deferred per reviewer guidance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)