### PR TITLE
fix(leaderboard): restore bucket + target inputs in LHF add-to-plan

### DIFF
--- a/src/features/leaderboard/components/LhfBulkPlanPicker.tsx
+++ b/src/features/leaderboard/components/LhfBulkPlanPicker.tsx
@@ -1,224 +1,368 @@
 "use client";
 
-import { useEffect, useRef, useState, type RefObject } from "react";
-import { createPortal } from "react-dom";
-import { Plus } from "lucide-react";
+import { useEffect, useState, type RefObject } from "react";
+import { X, ArrowLeft, SkipForward, Plus } from "lucide-react";
+import type { IncreaseTarget, IncreaseTargetBucket } from "../lib/types";
 import { useMyPlans, useAddDistrictToPlanMutation } from "../lib/queries";
 import { useCreateTerritoryPlan } from "@/features/plans/lib/queries";
-import type { IncreaseTarget, IncreaseTargetBucket } from "../lib/types";
+import { formatCurrency } from "@/features/shared/lib/format";
 
 interface Props {
   districts: IncreaseTarget[];
-  anchorRef: RefObject<HTMLButtonElement | null>;
+  /** Unused — kept for call-site compatibility (the wizard is a centered modal). */
+  anchorRef?: RefObject<HTMLButtonElement | null>;
   isOpen: boolean;
   onClose: () => void;
-  /** Fires after every district has been added. addedCount may be less than
-   *  districts.length if some additions failed (the picker shows an inline
-   *  error and keeps the popover open in that case). */
   onSuccess: (planName: string, addedCount: number) => void;
 }
 
 const TARGET_FY = 2027;
 
-function defaultBucket(category: IncreaseTarget["category"]): IncreaseTargetBucket {
-  return category === "missing_renewal" ? "renewal" : "winback";
-}
+const BUCKETS: { value: IncreaseTargetBucket; label: string }[] = [
+  { value: "renewal", label: "Renewal" },
+  { value: "winback", label: "Winback" },
+  { value: "expansion", label: "Expansion" },
+  { value: "newBusiness", label: "New Business" },
+];
 
-function defaultTarget(d: IncreaseTarget): number {
-  return d.suggestedTarget ?? 0;
+function defaultBucket(cat: IncreaseTarget["category"]): IncreaseTargetBucket {
+  return cat === "missing_renewal" ? "renewal" : "winback";
 }
 
 export default function LhfBulkPlanPicker({
   districts,
-  anchorRef,
   isOpen,
   onClose,
   onSuccess,
 }: Props) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const newNameInputRef = useRef<HTMLInputElement>(null);
-
-  const [namingNew, setNamingNew] = useState(false);
-  const [newName, setNewName] = useState("");
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [coords, setCoords] = useState<{ top: number; left: number } | null>(null);
-  const [isPending, setIsPending] = useState(false);
-
   const plansQuery = useMyPlans();
   const addMutation = useAddDistrictToPlanMutation();
   const createMutation = useCreateTerritoryPlan();
 
-  const fy27Plans = (plansQuery.data ?? []).filter((p) => p.fiscalYear === TARGET_FY);
+  const [stepIdx, setStepIdx] = useState(0);
+  const [planId, setPlanId] = useState<string>("");
+  const [bucket, setBucket] = useState<IncreaseTargetBucket>(() =>
+    districts[0] ? defaultBucket(districts[0].category) : "renewal",
+  );
+  const [target, setTarget] = useState<string>(() =>
+    districts[0]?.suggestedTarget != null ? String(districts[0].suggestedTarget) : "",
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [addedCount, setAddedCount] = useState(0);
+  const [namingNew, setNamingNew] = useState(false);
+  const [newName, setNewName] = useState("");
 
-  // Position popover above the anchor (toolbar lives at the bottom of the page).
+  const row = districts[stepIdx];
+  const total = districts.length;
+  const isLast = stepIdx === total - 1;
+
+  const fy27Plans = (plansQuery.data ?? []).filter((p) => p.fiscalYear === TARGET_FY);
+  const selectedPlanName = fy27Plans.find((p) => p.id === planId)?.name ?? null;
+
+  // Reset everything on open.
   useEffect(() => {
     if (!isOpen) return;
-    const update = () => {
-      if (!anchorRef.current) return;
-      const rect = anchorRef.current.getBoundingClientRect();
-      const width = 240;
-      const estHeight = namingNew ? 130 : 240;
-      const left = Math.max(8, Math.min(window.innerWidth - width - 8, rect.right - width));
-      const top = Math.max(8, rect.top - estHeight - 6);
-      setCoords({ top, left });
-    };
-    update();
-    window.addEventListener("resize", update);
-    window.addEventListener("scroll", update, true);
-    return () => {
-      window.removeEventListener("resize", update);
-      window.removeEventListener("scroll", update, true);
-    };
-  }, [isOpen, anchorRef, namingNew]);
-
-  useEffect(() => {
-    if (isOpen) return;
+    setStepIdx(0);
+    setPlanId("");
+    setAddedCount(0);
+    setError(null);
     setNamingNew(false);
     setNewName("");
-    setErrorMessage(null);
   }, [isOpen]);
 
+  // Per-step defaults (bucket + target follow each row).
   useEffect(() => {
-    if (!namingNew) return;
-    const id = requestAnimationFrame(() => newNameInputRef.current?.focus());
-    return () => cancelAnimationFrame(id);
-  }, [namingNew]);
+    if (!isOpen || !row) return;
+    setError(null);
+    setBucket(defaultBucket(row.category));
+    setTarget(row.suggestedTarget != null ? String(row.suggestedTarget) : "");
+  }, [isOpen, stepIdx, row]);
 
