### PR TITLE
fix(vacancies): recover from 80%+ scan failure rate (post-PR-#129 regression)

### DIFF
--- a/Docs/superpowers/plans/2026-04-28-vacancy-scan-coverage-recovery.md
+++ b/Docs/superpowers/plans/2026-04-28-vacancy-scan-coverage-recovery.md
@@ -25,10 +25,10 @@
 **Working directory (IMPORTANT):** all work happens in the worktree, not the main checkout:
 
 ```
-/Users/sierraarcega/territory-plan/.claude/worktrees/vacancies-and-news
+/Users/sierraarcega/territory-plan/.claude/worktrees/vacancy-recovery
 ```
 
-Branch: `vacancies-and-news` (created fresh from `origin/main` at `4a76d081`).
+Branch: `fix/vacancy-scan-coverage` (off `vacancies-and-news`, which is itself off `origin/main` at `4a76d081`). The companion `fix/news-ingest-timeout` branch runs the parallel news plan; the two branches don't share files and merge to main independently.
 
 **Verification tooling:** `psql "$DATABASE_URL"` (`DATABASE_URL` is in `.env.local`). `npm test` for Vitest. Production verification uses Vercel and Supabase MCPs.
 
@@ -60,11 +60,11 @@ This is a one-shot script. It reads every district with `jobBoardUrl IS NOT NULL
 - [ ] **Step 1: `cd` into the worktree and confirm branch**
 
 ```bash
-cd /Users/sierraarcega/territory-plan/.claude/worktrees/vacancies-and-news
+cd /Users/sierraarcega/territory-plan/.claude/worktrees/vacancy-recovery
 git status
 ```
 
-Expected: `On branch vacancies-and-news`, clean tree.
+Expected: `On branch fix/vacancy-scan-coverage`, clean tree.
 
 - [ ] **Step 2: Capture pre-backfill platform distribution**
 
@@ -600,10 +600,10 @@ Expected: zero type errors; all tests pass.
 ```bash
 git status
 git log --oneline origin/main..HEAD
-git push -u origin vacancies-and-news
+git push -u origin fix/vacancy-scan-coverage
 ```
 
-Expected: status clean, ~5 commits ahead of origin/main, push succeeds.
+Expected: status clean, ~6 commits ahead of origin/main (5 from this plan + the plan-docs commit on `vacancies-and-news`), push succeeds.
 
 - [ ] **Step 3: Open the PR (or hand off to user)**
 

--- a/prisma/migrations/20260428_district_vacancy_health/migration.sql
+++ b/prisma/migrations/20260428_district_vacancy_health/migration.sql
@@ -1,0 +1,13 @@
+-- Track per-district vacancy scan health for cron-side filtering.
+-- - vacancy_consecutive_failures resets to 0 on every successful scan,
+--   increments on every failed scan.
+-- - vacancy_last_failure_at is the timestamp of the most recent failure
+--   (NULL if never failed or last result was success).
+-- The scan-vacancies cron skips districts with consecutive_failures >= 5.
+
+ALTER TABLE districts
+  ADD COLUMN vacancy_consecutive_failures INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN vacancy_last_failure_at TIMESTAMP(3) NULL;
+
+CREATE INDEX districts_vacancy_consecutive_failures_idx
+  ON districts (vacancy_consecutive_failures);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -129,6 +129,10 @@ model District {
   jobBoardUrl      String? @map("job_board_url") @db.VarChar(1000)
   jobBoardPlatform String? @map("job_board_platform") @db.VarChar(50)
 
+  // ===== Vacancy Scan Health (cron-side filtering) =====
+  vacancyConsecutiveFailures Int       @default(0) @map("vacancy_consecutive_failures")
+  vacancyLastFailureAt       DateTime? @map("vacancy_last_failure_at")
+
   // ===== User Edits =====
   // Source: App users (shared across team)
   notes          String?

--- a/scripts/backfill-job-board-platform.ts
+++ b/scripts/backfill-job-board-platform.ts
@@ -1,0 +1,65 @@
+/**
+ * Backfill District.jobBoardPlatform from current jobBoardUrl using
+ * detectPlatform(). Idempotent — only writes when the detected platform
+ * differs from what's currently stored.
+ *
+ * Usage:
+ *   npx tsx scripts/backfill-job-board-platform.ts            # dry run
+ *   npx tsx scripts/backfill-job-board-platform.ts --commit   # actually write
+ */
+import { config } from "dotenv";
+config();
+
+import prisma from "@/lib/prisma";
+import { detectPlatform } from "@/features/vacancies/lib/platform-detector";
+
+async function main() {
+  const commit = process.argv.includes("--commit");
+
+  const districts = await prisma.district.findMany({
+    where: { jobBoardUrl: { not: null } },
+    select: { leaid: true, jobBoardUrl: true, jobBoardPlatform: true },
+  });
+
+  console.log(`[backfill] inspecting ${districts.length} districts`);
+
+  const transitions = new Map<string, number>(); // "from→to" → count
+  const updates: { leaid: string; from: string | null; to: string }[] = [];
+
+  for (const d of districts) {
+    if (!d.jobBoardUrl) continue;
+    const detected = detectPlatform(d.jobBoardUrl);
+    if (detected === d.jobBoardPlatform) continue;
+    const key = `${d.jobBoardPlatform ?? "(unset)"} → ${detected}`;
+    transitions.set(key, (transitions.get(key) ?? 0) + 1);
+    updates.push({ leaid: d.leaid, from: d.jobBoardPlatform, to: detected });
+  }
+
+  console.log(`[backfill] ${updates.length} districts need an update`);
+  for (const [key, n] of [...transitions.entries()].sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${key}: ${n}`);
+  }
+
+  if (!commit) {
+    console.log("[backfill] dry run — pass --commit to apply");
+    return;
+  }
+
+  let written = 0;
+  for (const u of updates) {
+    await prisma.district.update({
+      where: { leaid: u.leaid },
+      data: { jobBoardPlatform: u.to },
+    });
+    written++;
+    if (written % 500 === 0) console.log(`[backfill] wrote ${written}/${updates.length}`);
+  }
+  console.log(`[backfill] done, wrote ${written}`);
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/src/app/api/cron/scan-vacancies/route.ts
+++ b/src/app/api/cron/scan-vacancies/route.ts
@@ -53,9 +53,14 @@ export async function GET(request: NextRequest) {
     // Warm shared job-board cache before grouping
     await loadSharedJobBoardUrls();
 
-    // Find all districts with job board URLs
+    // Find all districts with job board URLs.
+    // Skip districts at >=5 consecutive failures so dead URLs auto-shed
+    // from rotation; an admin can manually reset the counter if needed.
     const districts = await prisma.district.findMany({
-      where: { jobBoardUrl: { not: null } },
+      where: {
+        jobBoardUrl: { not: null },
+        vacancyConsecutiveFailures: { lt: 5 },
+      },
       select: { leaid: true, name: true, jobBoardUrl: true },
     });
 
@@ -121,11 +126,32 @@ export async function GET(request: NextRequest) {
       return b.districts.length - a.districts.length;
     });
 
