### PR TITLE
feat(lhf): category count chips + summary banner

### DIFF
--- a/src/features/leaderboard/components/LowHangingFruitFilterBar.tsx
+++ b/src/features/leaderboard/components/LowHangingFruitFilterBar.tsx
@@ -194,22 +194,28 @@ export default function LowHangingFruitFilterBar({ filters, facets, onChange, sh
         Filters
       </span>
 
-      {/* Category */}
-      <Dropdown label="Category" activeCount={filters.categories.length} width={240}>
-        {() => (
-          <div className="py-1.5">
-            {(["missing_renewal", "fullmind_winback", "ek12_winback"] as IncreaseTargetCategory[]).map((c) => (
-              <CheckOption
-                key={c}
-                checked={filters.categories.includes(c)}
-                label={CATEGORY_LABELS[c]}
-                suffix={String(facets.categoryCounts[c] ?? 0)}
-                onChange={() => toggleCategory(c)}
-              />
-            ))}
-          </div>
-        )}
-      </Dropdown>
+      {/* Category chips — always-visible toggles with counts */}
+      {(["missing_renewal", "fullmind_winback", "ek12_winback"] as IncreaseTargetCategory[]).map((c) => {
+        const active = filters.categories.includes(c);
+        const count = facets.categoryCounts[c] ?? 0;
+        return (
+          <button
+            key={c}
+            type="button"
+            onClick={() => toggleCategory(c)}
+            className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-semibold border transition-colors whitespace-nowrap ${
+              active
+                ? "bg-[#EFEDF5] border-[#403770] text-[#403770]"
+                : "bg-white border-[#D4CFE2] text-[#6E6390] hover:border-[#C2BBD4]"
+            }`}
+          >
+            {CATEGORY_LABELS[c]}
+            <span className={`tabular-nums font-normal ${active ? "text-[#403770]" : "text-[#8A80A8]"}`}>
+              ({count})
+            </span>
+          </button>
+        );
+      })}
 
       {/* State */}
       <Dropdown label="State" activeCount={filters.states.length} width={260}>

--- a/src/features/leaderboard/components/LowHangingFruitFilterBar.tsx
+++ b/src/features/leaderboard/components/LowHangingFruitFilterBar.tsx
@@ -9,6 +9,7 @@ import { DEFAULT_FILTERS, UNASSIGNED_REP } from "../lib/filters";
 interface Facets {
   categoryCounts: Record<IncreaseTargetCategory, number>;
   states: string[];
+  stateCounts: Record<string, number>;
   products: string[];
   /** Distinct rep names from `lastClosedWon`, sorted, never including the
    *  unassigned sentinel (the dropdown adds that as a fixed first row). */
@@ -239,6 +240,7 @@ export default function LowHangingFruitFilterBar({ filters, facets, onChange, sh
                     key={s}
                     checked={filters.states.includes(s)}
                     label={s}
+                    suffix={String(facets.stateCounts[s] ?? 0)}
                     onChange={() => toggleState(s)}
                   />
                 ))

--- a/src/features/leaderboard/components/LowHangingFruitView.tsx
+++ b/src/features/leaderboard/components/LowHangingFruitView.tsx
@@ -233,19 +233,20 @@ export default function LowHangingFruitView() {
       fullmind_winback: 0,
       ek12_winback: 0,
     };
-    const states = new Set<string>();
+    const stateCounts: Record<string, number> = {};
     const products = new Set<string>();
     const reps = new Set<string>();
     for (const r of allRows) {
       counts[r.category]++;
-      if (r.state) states.add(r.state);
+      if (r.state) stateCounts[r.state] = (stateCounts[r.state] ?? 0) + 1;
       for (const p of r.productTypes) products.add(p);
       const rep = r.lastClosedWon?.repName;
       if (rep) reps.add(rep);
     }
     return {
       categoryCounts: counts,
-      states: [...states].sort(),
+      states: Object.keys(stateCounts).sort(),
+      stateCounts,
       products: [...products].sort(),
       reps: [...reps].sort((a, b) => a.localeCompare(b)),
     };

--- a/src/features/leaderboard/components/LowHangingFruitView.tsx
+++ b/src/features/leaderboard/components/LowHangingFruitView.tsx
@@ -345,6 +345,22 @@ export default function LowHangingFruitView() {
           </button>
         </header>
 
+        {/* Summary banner */}
+        <div className="flex-shrink-0 px-5 py-3.5 bg-[#F7F5FA] border-b border-[#E2DEEC]">
+          <p className="text-xs text-[#544A78] leading-relaxed">
+            You&apos;ll find 3 buckets of customers on this page:{" "}
+            <strong className="text-[#403770]">Missing Renewals</strong>,{" "}
+            <strong className="text-[#403770]">Fullmind Winbacks</strong>, and{" "}
+            <strong className="text-[#403770]">Elevate Winbacks</strong>.{" "}
+            All Winbacks are first-come, first-serve — it doesn&apos;t matter if you were the original rep or if the customer is from your company of origin.
+            Grab any winback that looks exciting and fits into the goals you have for your Book of Business!
+          </p>
+          <p className="text-xs text-[#544A78] mt-2">
+            <strong className="text-[#403770]">How to action them:</strong>{" "}
+            Click the <strong className="text-[#403770]">+Opp</strong> button to jump straight into the LMS and create the opportunity — or add to a plan and set a target to remove it from the list.
+          </p>
+        </div>
+
         <LowHangingFruitFilterBar
           filters={filters}
           facets={facets}

--- a/src/features/leaderboard/components/__tests__/LowHangingFruitView.test.tsx
+++ b/src/features/leaderboard/components/__tests__/LowHangingFruitView.test.tsx
@@ -75,7 +75,7 @@ describe("LowHangingFruitView", () => {
     // Row data
     expect(screen.getByText("Pasadena USD")).toBeInTheDocument();
     expect(screen.getByText("CA")).toBeInTheDocument();
-    expect(screen.getByText(/Missing renewal/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Missing renewal/i).length).toBeGreaterThan(0);
     expect(screen.getByText("Jordan Lee")).toBeInTheDocument();
 
     // Action bar


### PR DESCRIPTION
## Summary
- Replaces the single **Category** dropdown in the filter bar with three always-visible toggle chips (Missing Renewal, Fullmind Winback, EK12 Winback) — each displays its live count so reps see bucket sizes at a glance without opening any dropdown
- Adds an instructional **summary banner** between the page header and the filter bar explaining the three buckets, the first-come first-serve winback policy, and how to action rows (+Opp or add to plan)

## Test plan
- [ ] Filter bar shows three category chips with correct counts next to each label
- [ ] Clicking a chip toggles it active (plum highlight) and filters the table
- [ ] Multiple chips can be active simultaneously
- [ ] Summary banner is visible below the header, text matches spec
- [ ] Export CSV, bulk-select, and other filter dropdowns unaffected
- [ ] All leaderboard tests pass (36/36)

🤖 Generated with [Claude Code](https://claude.com/claude-code)