### PR TITLE
fix(activities): harden calendar-page chrome against narrow widths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ TanStack Query. Vitest for testing.
 - Fullmind brand — use tokens from `Documentation/UI Framework/tokens.md`
 - Never use Tailwind grays — use plum-derived neutrals (#F7F5FA, #EFEDF5)
 - Icons: Lucide only, `currentColor`, semantic sizing
+- **Narrow-width resilience** — every flex/grid containing text needs `whitespace-nowrap` on its text spans plus a planned overflow behavior (`overflow-x-auto`, `flex-wrap`, or vertical stack). Sidebars + right rails routinely squeeze the main column, so no chrome survives without it. See `Documentation/UI Framework/tokens.md` § Narrow-Width Resilience.
 
 ### Performance
 This is a daily-use tool for sales reps. It must feel smooth — no user action

--- a/Documentation/UI Framework/tokens.md
+++ b/Documentation/UI Framework/tokens.md
@@ -231,6 +231,53 @@ All animations are defined in `globals.css`. Standard timing:
 
 ---
 
+## Narrow-Width Resilience
+
+Chrome must stay legible when squeezed — sidebars open, right rails open, smaller laptops, 100% zoom. Apply these rules whenever you build a flex/grid that contains text. Without one of them, flexbox quietly wraps text inside the offending child and produces classic baseline-collision bugs (e.g. "Closed   $141K / lost" stacking onto two lines).
+
+### 1. Plan a wrap behavior — don't leave it ambiguous
+
+Every flex/grid container with growable content (header strips, pill rows, summary tiles, day-card grids) needs an explicit overflow plan. Pick one:
+
+| Goal | Apply |
+|------|-------|
+| Single-row chrome that should never wrap (deal-summary strips, ribbons) | `whitespace-nowrap` on every text node + parent gets `min-w-0 overflow-x-auto` and children get `flex-shrink-0` |
+| Toolbar/header that should drop to a new row when narrow (page headers with title + controls) | `flex flex-wrap` on parent + `gap-y-3` so the wrapped row has breathing room |
+| Tile that should keep all content visible at any width (calendar day cells, KPI cards) | Stack content vertically (`flex flex-col items-center`) — never use `justify-between` between two text blocks under ~120px wide |
+
+### 2. Keep label + number + amount on one visual line
+
+Inside a fixed-size pill, stat tile, or chip:
+
+- **Every text span** (count, label, amount) gets `whitespace-nowrap`. Yes, all of them.
+- **Avoid `justify-between`** between two competing text spans in cells under ~120px wide — the smaller tier loses the width fight and wraps to a second line, with the larger tier baseline-aligned to the wrong line.
+- **Hyphens are line-break points.** `past-due close` wraps at the hyphen with one space of pressure. Reword (`Past due`) or use `whitespace-nowrap`.
+
+### 3. Compact cells: prefer icon + number over text labels
+
+When a cell, pill, or chip is narrower than ~80px, labels like `5 items` / `5 deals` won't fit. Use a Lucide icon + `tabular-nums` count, with the full text in `aria-label`:
+
+```tsx
+<div className="inline-flex items-center gap-1 text-[#544A78]"
+     aria-label={`${itemCount} items`}>
+  <CalendarCheck2 className="w-2.5 h-2.5" aria-hidden /> {itemCount}
+</div>
+```
+
+Reserve text labels for cells ≥ 120px wide.
+
+### 4. Sanity test before merging
+
+For any new chrome component, mentally check at three widths:
+
+1. **Wide** (everything has room) — should look balanced.
+2. **Medium** (sidebar + right rail open, ~700px content area) — labels still on one line, no clipping.
+3. **Narrow** (everything squeezed, ~480px) — content either wraps to a new row or scrolls horizontally; never silently overflows or word-by-word stacks.
+
+If case 3 fails, add `flex-wrap` on the parent or `overflow-x-auto` + `whitespace-nowrap` on the children before merging.
+
+---
+
 ## File Reference
 
 | What | Where |

--- a/src/features/activities/components/page/ActivitiesPageHeader.tsx
+++ b/src/features/activities/components/page/ActivitiesPageHeader.tsx
@@ -29,17 +29,17 @@ export default function ActivitiesPageHeader({
 
   return (
     <header className="bg-white border-b border-[#E2DEEC] px-6 py-3">
-      <div className="flex items-center justify-between gap-4">
+      <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-3">
         <div className="min-w-0">
           <h1 className="text-2xl font-bold text-[#403770] tracking-[-0.01em]">Activities</h1>
-          <p className="text-xs text-[#8A80A8]">
+          <p className="text-xs text-[#8A80A8] whitespace-nowrap">
             Showing{" "}
             <span className="font-medium text-[#6E6390]">{count.toLocaleString()}</span>{" "}
             in this range
           </p>
         </div>
 
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <ScopeToggle scope={scope} onChange={onScopeChange} />
           <CalendarSyncBadge onReviewPending={onReviewPending} />
           <ViewToggle

--- a/src/features/activities/components/page/ScopeToggle.tsx
+++ b/src/features/activities/components/page/ScopeToggle.tsx
@@ -39,7 +39,7 @@ export default function ScopeToggle({ scope, onChange, className }: ScopeToggleP
             aria-checked={active}
             onClick={() => onChange(o.id)}
             className={cn(
-              "fm-focus-ring px-3 py-1.5 text-xs rounded-md transition-all duration-[120ms] ease-out",
+              "fm-focus-ring px-3 py-1.5 text-xs rounded-md transition-all duration-[120ms] ease-out whitespace-nowrap",
               "inline-flex items-center gap-1.5",
               active
                 ? "bg-[#403770] text-white font-semibold"

--- a/src/features/activities/components/page/WeekStrip.tsx
+++ b/src/features/activities/components/page/WeekStrip.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { addDays, format, isSameDay, startOfWeek } from "date-fns";
+import { Briefcase, CalendarCheck2 } from "lucide-react";
 import type { ActivityCategory } from "@/features/activities/types";
 import type { DealKind } from "@/features/activities/lib/filters-store";
 
@@ -60,7 +61,7 @@ export default function WeekStrip({
             key={i}
             type="button"
             onClick={() => onDayClick?.(date)}
-            className={`flex flex-col gap-1.5 px-3 py-2.5 rounded-[10px] text-left transition-all duration-120 min-h-[82px] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#F37167] focus-visible:ring-offset-2 ${
+            className={`flex flex-col items-center gap-1.5 px-2 py-2.5 rounded-[10px] text-center transition-all duration-120 min-h-[82px] min-w-0 overflow-hidden focus:outline-none focus-visible:ring-2 focus-visible:ring-[#F37167] focus-visible:ring-offset-2 ${
               isSelected
                 ? "bg-white border-[1.5px] border-[#403770] shadow-[0_2px_6px_rgba(64,55,112,0.08)]"
                 : isToday
@@ -68,7 +69,7 @@ export default function WeekStrip({
                   : "bg-white border border-[#E2DEEC] hover:border-[#C2BBD4]"
             }`}
           >
-            <div className="flex items-baseline justify-between">
+            <div className="flex flex-col items-center leading-none">
               <span
                 className={`text-[10px] uppercase tracking-[0.06em] font-semibold ${
                   isToday ? "text-[#F37167]" : "text-[#8A80A8]"
@@ -76,7 +77,7 @@ export default function WeekStrip({
               >
                 {format(date, "EEE")}
               </span>
-              <span className="text-lg font-bold text-[#403770] tabular-nums leading-none">
+              <span className="mt-0.5 text-lg font-bold text-[#403770] tabular-nums leading-none">
                 {format(date, "d")}
               </span>
             </div>
@@ -85,7 +86,7 @@ export default function WeekStrip({
               <span className="text-[10px] text-[#A69DC0] font-medium">No items</span>
             ) : (
               <>
-                <div className="flex items-center gap-[3px]">
+                <div className="flex items-center justify-center gap-[3px]">
                   {cats.slice(0, 4).map((c) => (
                     <span
                       key={c}
@@ -104,19 +105,30 @@ export default function WeekStrip({
                     />
                   ))}
                 </div>
-                <div className="text-[11px] font-semibold text-[#544A78] tabular-nums">
+                <div
+                  className="text-[11px] font-semibold tabular-nums leading-tight whitespace-nowrap flex flex-col items-center gap-0.5"
+                  aria-label={[
+                    itemCount > 0
+                      ? `${itemCount} ${itemCount === 1 ? "item" : "items"}`
+                      : null,
+                    dealCount > 0
+                      ? `${dealCount} deal${dealCount === 1 ? "" : "s"}`
+                      : null,
+                  ]
+                    .filter(Boolean)
+                    .join(", ")}
+                >
                   {itemCount > 0 && (
-                    <span>
-                      {itemCount} {itemCount === 1 ? "item" : "items"}
-                    </span>
-                  )}
-                  {itemCount > 0 && dealCount > 0 && (
-                    <span className="text-[#C2BBD4]"> · </span>
+                    <div className="text-[#544A78] inline-flex items-center gap-1">
+                      <CalendarCheck2 className="w-2.5 h-2.5" aria-hidden />
+                      {itemCount}
+                    </div>
                   )}
                   {dealCount > 0 && (
-                    <span className="text-[#403770]">
-                      {dealCount} deal{dealCount === 1 ? "" : "s"}
-                    </span>
+                    <div className="text-[#403770] inline-flex items-center gap-1">
+                      <Briefcase className="w-2.5 h-2.5" aria-hidden />
+                      {dealCount}
+                    </div>
                   )}
                 </div>
               </>

--- a/src/features/activities/components/page/deals/OppSummaryStrip.tsx
+++ b/src/features/activities/components/page/deals/OppSummaryStrip.tsx
@@ -59,7 +59,7 @@ export default function OppSummaryStrip({
   const coldAmt = coldList.reduce((s, d) => s + (d.amount ?? 0), 0);
 
   return (
-    <div className="flex items-center gap-0 px-4 py-2.5 bg-[#FBF9FC] border border-[#E2DEEC] rounded-[10px]">
+    <div className="flex items-center gap-0 px-4 py-2.5 bg-[#FBF9FC] border border-[#E2DEEC] rounded-[10px] min-w-0 overflow-x-auto">
       {(scopeLabel || rangeLabel) && (
         <button
           type="button"
@@ -95,9 +95,9 @@ export default function OppSummaryStrip({
                 ? `No ${s.label.toLowerCase()} in range`
                 : `See ${n} ${s.label.toLowerCase()} ${n === 1 ? "deal" : "deals"} totaling ${formatMoney(amt)}`
             }
-            className="fm-focus-ring flex items-baseline gap-1.5 px-4 py-1.5 bg-transparent [transition-duration:120ms] transition-colors hover:enabled:bg-[#F2EFF7] disabled:opacity-55 disabled:cursor-default"
+            className="fm-focus-ring flex items-baseline gap-1.5 px-4 py-1.5 bg-transparent [transition-duration:120ms] transition-colors hover:enabled:bg-[#F2EFF7] disabled:opacity-55 disabled:cursor-default whitespace-nowrap flex-shrink-0"
             style={{
-              minWidth: 120,
+              minWidth: 160,
               borderLeft: i === 0 ? "none" : "1px solid #E2DEEC",
               cursor: disabled ? "default" : "pointer",
             }}
@@ -119,14 +119,14 @@ export default function OppSummaryStrip({
       })}
 
       {(overdueDeals.length > 0 || coldList.length > 0) && (
-        <div className="ml-auto flex items-center gap-2 pl-3">
+        <div className="ml-auto flex items-center gap-2 pl-3 flex-shrink-0">
           {overdueDeals.length > 0 && (
             <button
               type="button"
               onClick={() => onOpen("overdue")}
               title={`${overdueDeals.length} open ${overdueDeals.length === 1 ? "deal has" : "deals have"} a close date in the past`}
               aria-label={`See ${overdueDeals.length} past-due open ${overdueDeals.length === 1 ? "deal" : "deals"} totaling ${formatMoney(overdueAmt)}`}
-              className="fm-focus-ring flex items-center gap-2 px-3 py-1.5 rounded-full bg-[#FFF4E6] border border-[#F3B26A] cursor-pointer hover:bg-[#FFE9CC] hover:border-[#E09545] [transition-duration:120ms] transition-colors"
+              className="fm-focus-ring flex items-center gap-2 px-3 py-1.5 rounded-full bg-[#FFF4E6] border border-[#F3B26A] cursor-pointer hover:bg-[#FFE9CC] hover:border-[#E09545] [transition-duration:120ms] transition-colors whitespace-nowrap"
             >
               <span
                 className="w-2 h-2 rounded-full flex-shrink-0"
@@ -137,7 +137,7 @@ export default function OppSummaryStrip({
                 {overdueDeals.length}
               </span>
               <span className="text-[11px] font-semibold text-[#8F5218]">
-                past-due close
+                Past due
               </span>
               <span className="text-[11px] font-semibold text-[#8F5218] tabular-nums opacity-70 pl-1 border-l border-[#8F521840]">
                 {formatMoney(overdueAmt)}
@@ -151,7 +151,7 @@ export default function OppSummaryStrip({
               onClick={() => onOpen("cold")}
               title={`${coldList.length} top ${coldList.length === 1 ? "district has" : "districts have"} had no logged activity in 21+ days`}
               aria-label={`See ${coldList.length} ${coldList.length === 1 ? "district" : "districts"} going cold totaling ${formatMoney(coldAmt)}`}
-              className="fm-focus-ring flex items-center gap-2 px-3 py-1.5 rounded-full bg-[#EEF3F7] border border-[#A9BFD0] cursor-pointer hover:bg-[#DCE6EF] hover:border-[#8AA4BB] [transition-duration:120ms] transition-colors"
+              className="fm-focus-ring flex items-center gap-2 px-3 py-1.5 rounded-full bg-[#EEF3F7] border border-[#A9BFD0] cursor-pointer hover:bg-[#DCE6EF] hover:border-[#8AA4BB] [transition-duration:120ms] transition-colors whitespace-nowrap"
             >
               <Snowflake
                 className="w-3 h-3 flex-shrink-0"


### PR DESCRIPTION
## Summary

The activities-calendar redesign shipped 2026-04-28 had several width-related visual bugs that surfaced as soon as the right rail (Team feed) was open at 100% zoom:

- **OppSummaryStrip** stat pills wrapped `Closed lost` / `New deals` labels onto a second line, with the dollar amount baseline-aligned to the wrong line — looked like `0  Closed   $34K` on row 1 / `won` on row 2.
- **OppSummaryStrip** "past-due close" pill broke at the hyphen and stacked vertically inside the pill.
- **WeekStrip** day cards clipped the trailing letters of `items` / `deals` and pushed 2-digit dates off the right edge.
- **ActivitiesPageHeader** wrapped `Showing N in this range` into a 1-word-per-line column whenever the right-side controls were wide enough to squeeze the title.
- **ScopeToggle** pills wrapped `My activities` / `All of Fullmind` inside the pill.

All five had the same root cause: a flex/grid container with growable text content, no ` whitespace-nowrap`, and no planned overflow behavior. The smaller text tier always loses the width fight.

### Fixes

| File | Change |
|---|---|
| `OppSummaryStrip.tsx` | `whitespace-nowrap` + `flex-shrink-0` on stat pills, `minWidth 120 → 160`, parent gets `min-w-0 overflow-x-auto` as a fallback. Past-due / cold pills also nowrap. Visible label `past-due close → Past due` (removes the hyphen break point). |
| `WeekStrip.tsx` | Stacked day name above date (centered) — eliminates the side-by-side `justify-between` width fight. Replaced `5 items` / `5 deals` text with `CalendarCheck2` + `Briefcase` icon chips; full text moved to `aria-label`. |
| `ActivitiesPageHeader.tsx` | `flex-wrap` on the parent so controls drop to a new row when narrow; `whitespace-nowrap` on the subtitle. |
| `ScopeToggle.tsx` | `whitespace-nowrap` on the pill button labels. |

### Codified the rule

To stop re-discovering this on every new chrome component, the pattern is documented in:

- `Documentation/UI Framework/tokens.md` § **Narrow-Width Resilience** — planned overflow choices, nowrap-everything rule, icon chips for compact cells, and a 3-width sanity test (wide / medium / narrow).
- `CLAUDE.md` § Styling — one-line pointer to the tokens.md section so any agent doing frontend work in this repo sees it before touching code.

## Test plan

- [ ] Activities page at 100% zoom with right rail open — stat pills no longer wrap, "Past due" pill on one line
- [ ] Schedule view week strip — day cards show date + dot row + icon chips, nothing clipped
- [ ] Activities page header at narrow widths — title row stays intact, controls wrap to a new row instead of squeezing the subtitle
- [ ] My activities / All of Fullmind pill labels stay on one line at any viewport
- [ ] Existing aria-labels for stat pills + day-card counts still pass screen-reader checks (verified — `page-a11y` + `OppSummaryStrip` tests still green, 54/54 across the activities feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)