+    // Cap unknown-platform groups in the per-run batch to MAX_UNKNOWN_PER_RUN.
+    // The Claude fallback path is failure-prone (~80% timeout rate as of the
+    // 2026-04-23 regression); reserving most slots for districts with a
+    // dedicated parser keeps the pipeline producing while the unknown URLs
+    // are addressed separately (backfill, manual triage).
+    const MAX_UNKNOWN_PER_RUN = 1;
+    const cappedGroups: typeof sortedGroups = [];
+    let unknownPicked = 0;
+    for (const g of sortedGroups) {
+      if (g.platform === "unknown") {
+        if (unknownPicked >= MAX_UNKNOWN_PER_RUN) continue;
+        unknownPicked++;
+      }
+      cappedGroups.push(g);
+      if (cappedGroups.length >= SCANS_PER_RUN) break;
+    }
+    // Append remaining sortedGroups after the capped batch so coverage stats
+    // (`remaining`, `neverScannedGroupsRemaining`) still reflect the full pool.
+    const tail = sortedGroups.filter((g) => !cappedGroups.includes(g));
+    const orderedGroups = [...cappedGroups, ...tail];
+
     // Run scans in parallel with capped concurrency
     const batchId = crypto.randomUUID();
     const results: { leaid: string; name: string; status: string; statewide: boolean }[] = [];
 
