### PR TITLE
feat(map): improve layer toggle UX and plans filter defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,4 @@ __pycache__/
 e2e/test-results/
 e2e/.auth/
 playwright-report/
+.worktrees/

--- a/src/features/map/components/SearchBar/PlansDropdown.tsx
+++ b/src/features/map/components/SearchBar/PlansDropdown.tsx
@@ -3,6 +3,7 @@
 import { useRef, useEffect, useCallback, useState, useMemo } from "react";
 import { useMapV2Store } from "@/features/map/lib/store";
 import { useTerritoryPlans } from "@/features/plans/lib/queries";
+import { useProfile } from "@/features/shared/lib/queries";
 
 interface PlansDropdownProps {
   onClose: () => void;
@@ -27,8 +28,10 @@ export default function PlansDropdown({ onClose }: PlansDropdownProps) {
   const setLayerFilter = useMapV2Store((s) => s.setLayerFilter);
   const openResultsPanel = useMapV2Store((s) => s.openResultsPanel);
   const ref = useRef<HTMLDivElement>(null);
+  const defaultApplied = useRef(false);
 
   const { data: plans } = useTerritoryPlans();
+  const { data: profile } = useProfile();
 
   const [planSearch, setPlanSearch] = useState("");
   const [ownerSearch, setOwnerSearch] = useState("");
@@ -43,6 +46,16 @@ export default function PlansDropdown({ onClose }: PlansDropdownProps) {
     return () => document.removeEventListener("mousedown", handler);
   }, [onClose]);
 
+  // Set role-based default once on mount: reps see only their own plans, admins/managers see all
+  useEffect(() => {
+    if (!profile || defaultApplied.current || filters.ownerIds !== undefined) return;
+    defaultApplied.current = true;
+    if (profile.role === "rep") {
+      setLayerFilter("plans", { ownerIds: [profile.id] });
+    }
+    // admin/manager: ownerIds stays undefined → API returns all plans
+  }, [profile]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const toggleStatus = useCallback((status: string) => {
     const current = filters.status ?? [];
     const next = current.includes(status)
@@ -53,10 +66,6 @@ export default function PlansDropdown({ onClose }: PlansDropdownProps) {
 
   const setFiscalYear = useCallback((fy: number | null) => {
     setLayerFilter("plans", { fiscalYear: fy });
-  }, [setLayerFilter]);
-
-  const setOwnerScope = useCallback((scope: "mine" | "all") => {
-    setLayerFilter("plans", { ownerScope: scope, ownerIds: null });
   }, [setLayerFilter]);
 
   const togglePlanId = useCallback((planId: string) => {
@@ -73,7 +82,7 @@ export default function PlansDropdown({ onClose }: PlansDropdownProps) {
     const next = current.includes(ownerId)
       ? current.filter((id) => id !== ownerId)
       : [...current, ownerId];
-    setLayerFilter("plans", { ownerIds: next.length ? next : null, ownerScope: "all" });
+    setLayerFilter("plans", { ownerIds: next.length ? next : null });
   }, [filters.ownerIds, setLayerFilter]);
 
   // Derive unique owners from plans data
@@ -91,6 +100,14 @@ export default function PlansDropdown({ onClose }: PlansDropdownProps) {
     }
     return [...seen.values()].sort((a, b) => a.fullName.localeCompare(b.fullName));
   }, [plans]);
+
+  const selectAllOwners = useCallback(() => {
+    setLayerFilter("plans", { ownerIds: owners.map((o) => o.id) });
+  }, [owners, setLayerFilter]);
+
+  const deselectAllOwners = useCallback(() => {
+    setLayerFilter("plans", { ownerIds: null });
+  }, [setLayerFilter]);
 
   // Filtered lists for search
   const filteredPlans = useMemo(() => {
@@ -197,31 +214,25 @@ export default function PlansDropdown({ onClose }: PlansDropdownProps) {
 
         {/* Owner */}
         <div>
-          <h4 className="text-[11px] font-semibold text-[#8A80A8] tracking-wider uppercase mb-2">Owner</h4>
-          <div className="flex items-center gap-1 mb-2">
-            <button
-              onClick={() => setOwnerScope("mine")}
-              className={`flex-1 px-3 py-1.5 rounded-lg text-xs font-semibold transition-colors ${
-                (filters.ownerScope ?? "mine") === "mine" && !selectedOwnerIds.length
-                  ? "bg-[#403770] text-white"
-                  : "bg-[#F0EDF5] text-[#544A78] hover:bg-[#E2DEEC]"
-              }`}
-            >
-              My Plans
-            </button>
-            <button
-              onClick={() => setOwnerScope("all")}
-              className={`flex-1 px-3 py-1.5 rounded-lg text-xs font-semibold transition-colors ${
-                filters.ownerScope === "all" && !selectedOwnerIds.length
-                  ? "bg-[#403770] text-white"
-                  : "bg-[#F0EDF5] text-[#544A78] hover:bg-[#E2DEEC]"
-              }`}
-            >
-              All Plans
-            </button>
+          <div className="flex items-center justify-between mb-2">
+            <h4 className="text-[11px] font-semibold text-[#8A80A8] tracking-wider uppercase">Owner</h4>
+            <div className="flex items-center gap-1">
+              <button
+                onClick={selectAllOwners}
+                className="text-[10px] font-semibold text-[#7B6BA4] hover:text-[#403770] transition-colors"
+              >
+                Select All
+              </button>
+              <span className="text-[#D4CFE2] text-[10px]">·</span>
+              <button
+                onClick={deselectAllOwners}
+                className="text-[10px] font-semibold text-[#7B6BA4] hover:text-[#403770] transition-colors"
+              >
+                Deselect All
+              </button>
+            </div>
           </div>
 
-          {/* Specific owners */}
           <input
             type="text"
             value={ownerSearch}
@@ -254,7 +265,7 @@ export default function PlansDropdown({ onClose }: PlansDropdownProps) {
           </div>
           {selectedOwnerIds.length > 0 && (
             <button
-              onClick={() => setLayerFilter("plans", { ownerIds: null, ownerScope: "mine" })}
+              onClick={deselectAllOwners}
               className="mt-1 text-[10px] text-coral hover:text-coral/80 font-medium"
             >
               Clear {selectedOwnerIds.length} selected

--- a/src/features/map/components/SearchBar/index.tsx
+++ b/src/features/map/components/SearchBar/index.tsx
@@ -85,7 +85,6 @@ function countPlanFilters(f: PlanLayerFilter): number {
   let n = 0;
   if (f.status?.length) n++;
   if (f.fiscalYear != null) n++;
-  if (f.ownerScope === "all") n++;
   if (f.planIds?.length) n++;
   if (f.ownerIds?.length) n++;
   return n;
@@ -362,53 +361,60 @@ export default function SearchBar() {
         <div className="w-px h-6 bg-[#D4CFE2]" />
 
         {/* Entity layer toggle + filter buttons — always visible */}
-        <div className="flex items-center gap-1">
-          {/* Districts — always active, not toggleable */}
-          <EntityLayerButton
-            label="Districts"
-            color="#403770"
-            active={true}
-            isOpen={openDropdown === "districts"}
-            onToggle={() => {/* Districts are always visible */}}
-            onChevronClick={() => handleEntityChevronClick("districts", "districts")}
-            count={countByDomain(searchFilters, "fullmind") + countByDomain(searchFilters, "competitors") + countByDomain(searchFilters, "finance") + countByDomain(searchFilters, "demographics") + countByDomain(searchFilters, "academics")}
-          />
-          <EntityLayerButton
-            label="Contacts"
-            color="#F37167"
-            active={activeLayers.has("contacts")}
-            isOpen={openDropdown === "contacts"}
-            onToggle={() => toggleLayer("contacts")}
-            onChevronClick={() => handleEntityChevronClick("contacts", "contacts")}
-            count={activeLayers.has("contacts") ? countContactFilters(contactFilters) : 0}
-          />
-          <EntityLayerButton
-            label="Vacancies"
-            color="#FFCF70"
-            active={activeLayers.has("vacancies")}
-            isOpen={openDropdown === "vacancies"}
-            onToggle={() => toggleLayer("vacancies")}
-            onChevronClick={() => handleEntityChevronClick("vacancies", "vacancies")}
-            count={activeLayers.has("vacancies") ? countVacancyFilters(vacancyFilters, vacancyDateRange) : 0}
-          />
-          <EntityLayerButton
-            label="Activities"
-            color="#6EA3BE"
-            active={activeLayers.has("activities")}
-            isOpen={openDropdown === "activities"}
-            onToggle={() => toggleLayer("activities")}
-            onChevronClick={() => handleEntityChevronClick("activities", "activities")}
-            count={activeLayers.has("activities") ? countActivityFilters(activityFilters, activityDateRange) : 0}
-          />
-          <EntityLayerButton
-            label="Plans"
-            color="#7B6BA4"
-            active={activeLayers.has("plans")}
-            isOpen={openDropdown === "plans"}
-            onToggle={() => toggleLayer("plans")}
-            onChevronClick={() => handleEntityChevronClick("plans", "plans")}
-            count={activeLayers.has("plans") ? countPlanFilters(planFilters) : 0}
-          />
+        <div className="flex flex-col gap-1.5">
+          {(["contacts", "vacancies", "activities", "plans"] as const).some((l) => !activeLayers.has(l)) && (
+            <span className="text-[10px] text-[#B8B0CF] select-none whitespace-nowrap leading-none pl-0.5">
+              Click a layer below to show it on the map
+            </span>
+          )}
+          <div className="flex items-center gap-1">
+            {/* Districts — always active, not toggleable */}
+            <EntityLayerButton
+              label="Districts"
+              color="#403770"
+              active={true}
+              isOpen={openDropdown === "districts"}
+              onToggle={() => {/* Districts are always visible */}}
+              onChevronClick={() => handleEntityChevronClick("districts", "districts")}
+              count={countByDomain(searchFilters, "fullmind") + countByDomain(searchFilters, "competitors") + countByDomain(searchFilters, "finance") + countByDomain(searchFilters, "demographics") + countByDomain(searchFilters, "academics")}
+            />
+            <EntityLayerButton
+              label="Contacts"
+              color="#F37167"
+              active={activeLayers.has("contacts")}
+              isOpen={openDropdown === "contacts"}
+              onToggle={() => activeLayers.has("contacts") ? toggleLayer("contacts") : handleEntityChevronClick("contacts", "contacts")}
+              onChevronClick={() => handleEntityChevronClick("contacts", "contacts")}
+              count={activeLayers.has("contacts") ? countContactFilters(contactFilters) : 0}
+            />
+            <EntityLayerButton
+              label="Vacancies"
+              color="#FFCF70"
+              active={activeLayers.has("vacancies")}
+              isOpen={openDropdown === "vacancies"}
+              onToggle={() => activeLayers.has("vacancies") ? toggleLayer("vacancies") : handleEntityChevronClick("vacancies", "vacancies")}
+              onChevronClick={() => handleEntityChevronClick("vacancies", "vacancies")}
+              count={activeLayers.has("vacancies") ? countVacancyFilters(vacancyFilters, vacancyDateRange) : 0}
+            />
+            <EntityLayerButton
+              label="Activities"
+              color="#6EA3BE"
+              active={activeLayers.has("activities")}
+              isOpen={openDropdown === "activities"}
+              onToggle={() => activeLayers.has("activities") ? toggleLayer("activities") : handleEntityChevronClick("activities", "activities")}
+              onChevronClick={() => handleEntityChevronClick("activities", "activities")}
+              count={activeLayers.has("activities") ? countActivityFilters(activityFilters, activityDateRange) : 0}
+            />
+            <EntityLayerButton
+              label="Plans"
+              color="#7B6BA4"
+              active={activeLayers.has("plans")}
+              isOpen={openDropdown === "plans"}
+              onToggle={() => activeLayers.has("plans") ? toggleLayer("plans") : handleEntityChevronClick("plans", "plans")}
+              onChevronClick={() => handleEntityChevronClick("plans", "plans")}
+              count={activeLayers.has("plans") ? countPlanFilters(planFilters) : 0}
+            />
+          </div>
         </div>
 
         {/* Clear filters */}
@@ -586,33 +592,32 @@ const EntityLayerButton = React.memo(function EntityLayerButton({
 }) {
   return (
     <div
-      className={`flex items-center rounded-lg text-xs font-semibold transition-colors ${
-        isOpen
-          ? "bg-white shadow-sm"
-          : active
-            ? "hover:bg-white hover:shadow-sm"
-            : "hover:bg-white/60"
-      }`}
+      className="flex items-center rounded-lg text-xs font-semibold transition-all duration-150"
       style={{
         borderWidth: "1px",
         borderStyle: "solid",
-        borderColor: isOpen ? `${color}60` : active && count > 0 ? `${color}40` : "transparent",
+        borderColor: isOpen ? `${color}70` : active ? `${color}55` : "transparent",
+        backgroundColor: isOpen ? `${color}18` : active ? `${color}12` : "transparent",
+        boxShadow: (isOpen || active) ? `0 0 0 0px ${color}20` : "none",
       }}
     >
       {/* Dot + label — toggles layer on/off */}
       <button
         onClick={onToggle}
-        className="flex items-center gap-1.5 pl-2.5 pr-1 py-1.5 rounded-l-lg transition-colors hover:bg-[#EFEDF5]/60"
-        style={{ color: active ? undefined : "#8A80A8" }}
+        className="flex items-center gap-1.5 pl-2.5 pr-1 py-1.5 rounded-l-lg transition-colors hover:brightness-95 cursor-pointer"
+        title={active ? `Hide ${label} layer` : `Enable ${label} and open filters`}
       >
         <span
-          className="w-2 h-2 rounded-full shrink-0 transition-opacity duration-150"
+          className="w-2 h-2 rounded-full shrink-0 transition-all duration-150"
           style={{
             backgroundColor: color,
-            opacity: active ? 1 : 0.4,
+            opacity: active ? 1 : 0.2,
           }}
         />
-        <span style={{ color: active ? "#544A78" : "#8A80A8" }}>
+        <span
+          className="whitespace-nowrap transition-colors duration-150"
+          style={{ color: active ? "#403770" : "#C0B8D8", fontWeight: active ? 600 : 400 }}
+        >
           {label}
         </span>
         {active && count > 0 && (
@@ -628,8 +633,9 @@ const EntityLayerButton = React.memo(function EntityLayerButton({
       {/* Chevron — opens filter dropdown */}
       <button
         onClick={onChevronClick}
-        className="flex items-center justify-center px-1.5 py-1.5 rounded-r-lg transition-colors hover:bg-[#EFEDF5]/80"
-        style={{ color: active ? "#544A78" : "#8A80A8" }}
+        className="flex items-center justify-center px-1.5 py-1.5 rounded-r-lg transition-colors hover:brightness-95 cursor-pointer"
+        title={active ? `Filter ${label}` : `Click to enable ${label} in view`}
+        style={{ color: active ? "#6B5FA8" : "#C0B8D8" }}
       >
         <svg
           className={`w-2.5 h-2.5 transition-transform ${isOpen ? "rotate-180" : ""}`}

--- a/src/features/map/components/SearchResults/ResultsTabStrip.tsx
+++ b/src/features/map/components/SearchResults/ResultsTabStrip.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMapV2Store } from "@/features/map/lib/store";
+import { useMapV2Store, type OverlayLayerType } from "@/features/map/lib/store";
 import { LAYER_ORDER, LAYER_COLORS, type LayerType } from "@/features/map/lib/layers";
 
 const LAYER_LABELS: Record<LayerType, string> = {
@@ -19,6 +19,8 @@ interface ResultsTabStripProps {
 export default function ResultsTabStrip({ counts, onCollapse }: ResultsTabStripProps) {
   const activeResultsTab = useMapV2Store((s) => s.activeResultsTab);
   const setActiveResultsTab = useMapV2Store((s) => s.setActiveResultsTab);
+  const activeLayers = useMapV2Store((s) => s.activeLayers);
+  const switchToLayer = useMapV2Store((s) => s.switchToLayer);
 
   return (
     <div className="shrink-0 border-b border-[#E2DEEC] flex items-center">
@@ -27,11 +29,18 @@ export default function ResultsTabStrip({ counts, onCollapse }: ResultsTabStripP
           const isActive = activeResultsTab === layer;
           const color = LAYER_COLORS[layer];
           const count = counts[layer];
+          const isLayerOn = layer === "districts" || activeLayers.has(layer as OverlayLayerType);
 
           return (
             <button
               key={layer}
-              onClick={() => setActiveResultsTab(layer)}
+              onClick={() => {
+                if (!isLayerOn) {
+                  switchToLayer(layer as OverlayLayerType);
+                } else {
+                  setActiveResultsTab(layer);
+                }
+              }}
               className="relative shrink-0 px-4 py-2.5 text-xs font-medium transition-colors whitespace-nowrap"
               style={{
                 color: isActive ? "#403770" : "#8A80A8",


### PR DESCRIPTION
## Summary

- **Layer pill visual contrast** — Active layers now show a colored tinted background + border; inactive layers drop to a very muted dot (20% opacity) + light text, making on/off state immediately obvious
- **One-click layer activation** — Clicking an inactive pill (label or chevron) now enables the layer and opens its filter panel + results tab in one action; no longer requires two separate clicks
- **Tab auto-enables layer** — Clicking a results tab whose layer is off now enables it automatically instead of showing the "layer is off" empty state
- **Contextual hint text** — A soft "Click a layer below to show it on the map" label appears above the pills whenever any overlay layer is inactive; disappears once all are enabled
- **Plans filter defaults by role** — Reps default to seeing only their own plans on first open; admins/managers see all plans
- **Select All / Deselect All** — Replaced the broken "My Plans / All Plans" scope toggle (which was never wired to the API) with functional Select All / Deselect All on the owner checkbox list

## Test plan

- [ ] Open map with all overlay layers off — verify pills look clearly muted and hint text appears above them
- [ ] Enable all layers — verify hint text disappears and pills show colored backgrounds
- [ ] Click an inactive layer pill — verify layer enables, filter panel opens, and results panel switches to that tab in one action
- [ ] Click the Plans tab in the results panel while Plans layer is off — verify it auto-enables instead of showing "Plans layer is off"
- [ ] Open Plans filter as a rep — verify your own name is pre-checked in the owner list
- [ ] Open Plans filter as admin/manager — verify no owner is pre-checked (all plans shown)
- [ ] Use Select All / Deselect All in owner section — verify checkboxes respond correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)