+  // Escape closes.
   useEffect(() => {
     if (!isOpen) return;
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         e.stopPropagation();
         onClose();
-        anchorRef.current?.focus();
       }
-    };
-    const onMouseDown = (e: MouseEvent) => {
-      const t = e.target as Node;
-      if (containerRef.current?.contains(t)) return;
-      if (anchorRef.current?.contains(t)) return;
-      onClose();
     };
     document.addEventListener("keydown", onKey, true);
-    document.addEventListener("mousedown", onMouseDown);
-    return () => {
-      document.removeEventListener("keydown", onKey, true);
-      document.removeEventListener("mousedown", onMouseDown);
-    };
-  }, [isOpen, onClose, anchorRef]);
+    return () => document.removeEventListener("keydown", onKey, true);
+  }, [isOpen, onClose]);
 
-  if (!isOpen || !coords) return null;
+  if (!isOpen || !row) return null;
 
-  // Sequentially add each district with derived defaults. Sequential (not
-  // Promise.all) keeps the DB writes ordered and avoids hammering the API
-  // when reps select 20+ rows at once.
-  const addAll = async (planId: string) => {
-    let added = 0;
-    for (const d of districts) {
-      try {
-        await addMutation.mutateAsync({
-          planId,
-          leaid: d.leaid,
-          bucket: defaultBucket(d.category),
-          targetAmount: defaultTarget(d),
-        });
-        added += 1;
-      } catch {
-        // Continue on per-row failure; surfaced via the count delta.
-      }
+  const targetNum = Number(target);
+  const isPending = addMutation.isPending || createMutation.isPending;
+  const canSubmit =
+    !!planId && Number.isFinite(targetNum) && targetNum > 0 && !isPending;
+
+  const finish = (added: number) => {
+    if (added > 0 && selectedPlanName) {
+      onSuccess(selectedPlanName, added);
+    } else {
+      onClose();
     }
-    return added;
   };
 
-  const handlePick = async (planId: string, planName: string) => {
-    if (isPending) return;
-    setErrorMessage(null);
-    setIsPending(true);
+  const advance = (added: number) => {
+    if (isLast) {
+      finish(added);
+      return;
+    }
+    setStepIdx((i) => i + 1);
+  };
+
+  const handleSubmit = async () => {
+    if (!canSubmit || !row) return;
     try {
-      const added = await addAll(planId);
-      if (added === 0) {
-        setErrorMessage("Couldn't add any districts. Try again.");
-      } else {
-        onSuccess(planName, added);
-      }
-    } finally {
-      setIsPending(false);
+      await addMutation.mutateAsync({
+        planId,
+        leaid: row.leaid,
+        bucket,
+        targetAmount: targetNum,
+      });
+      const next = addedCount + 1;
+      setAddedCount(next);
+      advance(next);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Couldn't add. Try again.");
     }
   };
 
-  const handleCreate = async (e: React.FormEvent) => {
+  const handleSkip = () => {
+    if (isLast) {
+      finish(addedCount);
+      return;
+    }
+    setStepIdx((i) => i + 1);
+  };
+
+  const handleCreatePlan = async (e: React.FormEvent) => {
     e.preventDefault();
     if (isPending) return;
     const trimmed = newName.trim();
-    if (!trimmed) {
-      newNameInputRef.current?.focus();
-      return;
-    }
-    setErrorMessage(null);
-    setIsPending(true);
+    if (!trimmed) return;
+    setError(null);
     try {
       const created = await createMutation.mutateAsync({
         name: trimmed,
         fiscalYear: TARGET_FY,
       });
-      const added = await addAll(created.id);
-      if (added === 0) {
-        setErrorMessage("Plan created, but no districts were added. Try again.");
-      } else {
-        onSuccess(created.name, added);
-      }
+      setPlanId(created.id);
+      setNamingNew(false);
+      setNewName("");
     } catch {
-      setErrorMessage("Couldn't create the plan. Try again.");
-    } finally {
-      setIsPending(false);
+      setError("Couldn't create the plan. Try again.");
     }
   };
 
-  return createPortal(
+  return (
     <div
-      ref={containerRef}
       role="dialog"
-      aria-label={`Add ${districts.length} districts to a plan`}
-      className="fixed z-50 w-60 rounded-xl bg-white shadow-lg border border-[#D4CFE2] overflow-hidden"
-      style={{ top: coords.top, left: coords.left }}
-      onClick={(e) => e.stopPropagation()}
+      aria-labelledby="bulk-wizard-title"
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
     >
-      {namingNew ? (
-        <form onSubmit={handleCreate} className="p-3 space-y-2">
-          <div className="text-[10px] font-bold uppercase tracking-wider text-[#8A80A8]">
-            Name your new FY27 plan
-          </div>
-          <input
-            ref={newNameInputRef}
-            type="text"
-            value={newName}
-            onChange={(e) => setNewName(e.target.value)}
-            placeholder="FY27 · "
-            className="w-full rounded-lg border border-[#C2BBD4] bg-white px-2 py-1.5 text-xs text-[#403770] focus:outline-none focus:ring-2 focus:ring-[#F37167]/40"
-            disabled={isPending}
-          />
-          {errorMessage && (
-            <p className="text-[11px] text-[#F37167]" role="alert">
-              {errorMessage}
-            </p>
-          )}
-          <div className="flex items-center justify-end gap-2">
+      <div
+        className="absolute inset-0 bg-black/40"
+        onClick={onClose}
+        aria-hidden
+      />
+      <div className="relative w-full max-w-md bg-white rounded-2xl shadow-xl overflow-hidden">
+        <header className="flex items-center justify-between px-5 py-3 border-b border-[#E2DEEC]">
+          <h2 id="bulk-wizard-title" className="text-sm font-bold text-[#403770]">
+            Add to plan
+          </h2>
+          <div className="flex items-center gap-3 text-xs text-[#8A80A8]">
+            <span className="tabular-nums">
+              Step {stepIdx + 1} of {total}
+            </span>
             <button
               type="button"
-              onClick={() => {
-                setNamingNew(false);
-                setNewName("");
-                setErrorMessage(null);
-              }}
-              disabled={isPending}
-              className="px-2 py-1 text-xs font-semibold text-[#6E6390] hover:text-[#403770] disabled:opacity-50"
+              onClick={onClose}
+              aria-label="Close"
+              className="p-1 rounded hover:bg-[#EFEDF5]"
             >
-              Cancel
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+        </header>
+
+        <div className="p-5 space-y-4">
+          <div>
+            <div className="text-base font-bold text-[#403770]">
+              {row.districtName}
+            </div>
+            <div className="text-xs text-[#8A80A8]">
+              {row.state} ·{" "}
+              {formatCurrency(
+                row.category === "missing_renewal"
+                  ? row.fy26Revenue
+                  : row.priorYearRevenue,
+                true,
+              )}{" "}
+              {row.category === "missing_renewal"
+                ? "FY26"
+                : row.priorYearFy ?? "prior"}
+            </div>
+          </div>
+
+          {/* Plan select OR new-plan name input */}
+          {namingNew ? (
+            <form onSubmit={handleCreatePlan} className="space-y-2">
+              <label className="block text-[10px] uppercase tracking-wider font-bold text-[#8A80A8] mb-1">
+                New FY27 plan name
+              </label>
+              <div className="flex items-center gap-2">
+                <input
+                  autoFocus
+                  type="text"
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  placeholder="FY27 · "
+                  disabled={isPending}
+                  className="flex-1 px-3 py-2 rounded-lg border border-[#C2BBD4] text-sm text-[#403770] focus:outline-none focus:ring-2 focus:ring-[#F37167]/40"
+                />
+                <button
+                  type="submit"
+                  disabled={isPending || !newName.trim()}
+                  className="px-3 py-2 rounded-lg text-xs font-semibold text-white bg-[#403770] hover:bg-[#322a5a] disabled:opacity-50"
+                >
+                  Create
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setNamingNew(false);
+                    setNewName("");
+                  }}
+                  disabled={isPending}
+                  className="text-xs font-semibold text-[#6E6390] hover:text-[#403770] disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+              </div>
+            </form>
+          ) : (
+            <div>
+              <div className="flex items-center justify-between mb-1">
+                <label className="block text-[10px] uppercase tracking-wider font-bold text-[#8A80A8]">
+                  Plan
+                </label>
+                <button
+                  type="button"
+                  onClick={() => setNamingNew(true)}
+                  className="inline-flex items-center gap-1 text-[11px] font-semibold text-[#403770] hover:underline"
+                >
+                  <Plus className="w-3 h-3" />
+                  New plan…
+                </button>
+              </div>
+              <select
+                value={planId}
+                onChange={(e) => setPlanId(e.target.value)}
+                className="w-full px-3 py-2 rounded-lg border border-[#C2BBD4] text-sm text-[#403770]"
+                disabled={plansQuery.isLoading || fy27Plans.length === 0}
+              >
+                <option value="">
+                  {fy27Plans.length === 0
+                    ? "No FY27 plans — create one"
+                    : "Select a plan…"}
+                </option>
+                {fy27Plans.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          <div>
+            <label className="block text-[10px] uppercase tracking-wider font-bold text-[#8A80A8] mb-1">
+              Type
+            </label>
+            <div className="flex flex-wrap gap-3">
+              {BUCKETS.map((b) => (
+                <label
+                  key={b.value}
+                  className="flex items-center gap-1.5 text-xs text-[#6E6390] cursor-pointer"
+                >
+                  <input
+                    type="radio"
+                    name="bulk-bucket"
+                    checked={bucket === b.value}
+                    onChange={() => setBucket(b.value)}
+                    className="w-3.5 h-3.5"
+                    style={{ accentColor: "#403770" }}
+                  />
+                  <span>{b.label}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <label
+              htmlFor="bulk-target-input"
+              className="block text-[10px] uppercase tracking-wider font-bold text-[#8A80A8] mb-1"
+            >
+              Target
+            </label>
+            <div className="flex items-center gap-2">
+              <div className="flex-1 relative">
+                <span className="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-[#8A80A8]">
+                  $
+                </span>
+                <input
+                  id="bulk-target-input"
+                  type="text"
+                  inputMode="decimal"
+                  value={target}
+                  onChange={(e) =>
+                    setTarget(e.target.value.replace(/[^\d.]/g, ""))
+                  }
+                  className="w-full pl-6 pr-3 py-2 rounded-lg border border-[#C2BBD4] text-sm text-[#403770] tabular-nums"
+                />
+              </div>
+              {row.suggestedTarget != null && (
+                <span className="text-xs text-[#8A80A8] whitespace-nowrap">
+                  Suggested: {formatCurrency(row.suggestedTarget, true)}
+                </span>
+              )}
+            </div>
+            {error && (
+              <div className="mt-1 text-xs text-[#B5453D]" role="alert">
+                {error}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <footer className="flex items-center justify-between gap-2 px-5 py-3 border-t border-[#E2DEEC] bg-[#F7F5FA]">
+          <button
+            type="button"
+            disabled={stepIdx === 0 || isPending}
+            onClick={() => setStepIdx((i) => Math.max(0, i - 1))}
+            className="inline-flex items-center gap-1 text-xs font-semibold text-[#6E6390] hover:text-[#403770] disabled:opacity-40"
+          >
+            <ArrowLeft className="w-3.5 h-3.5" /> Back
+          </button>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handleSkip}
+              disabled={isPending}
+              className="inline-flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-semibold text-[#6E6390] hover:bg-[#EFEDF5] disabled:opacity-40"
+            >
+              <SkipForward className="w-3.5 h-3.5" /> Skip this one
             </button>
             <button
-              type="submit"
-              disabled={isPending || !newName.trim()}
-              className="inline-flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-semibold text-white bg-[#403770] hover:bg-[#322a5a] disabled:opacity-50"
+              type="button"
+              disabled={!canSubmit}
+              onClick={handleSubmit}
+              className="inline-flex items-center gap-1 px-3 py-1.5 rounded-md text-xs font-semibold text-white bg-[#403770] hover:bg-[#322a5a] disabled:opacity-40 disabled:cursor-not-allowed"
             >
               {isPending && (
                 <span
@@ -226,66 +370,15 @@ export default function LhfBulkPlanPicker({
                   aria-hidden
                 />
               )}
-              Create &amp; add {districts.length}
+              {isPending
+                ? "Adding…"
+                : isLast
+                  ? "Add & finish"
+                  : "Add & continue →"}
             </button>
           </div>
-        </form>
-      ) : (
-        <>
-          <div className="px-3 py-2 text-[10px] font-bold uppercase tracking-wider text-[#8A80A8] border-b border-[#E2DEEC]">
-            Add {districts.length} {districts.length === 1 ? "district" : "districts"} to plan
-          </div>
-          <div className="max-h-64 overflow-y-auto">
-            {plansQuery.isLoading ? (
-              <div className="px-3 py-2 text-xs text-[#A69DC0]">Loading plans…</div>
-            ) : fy27Plans.length === 0 ? (
-              <div className="px-3 py-2 text-xs text-[#A69DC0]">No FY27 plans yet.</div>
-            ) : (
-              fy27Plans.map((p) => (
-                <button
-                  key={p.id}
-                  type="button"
-                  disabled={isPending}
-                  onClick={() => handlePick(p.id, p.name)}
-                  className="w-full flex items-center justify-between px-3 py-2 text-xs text-[#403770] hover:bg-[#F7F5FA] disabled:opacity-50 text-left"
-                >
-                  <span className="truncate">{p.name}</span>
-                  <span className="text-[11px] text-[#A69DC0] tabular-nums shrink-0 ml-2">
-                    {p.districtCount}
-                  </span>
-                </button>
-              ))
-            )}
-          </div>
-          {isPending && (
-            <div className="px-3 py-1.5 text-[11px] text-[#6E6390] flex items-center gap-1.5">
-              <span
-                className="w-3 h-3 border-2 border-[#403770] border-t-transparent rounded-full animate-spin"
-                aria-hidden
-              />
-              Adding {districts.length} districts…
-            </div>
-          )}
-          {errorMessage && (
-            <p className="px-3 py-1.5 text-[11px] text-[#F37167]" role="alert">
-              {errorMessage}
-            </p>
-          )}
-          <button
-            type="button"
-            onClick={() => {
-              setErrorMessage(null);
-              setNamingNew(true);
-            }}
-            disabled={isPending}
-            className="w-full flex items-center gap-1.5 px-3 py-2 text-xs font-semibold text-[#403770] border-t border-[#E2DEEC] hover:bg-[#F7F5FA] disabled:opacity-50"
-          >
-            <Plus className="w-3 h-3" />
-            New plan…
-          </button>
-        </>
-      )}
-    </div>,
-    document.body,
+        </footer>
+      </div>
+    </div>
   );
 }

--- a/src/features/leaderboard/components/LhfPlanPicker.tsx
+++ b/src/features/leaderboard/components/LhfPlanPicker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState, type RefObject } from "react";
+import { useEffect, useMemo, useRef, useState, type RefObject } from "react";
 import { createPortal } from "react-dom";
 import { Plus } from "lucide-react";
 import { useMyPlans, useAddDistrictToPlanMutation } from "../lib/queries";
@@ -20,13 +20,28 @@ interface Props {
 
 const TARGET_FY = 2027;
 
+const BUCKET_OPTIONS: { value: IncreaseTargetBucket; label: string }[] = [
+  { value: "renewal", label: "Renewal" },
+  { value: "winback", label: "Winback" },
+  { value: "expansion", label: "Expansion" },
+  { value: "newBusiness", label: "New Business" },
+];
+
 function defaultBucket(category: IncreaseTarget["category"]): IncreaseTargetBucket {
   return category === "missing_renewal" ? "renewal" : "winback";
 }
 
-function defaultTarget(district: IncreaseTarget): number {
-  if (district.suggestedTarget != null) return district.suggestedTarget;
-  return 0;
+function parseTargetInput(raw: string): number {
+  const cleaned = raw.replace(/[^\d.-]/g, "");
+  if (!cleaned) return 0;
+  const n = Number(cleaned);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function formatTargetInput(raw: string): string {
+  const n = parseTargetInput(raw);
+  if (n <= 0) return "";
+  return n.toLocaleString("en-US", { maximumFractionDigits: 0 });
 }
 
 export default function LhfPlanPicker({
@@ -37,11 +52,21 @@ export default function LhfPlanPicker({
   onSuccess,
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const firstFieldRef = useRef<HTMLSelectElement>(null);
   const newNameInputRef = useRef<HTMLInputElement>(null);
 
+  const [planId, setPlanId] = useState<string>("");
+  const [bucket, setBucket] = useState<IncreaseTargetBucket>(() =>
+    defaultBucket(district.category),
+  );
+  const [targetInput, setTargetInput] = useState<string>(() =>
+    district.suggestedTarget != null
+      ? formatTargetInput(String(district.suggestedTarget))
+      : "",
+  );
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [namingNew, setNamingNew] = useState(false);
   const [newName, setNewName] = useState("");
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [coords, setCoords] = useState<{ top: number; left: number } | null>(null);
 
   const plansQuery = useMyPlans();
@@ -49,41 +74,82 @@ export default function LhfPlanPicker({
   const createMutation = useCreateTerritoryPlan();
 
   const fy27Plans = (plansQuery.data ?? []).filter((p) => p.fiscalYear === TARGET_FY);
+  const isPlansLoading = plansQuery.isLoading;
+  const hasNoPlans = !isPlansLoading && fy27Plans.length === 0;
+  const isPending = addMutation.isPending || createMutation.isPending;
 
-  // Position popover below anchor, right-aligned.
+  const parsedTarget = useMemo(() => parseTargetInput(targetInput), [targetInput]);
+  const canSubmit = !!planId && parsedTarget > 0 && !isPending && !hasNoPlans;
+
+  // Reset every time we reopen for a fresh district.
+  useEffect(() => {
+    if (!isOpen) return;
+    setPlanId("");
+    setBucket(defaultBucket(district.category));
+    setTargetInput(
+      district.suggestedTarget != null
+        ? formatTargetInput(String(district.suggestedTarget))
+        : "",
+    );
+    setErrorMessage(null);
+    setNamingNew(false);
+    setNewName("");
+  }, [isOpen, district.leaid, district.category, district.suggestedTarget]);
+
+  // Position popover near anchor, right-aligned. Flips above when there's
+  // not enough room below (rows near the bottom of the viewport).
   useEffect(() => {
     if (!isOpen) return;
     const update = () => {
       if (!anchorRef.current) return;
       const rect = anchorRef.current.getBoundingClientRect();
-      const width = 240;
-      const left = Math.max(8, Math.min(window.innerWidth - width - 8, rect.right - width));
-      const top = rect.bottom + 6;
+      const width = 320;
+      // Measure rendered height when available; fall back to a conservative estimate.
+      const measured = containerRef.current?.offsetHeight ?? 0;
+      const height = measured > 0 ? measured : 360;
+      const margin = 8;
+      const gap = 6;
+      const left = Math.max(
+        margin,
+        Math.min(window.innerWidth - width - margin, rect.right - width),
+      );
+      const spaceBelow = window.innerHeight - rect.bottom;
+      const spaceAbove = rect.top;
+      let top: number;
+      if (spaceBelow >= height + gap + margin) {
+        top = rect.bottom + gap;
+      } else if (spaceAbove >= height + gap + margin) {
+        top = rect.top - height - gap;
+      } else {
+        // Neither side fits; pin near the larger side and clamp to viewport.
+        top =
+          spaceBelow >= spaceAbove
+            ? Math.min(rect.bottom + gap, window.innerHeight - height - margin)
+            : Math.max(margin, rect.top - height - gap);
+      }
       setCoords({ top, left });
     };
     update();
+    // Re-run after layout to catch the measured height once the popover paints.
+    const raf = requestAnimationFrame(update);
     window.addEventListener("resize", update);
     window.addEventListener("scroll", update, true);
     return () => {
+      cancelAnimationFrame(raf);
       window.removeEventListener("resize", update);
       window.removeEventListener("scroll", update, true);
     };
-  }, [isOpen, anchorRef]);
+  }, [isOpen, anchorRef, namingNew]);
 
-  // Reset internal state on close.
+  // Focus first field on open / new-plan input on toggle.
   useEffect(() => {
-    if (isOpen) return;
-    setNamingNew(false);
-    setNewName("");
-    setErrorMessage(null);
-  }, [isOpen]);
-
-  // Focus the name input when it appears.
-  useEffect(() => {
-    if (!namingNew) return;
-    const id = requestAnimationFrame(() => newNameInputRef.current?.focus());
+    if (!isOpen) return;
+    const id = requestAnimationFrame(() => {
+      if (namingNew) newNameInputRef.current?.focus();
+      else firstFieldRef.current?.focus();
+    });
     return () => cancelAnimationFrame(id);
-  }, [namingNew]);
+  }, [isOpen, namingNew]);
 
   // Outside click + escape.
   useEffect(() => {
@@ -111,17 +177,18 @@ export default function LhfPlanPicker({
 
   if (!isOpen || !coords) return null;
 
-  const isPending = addMutation.isPending || createMutation.isPending;
-
-  const handlePick = async (planId: string, planName: string) => {
-    if (isPending) return;
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canSubmit) return;
     setErrorMessage(null);
+    const chosenPlan = fy27Plans.find((p) => p.id === planId);
+    const planName = chosenPlan?.name ?? "plan";
     try {
       await addMutation.mutateAsync({
         planId,
         leaid: district.leaid,
-        bucket: defaultBucket(district.category),
-        targetAmount: defaultTarget(district),
+        bucket,
+        targetAmount: parsedTarget,
       });
       onSuccess(planName);
     } catch {
@@ -137,6 +204,10 @@ export default function LhfPlanPicker({
       newNameInputRef.current?.focus();
       return;
     }
+    if (parsedTarget <= 0) {
+      setErrorMessage("Set a target amount first.");
+      return;
+    }
     setErrorMessage(null);
     try {
       const created = await createMutation.mutateAsync({
@@ -146,8 +217,8 @@ export default function LhfPlanPicker({
       await addMutation.mutateAsync({
         planId: created.id,
         leaid: district.leaid,
-        bucket: defaultBucket(district.category),
-        targetAmount: defaultTarget(district),
+        bucket,
+        targetAmount: parsedTarget,
       });
       onSuccess(created.name);
     } catch {
@@ -155,37 +226,161 @@ export default function LhfPlanPicker({
     }
   };
 
-  // Portal to body so the popover escapes the table's sticky-cell stacking
-  // contexts (without it, sticky <td>s in rows below paint over the popover).
+  // Portal so the popover escapes sticky-cell stacking contexts in the table.
   return createPortal(
     <div
       ref={containerRef}
       role="dialog"
       aria-label={`Add ${district.districtName} to a plan`}
-      className="fixed z-50 w-60 rounded-xl bg-white shadow-lg border border-[#D4CFE2] overflow-hidden"
+      className="fixed z-50 w-80 rounded-xl bg-white shadow-xl border border-[#D4CFE2]"
       style={{ top: coords.top, left: coords.left }}
       onClick={(e) => e.stopPropagation()}
     >
-      {namingNew ? (
-        <form onSubmit={handleCreate} className="p-3 space-y-2">
-          <div className="text-[10px] font-bold uppercase tracking-wider text-[#8A80A8]">
-            Name your new FY27 plan
+      <form onSubmit={namingNew ? handleCreate : handleSubmit} className="p-4 space-y-3">
+        <div>
+          <h3 className="text-sm font-semibold text-[#403770] leading-tight">
+            Add to plan
+          </h3>
+          <p className="text-[11px] text-[#6E6390] truncate">
+            {district.districtName}
+            {district.state ? ` · ${district.state}` : ""}
+          </p>
+        </div>
+
+        {/* Plan select OR new-plan name input */}
+        {namingNew ? (
+          <div className="space-y-1">
+            <label
+              htmlFor="add-plan-newname"
+              className="block text-[11px] font-semibold text-[#544A78] uppercase tracking-wider"
+            >
+              New FY27 plan name
+            </label>
+            <input
+              id="add-plan-newname"
+              ref={newNameInputRef}
+              type="text"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              placeholder={`FY27 · ${district.districtName}`}
+              disabled={isPending}
+              className="w-full rounded-md border border-[#C2BBD4] bg-white px-2 py-1.5 text-sm text-[#403770] focus:border-[#403770] focus:outline-none focus:ring-2 focus:ring-[#F37167]/40"
+            />
           </div>
-          <input
-            ref={newNameInputRef}
-            type="text"
-            value={newName}
-            onChange={(e) => setNewName(e.target.value)}
-            placeholder={`FY27 · ${district.districtName}`}
-            className="w-full rounded-lg border border-[#C2BBD4] bg-white px-2 py-1.5 text-xs text-[#403770] focus:outline-none focus:ring-2 focus:ring-[#F37167]/40"
-            disabled={isPending}
-          />
-          {errorMessage && (
-            <p className="text-[11px] text-[#F37167]" role="alert">
-              {errorMessage}
-            </p>
-          )}
-          <div className="flex items-center justify-end gap-2">
+        ) : (
+          <div className="space-y-1">
+            <label
+              htmlFor="add-plan-select"
+              className="block text-[11px] font-semibold text-[#544A78] uppercase tracking-wider"
+            >
+              Plan
+            </label>
+            <select
+              id="add-plan-select"
+              ref={firstFieldRef}
+              value={planId}
+              onChange={(e) => setPlanId(e.target.value)}
+              disabled={hasNoPlans || isPlansLoading}
+              className="w-full rounded-md border border-[#C2BBD4] bg-white px-2 py-1.5 text-sm text-[#403770] focus:border-[#403770] focus:outline-none focus:ring-2 focus:ring-[#F37167]/40 disabled:opacity-60 disabled:cursor-not-allowed"
+            >
+              {isPlansLoading ? (
+                <option value="">Loading plans…</option>
+              ) : hasNoPlans ? (
+                <option value="">No FY27 plans yet</option>
+              ) : (
+                <>
+                  <option value="">Select a plan…</option>
+                  {fy27Plans.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.name}
+                    </option>
+                  ))}
+                </>
+              )}
+            </select>
+          </div>
+        )}
+
+        {/* Bucket radio group */}
+        <fieldset className="space-y-1">
+          <legend className="block text-[11px] font-semibold text-[#544A78] uppercase tracking-wider">
+            Type
+          </legend>
+          <div className="grid grid-cols-2 gap-1">
+            {BUCKET_OPTIONS.map((opt) => {
+              const selected = bucket === opt.value;
+              return (
+                <label
+                  key={opt.value}
+                  className={`flex items-center gap-1.5 px-2 py-1.5 rounded-md border text-xs cursor-pointer transition-colors ${
+                    selected
+                      ? "border-[#403770] bg-[#EFEDF5] text-[#403770] font-semibold"
+                      : "border-[#D4CFE2] text-[#6E6390] hover:border-[#C2BBD4]"
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    name="bucket"
+                    value={opt.value}
+                    checked={selected}
+                    onChange={() => setBucket(opt.value)}
+                    className="sr-only"
+                  />
+                  <span
+                    className={`w-3 h-3 rounded-full border flex items-center justify-center ${
+                      selected ? "border-[#403770]" : "border-[#A69DC0]"
+                    }`}
+                  >
+                    {selected && (
+                      <span className="w-1.5 h-1.5 rounded-full bg-[#403770]" />
+                    )}
+                  </span>
+                  {opt.label}
+                </label>
+              );
+            })}
+          </div>
+        </fieldset>
+
+        {/* Target input */}
+        <div className="space-y-1">
+          <label
+            htmlFor="add-plan-target"
+            className="block text-[11px] font-semibold text-[#544A78] uppercase tracking-wider"
+          >
+            Target
+          </label>
+          <div className="relative">
+            <span
+              className="absolute left-2 top-1/2 -translate-y-1/2 text-sm text-[#6E6390] pointer-events-none"
+              aria-hidden="true"
+            >
+              $
+            </span>
+            <input
+              id="add-plan-target"
+              type="text"
+              inputMode="decimal"
+              value={targetInput}
+              placeholder="0"
+              onChange={(e) => setTargetInput(e.target.value)}
+              onBlur={(e) => setTargetInput(formatTargetInput(e.target.value))}
+              className="w-full rounded-md border border-[#C2BBD4] bg-white pl-5 pr-2 py-1.5 text-sm text-[#403770] tabular-nums focus:border-[#403770] focus:outline-none focus:ring-2 focus:ring-[#F37167]/40"
+              required
+            />
+          </div>
+        </div>
+
+        {/* Error */}
+        {errorMessage && (
+          <p className="text-xs text-[#F37167]" role="alert">
+            {errorMessage}
+          </p>
+        )}
+
+        {/* Actions */}
+        <div className="flex items-center justify-between gap-2 pt-1">
+          {namingNew ? (
             <button
               type="button"
               onClick={() => {
@@ -194,71 +389,53 @@ export default function LhfPlanPicker({
                 setErrorMessage(null);
               }}
               disabled={isPending}
-              className="px-2 py-1 text-xs font-semibold text-[#6E6390] hover:text-[#403770] disabled:opacity-50"
+              className="text-[11px] font-semibold text-[#6E6390] hover:text-[#403770] disabled:opacity-50"
+            >
+              ← Pick existing plan
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => {
+                setErrorMessage(null);
+                setNamingNew(true);
+              }}
+              disabled={isPending}
+              className="inline-flex items-center gap-1 text-[11px] font-semibold text-[#403770] hover:underline disabled:opacity-50"
+            >
+              <Plus className="w-3 h-3" />
+              New plan…
+            </button>
+          )}
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={isPending}
+              className="px-3 py-1.5 rounded-md text-xs font-semibold text-[#6E6390] hover:text-[#403770] hover:bg-[#F7F5FA] disabled:opacity-50 transition-colors"
             >
               Cancel
             </button>
             <button
               type="submit"
-              disabled={isPending || !newName.trim()}
-              className="inline-flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-semibold text-white bg-[#403770] hover:bg-[#322a5a] disabled:opacity-50"
+              disabled={
+                namingNew
+                  ? isPending || !newName.trim() || parsedTarget <= 0
+                  : !canSubmit
+              }
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-semibold text-white bg-[#403770] hover:bg-[#322a5a] focus:outline-none focus:ring-2 focus:ring-[#F37167]/40 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
               {isPending && (
                 <span
                   className="w-3 h-3 border-2 border-white border-t-transparent rounded-full animate-spin"
-                  aria-hidden
+                  aria-hidden="true"
                 />
               )}
-              Create &amp; add
+              {namingNew ? "Create & add" : "Add to Plan"}
             </button>
           </div>
-        </form>
-      ) : (
-        <>
-          <div className="px-3 py-2 text-[10px] font-bold uppercase tracking-wider text-[#8A80A8] border-b border-[#E2DEEC]">
-            Add to plan
-          </div>
-          <div className="max-h-64 overflow-y-auto">
-            {plansQuery.isLoading ? (
-              <div className="px-3 py-2 text-xs text-[#A69DC0]">Loading plans…</div>
-            ) : fy27Plans.length === 0 ? (
-              <div className="px-3 py-2 text-xs text-[#A69DC0]">No FY27 plans yet.</div>
-            ) : (
-              fy27Plans.map((p) => (
-                <button
-                  key={p.id}
-                  type="button"
-                  disabled={isPending}
-                  onClick={() => handlePick(p.id, p.name)}
-                  className="w-full flex items-center justify-between px-3 py-2 text-xs text-[#403770] hover:bg-[#F7F5FA] disabled:opacity-50 text-left"
-                >
-                  <span className="truncate">{p.name}</span>
-                  <span className="text-[11px] text-[#A69DC0] tabular-nums shrink-0 ml-2">
-                    {p.districtCount}
-                  </span>
-                </button>
-              ))
-            )}
-          </div>
-          {errorMessage && (
-            <p className="px-3 py-1.5 text-[11px] text-[#F37167]" role="alert">
-              {errorMessage}
-            </p>
-          )}
-          <button
-            type="button"
-            onClick={() => {
-              setErrorMessage(null);
-              setNamingNew(true);
-            }}
-            disabled={isPending}
-            className="w-full flex items-center gap-1.5 px-3 py-2 text-xs font-semibold text-[#403770] border-t border-[#E2DEEC] hover:bg-[#F7F5FA] disabled:opacity-50"
-          >
-            <Plus className="w-3 h-3" />
-            New plan…
-          </button>
-        </>
-      )}
+        </div>
+      </form>
     </div>,
     document.body,
   );


### PR DESCRIPTION
## Summary
- The compact-ledger redesign collapsed the LHF Add-to-Plan flows to a one-click plan list that auto-derived bucket from row category and used the suggested target. Restores explicit per-row bucket choice (Renewal / Winback / Expansion / New Business) and editable dollar target — the experience reps had before the redesign.
- **Single-row `+ Plan`** (`LhfPlanPicker`): form with plan select, 4-bucket radio (default from category), `$` target input (default from `suggestedTarget`). Inline `+ New plan…` preserved. Popover flips above the anchor when there's not enough room below — fixes cut-off on near-bottom rows.
- **Bulk `Add N to plan`** (`LhfBulkPlanPicker`): centered modal wizard with `Step N of M`, plan select sticky across steps, per-row bucket radio + target input, `Back` / `Skip` / `Add & continue` (final step `Add & finish`).

## Test plan
- [ ] On a leaderboard "Increase your targets" row near the **top** of the viewport, click `+ Plan` → popover renders below the row, fully visible.
- [ ] On a row near the **bottom** of the viewport, click `+ Plan` → popover renders above the row, fully visible.
- [ ] Pick a plan, change `Type` from default, edit `$ target`, click `Add to Plan` → district added with the chosen bucket + target; toast appears.
- [ ] Click `+ New plan…` → input swaps in; create with a name → plan is created and the district is added in one step.
- [ ] Select 2+ rows → click `Add N to plan` in bottom toolbar → modal wizard appears with `Step 1 of N`; per-row bucket + target prefilled from each row's category/`suggestedTarget`.
- [ ] In the wizard: `Back` returns to prior step, `Skip` advances without adding, `Add & continue →` adds the row and advances; final step shows `Add & finish` and emits a single toast with the total added count.
- [ ] `Esc` closes both pickers; clicking outside the single-row popover closes it; clicking the modal backdrop closes the wizard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)