-    const batch = sortedGroups.slice(0, SCANS_PER_RUN);
+    const batch = orderedGroups.slice(0, SCANS_PER_RUN);
     const queue = new PQueue({ concurrency: CONCURRENCY });
 
     // Create all scan records upfront, then execute in parallel
@@ -188,7 +214,7 @@ export async function GET(request: NextRequest) {
     }, 0);
 
     const neverScannedGroupsPicked = batch.filter((g) => g.hasNeverScanned).length;
-    const neverScannedGroupsRemaining = sortedGroups
+    const neverScannedGroupsRemaining = orderedGroups
       .slice(batch.length)
       .filter((g) => g.hasNeverScanned).length;
 

--- a/src/features/vacancies/lib/__tests__/scan-runner.test.ts
+++ b/src/features/vacancies/lib/__tests__/scan-runner.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mocks use the closure-deferral pattern (matches platform-detector.test.ts).
+// Each fn() is a vi.fn declared with `const`; the vi.mock factory references
+// them through an arrow that defers the variable lookup until call time, so
+// it doesn't trip Vitest's mock-hoisting TDZ.
+const districtUpdate = vi.fn();
+const vacancyScanFindUnique = vi.fn();
+const vacancyScanUpdate = vi.fn();
+const getParserMock = vi.fn();
+const parseWithClaudeMock = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    district: {
+      update: (...args: unknown[]) => districtUpdate(...args),
+    },
+    vacancyScan: {
+      findUnique: (...args: unknown[]) => vacancyScanFindUnique(...args),
+      update: (...args: unknown[]) => vacancyScanUpdate(...args),
+    },
+  },
+}));
+
+vi.mock("@/features/vacancies/lib/platform-detector", () => ({
+  detectPlatform: () => "applitrack",
+  isStatewideBoardAsync: async () => false,
+  getAppliTrackInstance: () => null,
+}));
+vi.mock("@/features/vacancies/lib/post-processor", () => ({
+  processVacancies: async () => ({ vacancyCount: 0, fullmindRelevantCount: 0 }),
+}));
+vi.mock("@/features/vacancies/lib/parsers", () => ({
+  getParser: (...args: unknown[]) => getParserMock(...args),
+}));
+vi.mock("@/features/vacancies/lib/parsers/playwright-fallback", () => ({
+  parseWithPlaywright: async () => [],
+}));
+vi.mock("@/features/vacancies/lib/parsers/claude-fallback", () => ({
+  parseWithClaude: (...args: unknown[]) => parseWithClaudeMock(...args),
+}));
+
+import { runScan } from "../scan-runner";
+
+const baseScan = {
+  id: "scan_abc",
+  leaid: "0100001",
+  district: {
+    leaid: "0100001",
+    name: "Test District",
+    jobBoardUrl: "https://example.applitrack.com/onlineapp",
+    jobBoardPlatform: "applitrack",
+    enrollment: 1000,
+  },
+};
+
+beforeEach(() => {
+  districtUpdate.mockReset().mockResolvedValue({});
+  vacancyScanFindUnique.mockReset().mockResolvedValue(baseScan);
+  vacancyScanUpdate.mockReset().mockResolvedValue({});
+  // Default parser: returns 0 vacancies — drives runScan to the success path.
+  getParserMock.mockReset().mockImplementation(() => async () => []);
+  parseWithClaudeMock.mockReset().mockResolvedValue([]);
+});
+
+describe("runScan health-column updates", () => {
+  it("on completed: resets vacancyConsecutiveFailures and clears vacancyLastFailureAt", async () => {
+    await runScan("scan_abc");
+
+    const districtCalls = districtUpdate.mock.calls.filter(
+      (c) => (c[0] as any)?.where?.leaid === "0100001"
+    );
+    const last = districtCalls.at(-1)?.[0] as any;
+    expect(last?.data).toMatchObject({
+      vacancyConsecutiveFailures: 0,
+      vacancyLastFailureAt: null,
+    });
+  });
+
+  it("on failed: increments consecutive failures and stamps vacancyLastFailureAt", async () => {
+    // Make the parser itself throw — runScan's try/catch turns that into
+    // the failed-status branch.
+    getParserMock.mockImplementation(() => async () => {
+      throw new Error("boom");
+    });
+
+    await runScan("scan_abc");
+
+    const districtCalls = districtUpdate.mock.calls.filter(
+      (c) => (c[0] as any)?.where?.leaid === "0100001"
+    );
+    const last = districtCalls.at(-1)?.[0] as any;
+    expect(last?.data?.vacancyConsecutiveFailures).toMatchObject({ increment: 1 });
+    expect(last?.data?.vacancyLastFailureAt).toBeInstanceOf(Date);
+  });
+
+  it("on no-jobBoardUrl early-return: counts as a failure", async () => {
+    vacancyScanFindUnique.mockResolvedValueOnce({
+      ...baseScan,
+      district: { ...baseScan.district, jobBoardUrl: null },
+    });
+
+    await runScan("scan_abc");
+
+    const districtCalls = districtUpdate.mock.calls.filter(
+      (c) => (c[0] as any)?.where?.leaid === "0100001"
+    );
+    expect(districtCalls.length).toBeGreaterThan(0);
+    const last = districtCalls.at(-1)?.[0] as any;
+    expect(last?.data?.vacancyConsecutiveFailures).toMatchObject({ increment: 1 });
+  });
+});

