### PR TITLE
chore(db): record drop-dead-aggregate-views migration

### DIFF
--- a/prisma/migrations/20260429034928_drop_dead_aggregate_views/migration.sql
+++ b/prisma/migrations/20260429034928_drop_dead_aggregate_views/migration.sql
@@ -1,0 +1,19 @@
+-- Drop five dead aggregate views. None are referenced in app code, scheduler,
+-- scripts, or docs (audited 2026-04-28). They are kept alive only because
+-- 20260411_add_opportunity_session_fk drops + recreates them around an
+-- opportunities column-type change.
+--
+-- Canonical aggregate sources going forward:
+--   * district_financials (table, refreshed by refresh_fullmind_financials())
+--   * district_opportunity_actuals (matview, rep + category grain)
+--   * district_map_features (matview, vector-tile features)
+--
+-- district_health_view in particular used SUM(DISTINCT ...) to paper over
+-- join fan-out from joining opportunities, activities, contacts, sessions, and
+-- tasks in a single query — the math was suspect even when it was wired up.
+
+DROP VIEW IF EXISTS district_health_view;
+DROP VIEW IF EXISTS district_opportunities_view;
+DROP VIEW IF EXISTS opportunity_sessions_view;
+DROP VIEW IF EXISTS plan_district_engagement_view;
+DROP VIEW IF EXISTS district_map_data;


### PR DESCRIPTION
## Summary
- Adds `prisma/migrations/20260429034928_drop_dead_aggregate_views/migration.sql`, which drops five unused views: `district_health_view`, `district_opportunities_view`, `opportunity_sessions_view`, `plan_district_engagement_view`, `district_map_data`.
- **Already applied to production** on 2026-04-28 via `prisma migrate deploy`. This PR records the file in main so other clones don't get an "applied migration not found locally" warning, and so a fresh dev DB can replay history.

## Pre-drop audit
- Zero references in app code, scripts, scheduler, docs, or tests (grep across `.ts`, `.tsx`, `.mjs`, `.py`, `.sql`, `.md`).
- Zero database-internal dependents — verified via `pg_depend` + `pg_rewrite` (no view/matview reads them) and a `pg_proc.prosrc` scan (no function/trigger references the names).
- `district_map_data` was already missing from prod (out-of-band drop at some prior point); the `IF EXISTS` clause no-op'd it.

## What stays
The canonical aggregate sources are unchanged:
- `district_financials` (table, refreshed by `refresh_fullmind_financials()`)
- `district_opportunity_actuals` (matview, rep + category grain)
- `district_map_features` (matview, vector-tile features)

## Notes
A follow-up routine is scheduled for 2026-05-12 to verify no external consumer (BI dashboard, Studio bookmark, ad-hoc analyst SQL) was relying on these views, and — if clean — open a separate PR extracting the opportunity stage-bucket logic into a shared SQL function so `refresh_fullmind_financials()` and the DOA matview can't drift.

## Test plan
- [ ] `npx prisma migrate status` shows the migration as applied (will be true on prod; no-op on fresh DBs after merge).
- [ ] No prod regressions reported in the next 14 days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)