--- a/src/features/vacancies/lib/scan-runner.ts
+++ b/src/features/vacancies/lib/scan-runner.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@prisma/client";
 import prisma from "@/lib/prisma";
 import { detectPlatform, isStatewideBoardAsync, getAppliTrackInstance } from "./platform-detector";
 import { processVacancies } from "./post-processor";
@@ -8,6 +9,23 @@ import type { RawVacancy } from "./parsers/types";
 
 /** Maximum time (ms) a single scan is allowed to run before timing out. */
 const SCAN_TIMEOUT_MS = 180_000; // 3 min for state-wide redistribution
+
+async function markDistrictScanSuccess(leaid: string) {
+  await prisma.district.update({
+    where: { leaid },
+    data: { vacancyConsecutiveFailures: 0, vacancyLastFailureAt: null },
+  });
+}
+
+async function markDistrictScanFailure(leaid: string) {
+  await prisma.district.update({
+    where: { leaid },
+    data: {
+      vacancyConsecutiveFailures: { increment: 1 },
+      vacancyLastFailureAt: new Date(),
+    },
+  });
+}
 
 /**
  * Orchestrates a single district vacancy scan:
@@ -23,9 +41,24 @@ export async function runScan(scanId: string): Promise<void> {
   const timeoutController = new AbortController();
   const timeoutId = setTimeout(() => timeoutController.abort(), SCAN_TIMEOUT_MS);
 
+  // Hoisted so the catch block can reach it for the per-district health update.
+  let scan: Prisma.VacancyScanGetPayload<{
+    include: {
+      district: {
+        select: {
+          leaid: true;
+          name: true;
+          jobBoardUrl: true;
+          jobBoardPlatform: true;
+          enrollment: true;
+        };
+      };
+    };
+  }> | null = null;
+
   try {
     // Step 1: Fetch scan + district
-    const scan = await prisma.vacancyScan.findUnique({
+    scan = await prisma.vacancyScan.findUnique({
       where: { id: scanId },
       include: {
         district: {
@@ -54,6 +87,7 @@ export async function runScan(scanId: string): Promise<void> {
           completedAt: new Date(),
         },
       });
+      await markDistrictScanFailure(scan.district.leaid);
       return;
     }
 
@@ -140,6 +174,7 @@ export async function runScan(scanId: string): Promise<void> {
             completedAt: new Date(),
           },
         });
+        await markDistrictScanSuccess(scan.district.leaid);
         return;
       }
 
@@ -181,6 +216,7 @@ export async function runScan(scanId: string): Promise<void> {
           completedAt: new Date(),
         },
       });
+      await markDistrictScanSuccess(scan.district.leaid);
 
       // Redistribute remaining jobs to other districts in the background
       // — but ONLY if the URL is properly scoped (has applitrackclient param)
@@ -217,6 +253,7 @@ export async function runScan(scanId: string): Promise<void> {
               completedAt: new Date(),
             },
           });
+          await markDistrictScanSuccess(scan.district.leaid);
           return;
         }
       }
@@ -244,6 +281,7 @@ export async function runScan(scanId: string): Promise<void> {
           completedAt: new Date(),
         },
       });
+      await markDistrictScanSuccess(scan.district.leaid);
     }
   } catch (error) {
     const errorMessage =
@@ -260,6 +298,9 @@ export async function runScan(scanId: string): Promise<void> {
           completedAt: new Date(),
         },
       });
+      if (scan?.district?.leaid) {
+        await markDistrictScanFailure(scan.district.leaid);
+      }
     } catch (updateError) {
       console.error(
         `[scan-runner] Failed to update scan ${scanId} status:`,


### PR DESCRIPTION
## Summary
- Backfill `District.jobBoardPlatform` from current URLs (one-shot script — many "unset" districts are actually applitrack/olas/schoolspring)
- Add `District.vacancyConsecutiveFailures` + `vacancyLastFailureAt` columns; `runScan` maintains them on every terminal status
- Cron skips districts with 5+ consecutive failures so dead URLs auto-shed from the rotation
- Cap unknown-platform scans at 1 of 5 per cron run so the Claude-fallback failure mode can't starve working districts

## Diagnostic
PR #129 (2026-04-22) correctly unstuck the never-scanned long tail, but ~70% of district URLs (8,940 of 12,639) had no platform set or `unknown`, falling through to `parseWithClaude` on Vercel which mostly times out at ~18s. Failure rate jumped from 0% on 4/22 to 45%/68%/100%/100%/78%/86%/100% from 4/23 onward; net new vacancies dropped from steady-state to 1/day.

## Dev backfill result
- 7,429 districts had `(unset)` platform → 0 after backfill
- +1,849 routed to dedicated `applitrack` parser (the recovered slice)
- +5,580 routed to `unknown` — still Claude-bound, but the new cap of 1 unknown/run keeps them from starving the working districts

## Production deploy steps (after merge)
1. Vercel auto-deploys the migration on push.
2. Run the backfill against prod: \`DATABASE_URL=\$PROD_DATABASE_URL npx tsx scripts/backfill-job-board-platform.ts --commit\`.
3. Wait one cron tick (next hour at :00) and verify the failure rate drops in \`vacancy_scans\`.

## Test plan
- [x] Type check passes (\`npx tsc --noEmit\`)
- [x] All Vitest tests pass (1,582 passing, 3 pre-existing failures unrelated to this change)
- [x] New scan-runner.test.ts: 3/3 passing
- [ ] Manual \`curl /api/cron/scan-vacancies\` against dev returns mixed \`completed\` / \`failed\` results (deferred — needs running dev server)
- [x] After backfill: platform distribution shows 0 \`(unset)\` districts on dev
- [ ] After 24h prod soak: \`vacancy_scans\` failure rate drops to <30% (from 80%+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)