### PR TITLE
fix(leaderboard): close $1.3M FY attribution gap (Monica's number: $1.96M → $3.29M)

### DIFF
--- a/Docs/superpowers/plans/2026-04-30-leaderboard-fy-attribution-fix.md
+++ b/Docs/superpowers/plans/2026-04-30-leaderboard-fy-attribution-fix.md
@@ -1,0 +1,1635 @@
+# Leaderboard FY Attribution Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make territory-plan's FY26 leaderboard match es-bi's FY26 session-revenue total by re-bucketing sessions by `session.start_time`, sentinel-bucketing unmatched-district opps so they don't disappear, and adding a daily current-FY full re-sync to close the OpenSearch indexing gap.
+
+**Architecture:** Three independent additions stitched together at the leaderboard query layer. (1) New SQL function `session_fy()` and view `rep_session_actuals` aggregate the existing `sessions` table by session-derived FY. (2) Existing matview `district_opportunity_actuals` is rewritten to keep unmatched opps under a `'_NOMAP'` sentinel, and to expose `sub_revenue` as its own column for independent subscription rollups. (3) `getRepActuals()` reads BOTH views and sums `sessions(by date) + subscriptions(by opp tag)`. (4) A daily cron entry in the scheduler runs a full re-fetch of current/prior-FY opps, bypassing the incremental `since` filter. (5) A one-time TS script auto-resolves the existing `unmatched_opportunities` queue.
+
+**Tech Stack:** PostgreSQL (Supabase), Prisma raw SQL, TypeScript / Vitest, Python / pytest, OpenSearch client.
+
+**Spec:** `docs/superpowers/specs/2026-04-30-leaderboard-fy-attribution-fix-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+- `prisma/migrations/manual/2026-04-30_session_fy_function.sql` — `session_fy(timestamptz) → text` function
+- `prisma/migrations/manual/2026-04-30_rep_session_actuals_view.sql` — `rep_session_actuals` view
+- `prisma/migrations/manual/2026-04-30_district_opp_actuals_nomap.sql` — re-create `district_opportunity_actuals` with `_NOMAP` sentinel and `sub_revenue` exposed
+- `src/lib/__tests__/session-fy.test.ts` — boundary tests for `session_fy()`
+- `src/lib/__tests__/rep-session-actuals.test.ts` — view shape tests
+- `src/lib/__tests__/opportunity-actuals.test.ts` — `getRepActuals()` post-rewrite
+- `src/lib/unmatched-counts.ts` — new helper `getUnmatchedCountsByRep()`
+- `src/lib/__tests__/unmatched-counts.test.ts`
+- `scripts/backfill-unmatched-resolutions.ts` — one-time auto-resolve script
+- `scripts/__tests__/backfill-unmatched-resolutions.test.ts`
+- `scheduler/run_current_fy_backfill.py` — daily backfill entry-point function (re-uses run_sync helpers)
+- `scheduler/tests/test_run_current_fy_backfill.py`
+
+**Modified files:**
+- `scripts/district-opportunity-actuals-view.sql` — source-of-truth for the matview definition; updated to use `_NOMAP` sentinel and expose `sub_revenue`. The migration above re-runs this script.
+- `src/lib/opportunity-actuals.ts` — `getRepActuals()` rewrites query to read both views and sum
+- `src/features/leaderboard/lib/fetch-leaderboard.ts` — include unmatched count per rep in the payload
+- `src/features/leaderboard/lib/types.ts` — add `unmatchedOppCount`, `unmatchedRevenue` to `LeaderboardEntry`
+- `src/features/leaderboard/components/RevenueTable.tsx` — render unmatched-count badge
+- `scheduler/sync/queries.py` — new `fetch_opportunities_for_school_yrs(client, school_yrs)` helper
+- `scheduler/run_scheduler.py` — register daily 04:00 UTC schedule entry
+- `scheduler/tests/test_queries.py` — test for new helper
+
+---
+
+## Migration / Deployment Order
+
+Tasks below are ordered so each merge is independently revertable. Only Task 7 (the `getRepActuals()` rewrite) actually moves user-visible numbers; everything before it is invisible infrastructure, everything after it (badge, daily re-sync, queue backfill) layers on additional fixes.
+
+---
+
+## Task 1: `session_fy()` SQL function
+
+**Files:**
+- Create: `prisma/migrations/manual/2026-04-30_session_fy_function.sql`
+- Test: `src/lib/__tests__/session-fy.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/__tests__/session-fy.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import prisma from "@/lib/prisma";
+
+describe("session_fy()", () => {
+  async function fy(iso: string): Promise<string | null> {
+    const rows = await prisma.$queryRaw<{ fy: string | null }[]>`
+      SELECT session_fy(${iso}::timestamptz) AS fy
+    `;
+    return rows[0]?.fy ?? null;
+  }
+
+  it("July 1 begins the new fiscal year", async () => {
+    expect(await fy("2025-07-01T00:00:00Z")).toBe("2025-26");
+  });
+
+  it("June 30 is the prior fiscal year", async () => {
+    expect(await fy("2025-06-30T23:59:59Z")).toBe("2024-25");
+  });
+
+  it("Mid-FY26 timestamp", async () => {
+    expect(await fy("2026-04-30T12:00:00Z")).toBe("2025-26");
+  });
+
+  it("Returns NULL for NULL input", async () => {
+    const rows = await prisma.$queryRaw<{ fy: string | null }[]>`
+      SELECT session_fy(NULL::timestamptz) AS fy
+    `;
+    expect(rows[0].fy).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/lib/__tests__/session-fy.test.ts`
+Expected: FAIL with "function session_fy(timestamp with time zone) does not exist"
+
+- [ ] **Step 3: Write the migration**
+
+Create `prisma/migrations/manual/2026-04-30_session_fy_function.sql`:
+
+```sql
+-- Maps a session timestamp to a Fullmind fiscal-year string ("YYYY-YY").
+-- Fiscal years run July 1 → June 30. Returns NULL for NULL input.
+-- Example: '2025-07-01' → '2025-26'; '2025-06-30' → '2024-25'.
+
+CREATE OR REPLACE FUNCTION session_fy(ts timestamptz) RETURNS text AS $$
+  SELECT CASE
+    WHEN ts IS NULL THEN NULL
+    WHEN EXTRACT(MONTH FROM ts) >= 7
+      THEN EXTRACT(YEAR FROM ts)::int::text || '-' ||
+           LPAD(((EXTRACT(YEAR FROM ts)::int + 1) % 100)::text, 2, '0')
+    ELSE (EXTRACT(YEAR FROM ts)::int - 1)::text || '-' ||
+         LPAD((EXTRACT(YEAR FROM ts)::int % 100)::text, 2, '0')
+  END
+$$ LANGUAGE SQL IMMUTABLE;
+```
+
+- [ ] **Step 4: Apply the migration**
+
+Run:
+```bash
+psql "$SUPABASE_DB_URL" -f prisma/migrations/manual/2026-04-30_session_fy_function.sql
+```
+
+Or via the Supabase MCP `apply_migration` tool with the file contents.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm test -- src/lib/__tests__/session-fy.test.ts`
+Expected: 4 PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add prisma/migrations/manual/2026-04-30_session_fy_function.sql src/lib/__tests__/session-fy.test.ts
+git commit -m "feat(db): add session_fy() function for date-based FY bucketing"
+```
+
+---
+
+## Task 2: `rep_session_actuals` view
+
+**Files:**
+- Create: `prisma/migrations/manual/2026-04-30_rep_session_actuals_view.sql`
+- Test: `src/lib/__tests__/rep-session-actuals.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/__tests__/rep-session-actuals.test.ts`:
+
+```ts
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import prisma from "@/lib/prisma";
+
+const REP_EMAIL = "test+repsessionactuals@example.com";
+const OPP_ID = "test_rsa_opp_1";
+const SESSION_ID = "test_rsa_sess_1";
+
+describe("rep_session_actuals view", () => {
+  beforeAll(async () => {
+    await prisma.$executeRaw`DELETE FROM sessions WHERE id = ${SESSION_ID}`;
+    await prisma.$executeRaw`DELETE FROM opportunities WHERE id = ${OPP_ID}`;
+    await prisma.$executeRaw`
+      INSERT INTO opportunities (id, sales_rep_email, district_lea_id, school_yr, state)
+      VALUES (${OPP_ID}, ${REP_EMAIL}, '0612345', '2024-25', 'CA')
+    `;
+    await prisma.$executeRaw`
+      INSERT INTO sessions (id, opportunity_id, session_price, start_time, status)
+      VALUES (${SESSION_ID}, ${OPP_ID}, 1000, '2025-09-15T10:00:00Z', 'completed')
+    `;
+  });
+
+  afterAll(async () => {
+    await prisma.$executeRaw`DELETE FROM sessions WHERE id = ${SESSION_ID}`;
+    await prisma.$executeRaw`DELETE FROM opportunities WHERE id = ${OPP_ID}`;
+  });
+
+  it("buckets sessions by session_fy(start_time), not opp.school_yr", async () => {
+    const rows = await prisma.$queryRaw<
+      { school_yr: string; session_revenue: number }[]
+    >`
+      SELECT school_yr, session_revenue::float
+      FROM rep_session_actuals
+      WHERE sales_rep_email = ${REP_EMAIL}
+    `;
+    // Opp tagged 2024-25, but session.start_time = Sep 2025 → FY26 bucket
+    expect(rows).toHaveLength(1);
+    expect(rows[0].school_yr).toBe("2025-26");
+    expect(rows[0].session_revenue).toBe(1000);
+  });
+
+  it("excludes cancelled sessions", async () => {
+    await prisma.$executeRaw`
+      INSERT INTO sessions (id, opportunity_id, session_price, start_time, status)
+      VALUES ('test_rsa_cancelled', ${OPP_ID}, 500, '2025-10-01T10:00:00Z', 'cancelled')
+    `;
+    const rows = await prisma.$queryRaw<{ session_revenue: number }[]>`
+      SELECT SUM(session_revenue)::float AS session_revenue
+      FROM rep_session_actuals
+      WHERE sales_rep_email = ${REP_EMAIL}
+    `;
+    expect(rows[0].session_revenue).toBe(1000); // unchanged
+    await prisma.$executeRaw`DELETE FROM sessions WHERE id = 'test_rsa_cancelled'`;
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/lib/__tests__/rep-session-actuals.test.ts`
+Expected: FAIL with "relation rep_session_actuals does not exist"
+
+- [ ] **Step 3: Write the migration**
+
+Create `prisma/migrations/manual/2026-04-30_rep_session_actuals_view.sql`:
+
+```sql
+-- View: rep_session_actuals
+-- Aggregates the sessions table by (rep, district, session_fy(start_time)).
+-- Used by the leaderboard to bucket session revenue by when the session
+-- actually happened, not by the parent opportunity's school_yr tag.
+-- Subscriptions are NOT in this view — they continue to come from
+-- district_opportunity_actuals (Choice A in the design spec).
+
+DROP VIEW IF EXISTS rep_session_actuals;
+
+CREATE VIEW rep_session_actuals AS
+SELECT
+  o.sales_rep_email,
+  o.sales_rep_name,
+  COALESCE(o.district_lea_id, '_NOMAP') AS district_lea_id,
+  o.state,
+  session_fy(s.start_time) AS school_yr,
+  SUM(s.session_price) AS session_revenue,
+  COUNT(*)::int AS session_count
+FROM sessions s
+JOIN opportunities o ON o.id = s.opportunity_id
+WHERE s.status NOT IN ('cancelled', 'canceled')
+  AND s.session_price IS NOT NULL
+  AND session_fy(s.start_time) IS NOT NULL
+GROUP BY 1, 2, 3, 4, 5;
+
+COMMENT ON VIEW rep_session_actuals IS
+  'Sessions aggregated by session-date FY (not opp.school_yr). See spec 2026-04-30-leaderboard-fy-attribution-fix-design.md';
+```
+
+- [ ] **Step 4: Apply the migration**
+
+Run:
+```bash
+psql "$SUPABASE_DB_URL" -f prisma/migrations/manual/2026-04-30_rep_session_actuals_view.sql
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm test -- src/lib/__tests__/rep-session-actuals.test.ts`
+Expected: 2 PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add prisma/migrations/manual/2026-04-30_rep_session_actuals_view.sql src/lib/__tests__/rep-session-actuals.test.ts
+git commit -m "feat(db): add rep_session_actuals view bucketing sessions by start_time"
+```
+
+---
+
+## Task 3: `district_opportunity_actuals` — `_NOMAP` sentinel + expose `sub_revenue`
+
+**Files:**
+- Modify: `scripts/district-opportunity-actuals-view.sql:85, 131-135`
+- Create: `prisma/migrations/manual/2026-04-30_district_opp_actuals_nomap.sql` (calls the modified script)
+- Test: `src/lib/__tests__/district-opp-actuals-nomap.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/__tests__/district-opp-actuals-nomap.test.ts`:
+
+```ts
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import prisma from "@/lib/prisma";
+
+const REP_EMAIL = "test+nomap@example.com";
+const OPP_NULL_DISTRICT = "test_nomap_opp_null";
+const OPP_REAL_DISTRICT = "test_nomap_opp_real";
+
+describe("district_opportunity_actuals _NOMAP sentinel", () => {
+  beforeAll(async () => {
+    await prisma.$executeRaw`DELETE FROM opportunities WHERE id IN (${OPP_NULL_DISTRICT}, ${OPP_REAL_DISTRICT})`;
+    await prisma.$executeRaw`
+      INSERT INTO opportunities (id, sales_rep_email, district_lea_id, school_yr, state, stage,
+                                 net_booking_amount, total_revenue, completed_revenue, scheduled_revenue,
+                                 total_take, completed_take, scheduled_take, contract_type)
+      VALUES
+        (${OPP_NULL_DISTRICT}, ${REP_EMAIL}, NULL, '2025-26', 'CA', 'Closed Won',
+         5000, 5000, 5000, 0, 1000, 1000, 0, 'New Business'),
+        (${OPP_REAL_DISTRICT}, ${REP_EMAIL}, '0612345', '2025-26', 'CA', 'Closed Won',
+         3000, 3000, 3000, 0, 600, 600, 0, 'New Business')
+    `;
+    await prisma.$executeRaw`REFRESH MATERIALIZED VIEW district_opportunity_actuals`;
+  });
+
+  afterAll(async () => {
+    await prisma.$executeRaw`DELETE FROM opportunities WHERE id IN (${OPP_NULL_DISTRICT}, ${OPP_REAL_DISTRICT})`;
+    await prisma.$executeRaw`REFRESH MATERIALIZED VIEW district_opportunity_actuals`;
+  });
+
+  it("includes opps with NULL district_lea_id under _NOMAP sentinel", async () => {
+    const rows = await prisma.$queryRaw<{ district_lea_id: string; total_revenue: number }[]>`
+      SELECT district_lea_id, total_revenue::float
+      FROM district_opportunity_actuals
+      WHERE sales_rep_email = ${REP_EMAIL} AND school_yr = '2025-26'
+      ORDER BY district_lea_id
+    `;
+    expect(rows.map(r => r.district_lea_id).sort()).toEqual(["0612345", "_NOMAP"]);
+    expect(rows.find(r => r.district_lea_id === "_NOMAP")?.total_revenue).toBe(5000);
+  });
+
+  it("rep total includes _NOMAP rows", async () => {
+    const rows = await prisma.$queryRaw<{ total: number }[]>`
+      SELECT SUM(total_revenue)::float AS total
+      FROM district_opportunity_actuals
+      WHERE sales_rep_email = ${REP_EMAIL} AND school_yr = '2025-26'
+    `;
+    expect(rows[0].total).toBe(8000); // 5000 + 3000
+  });
+
+  it("exposes sub_revenue as its own column", async () => {
+    const rows = await prisma.$queryRaw<{ sub_revenue: number; total_revenue: number }[]>`
+      SELECT sub_revenue::float, total_revenue::float
+      FROM district_opportunity_actuals
+      WHERE sales_rep_email = ${REP_EMAIL}
+      LIMIT 1
+    `;
+    expect(rows[0]).toHaveProperty("sub_revenue");
+    expect(typeof rows[0].sub_revenue).toBe("number");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/lib/__tests__/district-opp-actuals-nomap.test.ts`
+Expected: FAIL — `_NOMAP` row missing (current view filter drops it) and/or `sub_revenue` column missing.
+
+- [ ] **Step 3: Modify the source-of-truth view script**
+
+In `scripts/district-opportunity-actuals-view.sql`:
+
+Change line 85 from:
+```sql
+  WHERE o.district_lea_id IS NOT NULL
+```
+to remove the WHERE clause entirely (drop that line):
+```sql
+  -- (no WHERE — opps with NULL district_lea_id are bucketed under _NOMAP below)
+```
+
+Change line ~116 (inside the final SELECT, the `co.district_lea_id` reference) from:
+```sql
+  co.district_lea_id,
+```
+to:
+```sql
+  COALESCE(co.district_lea_id, '_NOMAP') AS district_lea_id,
+```
+
+Change line ~133–134 to ALSO expose `sub_revenue` as its own column:
+```sql
+  -- Revenue: Fullmind session-derived totals + Elevate K12 subscription revenue
+  -- sub_revenue is signed so credits/cancellations offset positives
+  COALESCE(SUM(co.total_revenue), 0)     + COALESCE(SUM(co.sub_revenue), 0) AS total_revenue,
+  COALESCE(SUM(co.completed_revenue), 0) + COALESCE(SUM(co.sub_revenue), 0) AS completed_revenue,
+  COALESCE(SUM(co.scheduled_revenue), 0) AS scheduled_revenue,
+  COALESCE(SUM(co.sub_revenue), 0) AS sub_revenue,
+```
+
+Update the GROUP BY at line 161:
+```sql
+GROUP BY COALESCE(co.district_lea_id, '_NOMAP'), co.school_yr, co.sales_rep_email, co.category;
+```
+
+And update the `chain_floors` and `bucket_min_purchase` CTEs (lines 96, 105) to also use the COALESCE so they aggregate consistently:
+
+```sql
+chain_floors AS (
+  SELECT
+    COALESCE(district_lea_id, '_NOMAP') AS district_lea_id,
+    school_yr,
+    sales_rep_email,
+    category,
+    chain_key,
+    MAX(minimum_purchase_amount) FILTER (WHERE stage_prefix >= 6) AS chain_floor
+  FROM categorized_opps
+  GROUP BY COALESCE(district_lea_id, '_NOMAP'), school_yr, sales_rep_email, category, chain_key
+),
+bucket_min_purchase AS (
+  SELECT
+    COALESCE(district_lea_id, '_NOMAP') AS district_lea_id,
+    school_yr,
+    sales_rep_email,
+    category,
+    COALESCE(SUM(chain_floor), 0) AS min_purchase_bookings
+  FROM chain_floors
+  GROUP BY COALESCE(district_lea_id, '_NOMAP'), school_yr, sales_rep_email, category
+)
+```
+
+(Note: chain_floors already pulls from categorized_opps which would have the COALESCE if applied at that CTE level. Simpler: apply COALESCE in `categorized_opps` too. Equivalent end result; pick one and stay consistent.)
+
+- [ ] **Step 4: Write the deploy migration**
+
+Create `prisma/migrations/manual/2026-04-30_district_opp_actuals_nomap.sql`:
+
+```sql
+-- Re-create district_opportunity_actuals to:
+--  1. Bucket opps with NULL district_lea_id under '_NOMAP' sentinel (was dropped)
+--  2. Expose sub_revenue as its own column (was only inside total_revenue SUM)
+--
+-- Source of truth: scripts/district-opportunity-actuals-view.sql.
+-- This migration inlines the same SQL so a CI runner without the scripts/
+-- directory can apply it.
+--
+-- Spec: docs/superpowers/specs/2026-04-30-leaderboard-fy-attribution-fix-design.md
+
+-- (Paste full updated content of scripts/district-opportunity-actuals-view.sql here.)
+```
+
+Note: paste the full contents of the modified `scripts/district-opportunity-actuals-view.sql` into this file. The two artifacts intentionally duplicate; the script is the source of truth, the migration is the deploy artifact.
+
+- [ ] **Step 5: Apply the migration**
+
+```bash
+psql "$SUPABASE_DB_URL" -f prisma/migrations/manual/2026-04-30_district_opp_actuals_nomap.sql
+```
+
+- [ ] **Step 6: Run consumer audit grep**
+
+Search for assumptions about `district_lea_id` being numeric/7-digit:
+
+```bash
+rg "district_lea_id\s*[~!=]" --type ts --type sql src/ scripts/ scheduler/
+rg "district_lea_id.*LIKE" --type ts --type sql src/ scripts/ scheduler/
+```
+
+For each hit, confirm whether `_NOMAP` would break the assumption. Most district pages already filter by a specific lea_id value (e.g. `WHERE district_lea_id = $1`), which trivially excludes `_NOMAP`. Map features that JOIN to `districts` table will naturally exclude `_NOMAP` because no row in `districts` has that ID. Add an explicit `AND district_lea_id != '_NOMAP'` only where (a) consumer aggregates across districts and (b) `_NOMAP` rows shouldn't contribute. Document each case in the commit message.
+
+- [ ] **Step 7: Run test to verify it passes**
+
+Run: `npm test -- src/lib/__tests__/district-opp-actuals-nomap.test.ts`
+Expected: 3 PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scripts/district-opportunity-actuals-view.sql prisma/migrations/manual/2026-04-30_district_opp_actuals_nomap.sql src/lib/__tests__/district-opp-actuals-nomap.test.ts
+git commit -m "feat(db): keep unmatched-district opps in district_opportunity_actuals via _NOMAP sentinel and expose sub_revenue separately"
+```
+
+---
+
+## Task 4: `getRepActuals()` — read both views, sum sessions(by date) + subs(by tag)
+
+**Files:**
+- Modify: `src/lib/opportunity-actuals.ts:156-217` (`getRepActuals` function only)
+- Create: `src/lib/__tests__/opportunity-actuals.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/__tests__/opportunity-actuals.test.ts`:
+
+```ts
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import prisma from "@/lib/prisma";
+import { getRepActuals } from "@/lib/opportunity-actuals";
+
+const REP_EMAIL = "test+repactuals@example.com";
+const OPP_ID = "test_repactuals_opp_1";
+const SESSION_FY26 = "test_repactuals_sess_fy26";
+
+describe("getRepActuals (post-rewrite)", () => {
+  beforeAll(async () => {
+    await prisma.$executeRaw`DELETE FROM sessions WHERE id = ${SESSION_FY26}`;
+    await prisma.$executeRaw`DELETE FROM opportunities WHERE id = ${OPP_ID}`;
+
+    // Opp tagged FY25 ('2024-25') but with a session in FY26 (Sep 2025).
+    // This is exactly Monica's pattern: multi-year contract w/ FY26-dated work.
+    await prisma.$executeRaw`
+      INSERT INTO opportunities (id, sales_rep_email, district_lea_id, school_yr, state,
+                                 stage, net_booking_amount, total_revenue, completed_revenue,
+                                 scheduled_revenue, total_take, completed_take, scheduled_take,
+                                 contract_type)
+      VALUES (${OPP_ID}, ${REP_EMAIL}, '0612345', '2024-25', 'CA', 'Closed Won',
+              10000, 10000, 10000, 0, 2000, 2000, 0, 'Renewal')
+    `;
+    await prisma.$executeRaw`
+      INSERT INTO sessions (id, opportunity_id, session_price, start_time, status)
+      VALUES (${SESSION_FY26}, ${OPP_ID}, 7500, '2025-09-15T10:00:00Z', 'completed')
+    `;
+    await prisma.$executeRaw`REFRESH MATERIALIZED VIEW district_opportunity_actuals`;
+  });
+
+  afterAll(async () => {
+    await prisma.$executeRaw`DELETE FROM sessions WHERE id = ${SESSION_FY26}`;
+    await prisma.$executeRaw`DELETE FROM opportunities WHERE id = ${OPP_ID}`;
+    await prisma.$executeRaw`REFRESH MATERIALIZED VIEW district_opportunity_actuals`;
+  });
+
+  it("counts FY26-dated session revenue under FY26 even when opp is tagged FY25", async () => {
+    const actuals = await getRepActuals(REP_EMAIL, "2025-26");
+    expect(actuals.totalRevenue).toBe(7500);
+  });
+
+  it("does NOT double-count: FY25 query excludes the FY26-dated session", async () => {
+    const actuals = await getRepActuals(REP_EMAIL, "2024-25");
+    // The opp tagged 2024-25 has 10000 in opportunities.total_revenue, but the
+    // post-rewrite query reads SESSION revenue from rep_session_actuals (which
+    // attributes by date), so the FY26-dated session is NOT in FY25.
+    // Subscriptions still come from district_opportunity_actuals; this opp
+    // has none, so 0 is the expected total for FY25.
+    expect(actuals.totalRevenue).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/lib/__tests__/opportunity-actuals.test.ts`
+Expected: FAIL — current `getRepActuals()` returns `0` for FY26 (because opp.school_yr ≠ '2025-26') and `10000` for FY25 (the opp's tagged year).
+
+- [ ] **Step 3: Rewrite `getRepActuals()`**
+
+In `src/lib/opportunity-actuals.ts`, replace the body of `getRepActuals()` (lines 156–217):
+
+```ts
+export async function getRepActuals(
+  salesRepEmail: string,
+  schoolYr: string
+): Promise<RepActuals> {
+  // Sessions: bucketed by session.start_time → session_fy() → school_yr.
+  // Subscriptions, pipeline, take, bookings, min purchases: bucketed by
+  // opp.school_yr (existing semantics, unchanged).
+  const [sessionRows, subAndOtherRows] = await Promise.all([
+    safeQueryRaw(
+      prisma.$queryRaw<{ session_revenue: number }[]>`
+        SELECT COALESCE(SUM(session_revenue), 0) AS session_revenue
+        FROM rep_session_actuals
+        WHERE sales_rep_email = ${salesRepEmail}
+          AND school_yr = ${schoolYr}
+      `,
+      [{ session_revenue: 0 }]
+    ),
+    safeQueryRaw(
+      prisma.$queryRaw<
+        {
+          sub_revenue: number;
+          total_take: number;
+          completed_take: number;
+          scheduled_take: number;
+          weighted_pipeline: number;
+          open_pipeline: number;
+          bookings: number;
+          min_purchase_bookings: number;
+          invoiced: number;
+        }[]
+      >`
+        SELECT
+          COALESCE(SUM(sub_revenue), 0) AS sub_revenue,
+          COALESCE(SUM(total_take), 0) AS total_take,
+          COALESCE(SUM(completed_take), 0) AS completed_take,
+          COALESCE(SUM(scheduled_take), 0) AS scheduled_take,
+          COALESCE(SUM(weighted_pipeline), 0) AS weighted_pipeline,
+          COALESCE(SUM(open_pipeline), 0) AS open_pipeline,
+          COALESCE(SUM(bookings), 0) AS bookings,
+          COALESCE(SUM(min_purchase_bookings), 0) AS min_purchase_bookings,
+          COALESCE(SUM(invoiced), 0) AS invoiced
+        FROM district_opportunity_actuals
+        WHERE sales_rep_email = ${salesRepEmail}
+          AND school_yr = ${schoolYr}
+      `,
+      [{ sub_revenue: 0, total_take: 0, completed_take: 0, scheduled_take: 0,
+         weighted_pipeline: 0, open_pipeline: 0, bookings: 0,
+         min_purchase_bookings: 0, invoiced: 0 }]
+    ),
+  ]);
+
+  const sessionRevenue = Number(sessionRows[0]?.session_revenue ?? 0);
+  const r = subAndOtherRows[0] ?? {
+    sub_revenue: 0, total_take: 0, completed_take: 0, scheduled_take: 0,
+    weighted_pipeline: 0, open_pipeline: 0, bookings: 0,
+    min_purchase_bookings: 0, invoiced: 0,
+  };
+
+  return {
+    totalRevenue: sessionRevenue + Number(r.sub_revenue),
+    totalTake: Number(r.total_take),
+    completedTake: Number(r.completed_take),
+    scheduledTake: Number(r.scheduled_take),
+    weightedPipeline: Number(r.weighted_pipeline),
+    openPipeline: Number(r.open_pipeline),
+    bookings: Number(r.bookings),
+    minPurchaseBookings: Number(r.min_purchase_bookings),
+    invoiced: Number(r.invoiced),
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/lib/__tests__/opportunity-actuals.test.ts`
+Expected: 2 PASS
+
+- [ ] **Step 5: Run the existing leaderboard test suite to verify no regressions**
+
+Run: `npm test -- src/features/leaderboard/`
+Expected: All existing tests still PASS. The mocked `getRepActuals` in `fetch-leaderboard.test.ts` returns the same shape, so consumer tests are unaffected.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/opportunity-actuals.ts src/lib/__tests__/opportunity-actuals.test.ts
+git commit -m "feat(leaderboard): bucket session revenue by session date, not opp.school_yr"
+```
+
+---
+
+## Task 5: Helper to count unmatched opps per rep
+
+**Files:**
+- Create: `src/lib/unmatched-counts.ts`
+- Test: `src/lib/__tests__/unmatched-counts.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/__tests__/unmatched-counts.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  default: { $queryRaw: vi.fn() },
+}));
+
+import prisma from "@/lib/prisma";
+import { getUnmatchedCountsByRep } from "@/lib/unmatched-counts";
+
+const mockQueryRaw = vi.mocked(prisma.$queryRaw);
+
+describe("getUnmatchedCountsByRep", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("groups unresolved unmatched opps by sales_rep_email", async () => {
+    mockQueryRaw.mockResolvedValue([
+      { sales_rep_email: "alice@x.com", unmatched_count: 3, unmatched_revenue: 12500 },
+      { sales_rep_email: "bob@x.com", unmatched_count: 1, unmatched_revenue: 7000 },
+    ] as never);
+
+    const result = await getUnmatchedCountsByRep(["alice@x.com", "bob@x.com"]);
+
+    expect(result.get("alice@x.com")).toEqual({ count: 3, revenue: 12500 });
+    expect(result.get("bob@x.com")).toEqual({ count: 1, revenue: 7000 });
+  });
+
+  it("returns empty map when no rep emails passed", async () => {
+    const result = await getUnmatchedCountsByRep([]);
+    expect(result.size).toBe(0);
+    expect(mockQueryRaw).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- src/lib/__tests__/unmatched-counts.test.ts`
+Expected: FAIL — module `@/lib/unmatched-counts` doesn't exist.
+
+- [ ] **Step 3: Implement the helper**
+
+Create `src/lib/unmatched-counts.ts`:
+
+```ts
+import prisma from "@/lib/prisma";
+
+export interface UnmatchedSummary {
+  count: number;
+  revenue: number;
+}
+
+export async function getUnmatchedCountsByRep(
+  repEmails: string[]
+): Promise<Map<string, UnmatchedSummary>> {
+  if (repEmails.length === 0) return new Map();
+
+  const rows = await prisma.$queryRaw<
+    { sales_rep_email: string; unmatched_count: number; unmatched_revenue: number }[]
+  >`
+    SELECT
+      o.sales_rep_email,
+      COUNT(*)::int AS unmatched_count,
+      COALESCE(SUM(o.total_revenue), 0)::float AS unmatched_revenue
+    FROM unmatched_opportunities u
+    JOIN opportunities o ON o.id = u.id
+    WHERE u.resolved = false
+      AND o.sales_rep_email = ANY(${repEmails})
+    GROUP BY o.sales_rep_email
+  `;
+
+  const map = new Map<string, UnmatchedSummary>();
+  for (const row of rows) {
+    map.set(row.sales_rep_email, {
+      count: Number(row.unmatched_count),
+      revenue: Number(row.unmatched_revenue),
+    });
+  }
+  return map;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- src/lib/__tests__/unmatched-counts.test.ts`
+Expected: 2 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/unmatched-counts.ts src/lib/__tests__/unmatched-counts.test.ts
+git commit -m "feat: add getUnmatchedCountsByRep helper"
+```
+
+---
+
+## Task 6: Wire unmatched count into leaderboard payload
+
+**Files:**
+- Modify: `src/features/leaderboard/lib/types.ts` (add fields to `LeaderboardEntry`)
+- Modify: `src/features/leaderboard/lib/fetch-leaderboard.ts:34-231`
+- Modify: `src/features/leaderboard/lib/__tests__/fetch-leaderboard.test.ts` (update mocks + add assertion)
+
+- [ ] **Step 1: Add fields to the type**
+
+In `src/features/leaderboard/lib/types.ts`, add to the `LeaderboardEntry` interface:
+
+```ts
+  unmatchedOppCount: number;
+  unmatchedRevenue: number;
+```
+
+- [ ] **Step 2: Write the failing test**
+
+In `src/features/leaderboard/lib/__tests__/fetch-leaderboard.test.ts`, add a new test:
+
+```ts
+it("populates unmatchedOppCount and unmatchedRevenue from getUnmatchedCountsByRep", async () => {
+  vi.doMock("@/lib/unmatched-counts", () => ({
+    getUnmatchedCountsByRep: vi.fn().mockResolvedValue(new Map([
+      ["alice@x.com", { count: 3, revenue: 12500 }],
+    ])),
+  }));
+  // re-import after mocking
+  const { fetchLeaderboardData } = await import("../fetch-leaderboard");
+
+  mockUserProfile.mockResolvedValue([
+    { id: "u1", fullName: "Alice", avatarUrl: null, email: "alice@x.com", role: "rep" },
+  ] as never);
+  mockGetRepActuals.mockResolvedValue({
+    openPipeline: 0, totalTake: 0, totalRevenue: 0, minPurchaseBookings: 0,
+  } as never);
+
+  const payload = await fetchLeaderboardData();
+  const entry = payload.entries.find((e) => e.userId === "u1")!;
+  expect(entry.unmatchedOppCount).toBe(3);
+  expect(entry.unmatchedRevenue).toBe(12500);
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npm test -- src/features/leaderboard/lib/__tests__/fetch-leaderboard.test.ts`
+Expected: FAIL — `unmatchedOppCount` is undefined on the entry.
+
+- [ ] **Step 4: Wire into `fetchLeaderboardData()`**
+
+In `src/features/leaderboard/lib/fetch-leaderboard.ts`:
+
+Add at the top of the file with other imports:
+```ts
+import { getUnmatchedCountsByRep } from "@/lib/unmatched-counts";
+```
+
+Inside `fetchLeaderboardData()`, after `rosterEmails` is built (around line 97), parallelize the fetch:
+
+```ts
+const unmatchedByRep = await getUnmatchedCountsByRep(rosterEmails);
+```
+
+Inside the `entries` map (around line 162) where each entry is constructed, add:
+
+```ts
+const unmatched = unmatchedByRep.get(profile.email) ?? { count: 0, revenue: 0 };
+return {
+  // ...existing fields...
+  unmatchedOppCount: unmatched.count,
+  unmatchedRevenue: unmatched.revenue,
+};
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm test -- src/features/leaderboard/lib/__tests__/fetch-leaderboard.test.ts`
+Expected: All tests PASS (existing + new one).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/leaderboard/lib/types.ts src/features/leaderboard/lib/fetch-leaderboard.ts src/features/leaderboard/lib/__tests__/fetch-leaderboard.test.ts
+git commit -m "feat(leaderboard): include unmatched-opp counts in payload"
+```
+
+---
+
+## Task 7: Unmatched-count badge in `RevenueTable.tsx`
+
+**Files:**
+- Modify: `src/features/leaderboard/components/RevenueTable.tsx`
+- Test: extend an existing component test (or create one if none exists for RevenueTable)
+
+- [ ] **Step 1: Locate existing tests for RevenueTable**
+
+Run:
+```bash
+ls src/features/leaderboard/components/__tests__/ 2>/dev/null
+rg "RevenueTable" --type ts -l src/features/leaderboard/
+```
+
+If no test file exists for RevenueTable, create `src/features/leaderboard/components/__tests__/RevenueTable.test.tsx`. Otherwise extend the existing one.
+
+- [ ] **Step 2: Write the failing test**
+
+```tsx
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { RevenueTable } from "../RevenueTable";
+
+describe("RevenueTable unmatched badge", () => {
+  it("shows unmatched count + revenue for reps with pending unmatched opps", () => {
+    const entries = [
+      {
+        userId: "u1", fullName: "Monica", avatarUrl: null, rank: 1,
+        take: 0, pipeline: 0, pipelineCurrentFY: 0, pipelineNextFY: 0,
+        revenue: 1800000, revenueCurrentFY: 1800000, revenuePriorFY: 0,
+        priorYearRevenue: 0, minPurchasesCurrentFY: 0, minPurchasesPriorFY: 0,
+        revenueTargeted: 0, targetedCurrentFY: 0, targetedNextFY: 0,
+        unmatchedOppCount: 7, unmatchedRevenue: 254000,
+      },
+    ];
+    render(<RevenueTable entries={entries as never} /* other required props */ />);
+    expect(screen.getByText(/7 unmatched/i)).toBeInTheDocument();
+    expect(screen.getByText(/\$254/)).toBeInTheDocument();
+  });
+
+  it("hides badge when unmatchedOppCount is 0", () => {
+    const entries = [
+      {
+        userId: "u1", fullName: "Alice", avatarUrl: null, rank: 1,
+        take: 0, pipeline: 0, pipelineCurrentFY: 0, pipelineNextFY: 0,
+        revenue: 0, revenueCurrentFY: 0, revenuePriorFY: 0,
+        priorYearRevenue: 0, minPurchasesCurrentFY: 0, minPurchasesPriorFY: 0,
+        revenueTargeted: 0, targetedCurrentFY: 0, targetedNextFY: 0,
+        unmatchedOppCount: 0, unmatchedRevenue: 0,
+      },
+    ];
+    render(<RevenueTable entries={entries as never} />);
+    expect(screen.queryByText(/unmatched/i)).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npm test -- src/features/leaderboard/components/__tests__/RevenueTable.test.tsx`
+Expected: FAIL — badge not rendered.
+
+- [ ] **Step 4: Implement the badge**
+
+In `src/features/leaderboard/components/RevenueTable.tsx`, in the row-rendering JSX next to the rep's name, add:
+
+```tsx
+{entry.unmatchedOppCount > 0 && (
+  <a
+    href={`/admin/unmatched?rep=${encodeURIComponent(entry.userId)}`}
+    className="ml-2 inline-flex items-center gap-1 rounded bg-[#EFEDF5] px-2 py-0.5 text-xs text-[#5B4B7A] hover:bg-[#E0DCEB]"
+    title={`${entry.unmatchedOppCount} opportunities awaiting district resolution`}
+  >
+    {entry.unmatchedOppCount} unmatched · ${Math.round(entry.unmatchedRevenue / 1000)}k
+  </a>
+)}
+```
+
+(Color tokens are pulled from `Documentation/UI Framework/tokens.md` — plum-derived neutrals per CLAUDE.md.)
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm test -- src/features/leaderboard/components/__tests__/RevenueTable.test.tsx`
+Expected: 2 PASS
+
+- [ ] **Step 6: Manual UI sanity check**
+
+```bash
+npm run dev
+```
+Navigate to `/leaderboard`. For Monica (or any rep with unmatched opps), confirm a small badge appears next to her name and clicks through to `/admin/unmatched`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/features/leaderboard/components/RevenueTable.tsx src/features/leaderboard/components/__tests__/RevenueTable.test.tsx
+git commit -m "feat(leaderboard): show unmatched-opp badge per rep"
+```
+
+---
+
+## Task 8: New `fetch_opportunities_for_school_yrs()` helper
+
+**Files:**
+- Modify: `scheduler/sync/queries.py`
+- Modify: `scheduler/tests/test_queries.py`
+
+- [ ] **Step 1: Write the failing test**
+
+In `scheduler/tests/test_queries.py`, add:
+
+```python
+from unittest.mock import patch, MagicMock
+from sync.queries import fetch_opportunities_for_school_yrs
+
+
+@patch("sync.queries.scroll_all")
+def test_fetch_opportunities_for_school_yrs_filters_by_provided_list(mock_scroll):
+    mock_scroll.return_value = []
+    client = MagicMock()
+    fetch_opportunities_for_school_yrs(client, ["2025-26", "2024-25"])
+    args = mock_scroll.call_args
+    body = args[0][2]  # query body
+    filters = body["bool"]["filter"]
+    yr_filter = next(f for f in filters if "terms" in f)
+    assert yr_filter["terms"]["school_yr.keyword"] == ["2025-26", "2024-25"]
+
+
+@patch("sync.queries.scroll_all")
+def test_fetch_opportunities_for_school_yrs_does_not_apply_since(mock_scroll):
+    mock_scroll.return_value = []
+    client = MagicMock()
+    fetch_opportunities_for_school_yrs(client, ["2025-26"])
+    body = mock_scroll.call_args[0][2]
+    filters = body["bool"]["filter"]
+    # No range filter on updated_at — every opp in the school year is fetched
+    assert not any("range" in f and "updated_at" in (f.get("range") or {}) for f in filters)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd scheduler && pytest tests/test_queries.py::test_fetch_opportunities_for_school_yrs_filters_by_provided_list -v`
+Expected: FAIL — `ImportError: cannot import name 'fetch_opportunities_for_school_yrs'`
+
+- [ ] **Step 3: Implement the helper**
+
+In `scheduler/sync/queries.py`, after `fetch_opportunities()` (around line 39), add:
+
+```python
+def fetch_opportunities_for_school_yrs(client, school_yrs):
+    """Fetch opportunities for an explicit list of school years, ignoring incremental.
+
+    Used by the daily current-FY backfill: re-fetches every opp in the supplied
+    school years regardless of opp.updated_at, so sessions whose lastIndexedAt
+    didn't advance still get pulled into Supabase via Phase 2b's full session
+    refresh in run_sync's downstream pipeline.
+    """
+    logger.info(f"Full re-fetch of opportunities for school years: {school_yrs}")
+    query = {
+        "bool": {
+            "filter": [{"terms": {"school_yr.keyword": school_yrs}}],
+        }
+    }
+    hits = scroll_all(client, "clj-prod-opportunities", query, OPPORTUNITY_SOURCE_FIELDS)
+    logger.info(f"Fetched {len(hits)} opportunities for {school_yrs}")
+    return hits
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd scheduler && pytest tests/test_queries.py -v -k school_yrs`
+Expected: 2 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scheduler/sync/queries.py scheduler/tests/test_queries.py
+git commit -m "feat(scheduler): add fetch_opportunities_for_school_yrs helper"
+```
+
+---
+
+## Task 9: `run_current_fy_backfill()` function
+
+**Files:**
+- Modify: `scheduler/run_sync.py` (add new function alongside existing `run_sync()`)
+- Test: `scheduler/tests/test_run_current_fy_backfill.py` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `scheduler/tests/test_run_current_fy_backfill.py`:
+
+```python
+import os
+os.environ["OPENSEARCH_HOST"] = "https://test:9200"
+os.environ["OPENSEARCH_USERNAME"] = "user"
+os.environ["OPENSEARCH_PASSWORD"] = "pass"
+os.environ["SUPABASE_DB_URL"] = "postgresql://test:test@localhost:5432/test"
+
+from unittest.mock import patch, MagicMock
+from datetime import datetime, timezone
+from run_sync import run_current_fy_backfill
+
+
+@patch("run_sync.refresh_opportunity_actuals")
+@patch("run_sync.refresh_fullmind_financials")
+@patch("run_sync.refresh_map_features")
+@patch("run_sync.update_district_pipeline_aggregates")
+@patch("run_sync.upsert_unmatched")
+@patch("run_sync.upsert_sessions")
+@patch("run_sync.upsert_opportunities")
+@patch("run_sync.get_connection")
+@patch("run_sync.build_opportunity_record")
+@patch("run_sync.fetch_district_mappings")
+@patch("run_sync.fetch_sessions")
+@patch("run_sync.fetch_opportunities_for_school_yrs")
+@patch("run_sync.get_client")
+def test_run_current_fy_backfill_uses_school_yr_helper_not_incremental(
+    mock_get_client, mock_fetch_yrs, mock_fetch_sessions,
+    mock_fetch_districts, mock_build, mock_get_conn,
+    mock_upsert_opps, mock_upsert_sessions, mock_upsert_unmatched,
+    mock_update_agg, mock_refresh_map, mock_refresh_fin, mock_refresh_actuals,
+):
+    mock_fetch_yrs.return_value = [
+        {"_source": {"id": "opp1", "accounts": [{"id": "acc1"}]}}
+    ]
+    mock_fetch_sessions.return_value = []
+    mock_fetch_districts.return_value = {}
+    mock_build.return_value = {
+        "id": "opp1", "district_lea_id": "0100001", "net_booking_amount": 1,
+        "service_types": [],
+    }
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_cursor.fetchall.return_value = []
+    mock_conn.cursor.return_value.__enter__ = lambda s: mock_cursor
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_get_conn.return_value = mock_conn
+
+    # Today is 2026-04-30 → current FY = 2025-26, prior FY = 2024-25
+    with patch("run_sync.datetime") as mock_dt:
+        mock_dt.now.return_value = datetime(2026, 4, 30, tzinfo=timezone.utc)
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        result = run_current_fy_backfill()
+
+    mock_fetch_yrs.assert_called_once()
+    school_yrs_arg = mock_fetch_yrs.call_args[0][1]
+    assert sorted(school_yrs_arg) == ["2024-25", "2025-26"]
+    assert result["status"] == "success"
+    assert result["opps_synced"] == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd scheduler && pytest tests/test_run_current_fy_backfill.py -v`
+Expected: FAIL — `ImportError: cannot import name 'run_current_fy_backfill'`
+
+- [ ] **Step 3: Implement `run_current_fy_backfill()`**
+
+In `scheduler/run_sync.py`, add the import and a new function alongside `run_sync()`:
+
+Update the imports block:
+```python
+from sync.queries import (
+    fetch_opportunities,
+    fetch_opportunities_by_ids,
+    fetch_opportunities_for_school_yrs,  # NEW
+    fetch_changed_sessions,
+    fetch_sessions,
+    fetch_district_mappings,
+)
+```
+
+After `run_sync()`, add:
+
+```python
+def _derive_current_and_prior_school_yrs(now: datetime) -> list[str]:
+    """e.g. now=2026-04-30 -> ['2024-25', '2025-26']. now=2025-09-01 -> ['2024-25', '2025-26']."""
+    if now.month >= 7:
+        current_start = now.year
+    else:
+        current_start = now.year - 1
+    current = f"{current_start}-{str(current_start + 1)[-2:]}"
+    prior_start = current_start - 1
+    prior = f"{prior_start}-{str(prior_start + 1)[-2:]}"
+    return [prior, current]
+
+
+def run_current_fy_backfill():
+    """Daily backfill: re-fetch all opps in current FY + prior FY unconditionally.
+
+    Bypasses incremental's `since` filter to catch sessions that landed in
+    OpenSearch without advancing `lastIndexedAt`. Reuses the same downstream
+    pipeline as run_sync().
+    """
+    now = datetime.now(timezone.utc)
+    school_yrs = _derive_current_and_prior_school_yrs(now)
+    logger.info(f"=== Starting current-FY backfill at {now.isoformat()} for {school_yrs} ===")
+
+    conn = get_connection()
+    os_client = get_client()
+    opp_hits = fetch_opportunities_for_school_yrs(os_client, school_yrs)
+    if not opp_hits:
+        logger.info("No opportunities returned, skipping backfill")
+        conn.close()
+        return {"status": "success", "opps_synced": 0, "sessions_stored": 0,
+                "unmatched_count": None, "error": None}
+
+    opp_ids = [h["_source"]["id"] for h in opp_hits]
+    session_hits = fetch_sessions(os_client, opp_ids)
+
+    sessions_by_opp = defaultdict(list)
+    for sh in session_hits:
+        src = sh["_source"]
+        src["_id"] = sh["_id"]
+        sessions_by_opp[src["opportunityId"]].append(src)
+
+    account_ids = set()
+    for h in opp_hits:
+        for acc in (h["_source"].get("accounts") or []):
+            if acc.get("id"):
+                account_ids.add(acc["id"])
+    district_mapping = fetch_district_mappings(os_client, list(account_ids))
+
+    try:
+        manual_resolutions = _load_manual_resolutions(conn)
+        matched_records = []
+        unmatched_records = []
+        for h in opp_hits:
+            opp = h["_source"]
+            opp_sessions = sessions_by_opp.get(opp["id"], [])
+            record, unmatched = _build_record_and_classify(
+                opp, opp_sessions, district_mapping, now=now
+            )
+            if record["district_lea_id"] is None and opp["id"] in manual_resolutions:
+                record["district_lea_id"] = manual_resolutions[opp["id"]]
+                unmatched = None
+            matched_records.append(record)
+            if unmatched is not None:
+                unmatched_records.append(unmatched)
+
+        upsert_opportunities(conn, matched_records)
+        if unmatched_records:
+            upsert_unmatched(conn, unmatched_records)
+
+        session_records_by_opp = {}
+        for opp_id, opp_sessions in sessions_by_opp.items():
+            session_records_by_opp[opp_id] = [
+                {
+                    "id": s["_id"],
+                    "opportunity_id": s["opportunityId"],
+                    "service_type": s.get("serviceType"),
+                    "session_price": _to_decimal(s.get("sessionPrice")),
+                    "educator_price": _to_decimal(s.get("educatorPrice")),
+                    "educator_approved_price": _to_decimal(s.get("educatorApprovedPrice")),
+                    "start_time": s.get("startTime"),
+                    "type": s.get("type"),
+                    "status": s.get("status"),
+                    "service_name": s.get("serviceName"),
+                    "synced_at": now,
+                }
+                for s in opp_sessions
+            ]
+        total_sessions = sum(len(v) for v in session_records_by_opp.values())
+        upsert_sessions(conn, session_records_by_opp)
+
+        newly_matched_ids = [
+            r["id"] for r in matched_records if r.get("district_lea_id") is not None
+        ]
+        remove_matched_from_unmatched(conn, newly_matched_ids)
+
+        update_district_pipeline_aggregates(conn)
+        refresh_map_features(conn)
+        refresh_fullmind_financials(conn)
+        refresh_opportunity_actuals(conn)
+
+        logger.info(
+            f"=== Backfill complete: {len(matched_records)} opps, "
+            f"{total_sessions} sessions, "
+            f"{len(unmatched_records)} unmatched ==="
+        )
+        return {
+            "status": "success",
+            "opps_synced": len(matched_records),
+            "sessions_stored": total_sessions,
+            "unmatched_count": len(unmatched_records),
+            "error": None,
+        }
+    finally:
+        conn.close()
+```
+
+Note: this function intentionally does NOT call `set_last_synced_at()` because it isn't an incremental cycle — leaving the watermark untouched lets the next hourly incremental still pick up everything since the previous hourly run.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd scheduler && pytest tests/test_run_current_fy_backfill.py -v`
+Expected: 1 PASS
+
+- [ ] **Step 5: Run the existing run_sync test suite to verify no regressions**
+
+Run: `cd scheduler && pytest tests/test_run_sync.py -v`
+Expected: All existing tests still PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scheduler/run_sync.py scheduler/tests/test_run_current_fy_backfill.py
+git commit -m "feat(scheduler): add run_current_fy_backfill for daily full re-sync of current FY"
+```
+
+---
+
+## Task 10: Wire daily 04:00 UTC schedule entry
+
+**Files:**
+- Modify: `scheduler/run_scheduler.py:148`
+- Test: `scheduler/tests/test_run_scheduler.py` (or extend)
+
+- [ ] **Step 1: Write the failing test**
+
+In `scheduler/tests/test_run_scheduler.py`, add:
+
+```python
+from unittest.mock import patch, MagicMock
+
+
+@patch("run_scheduler.schedule")
+def test_daily_backfill_is_registered_at_04_00(mock_schedule):
+    # Importing the module should set up both schedules.
+    import importlib
+    import run_scheduler
+    importlib.reload(run_scheduler)
+
+    # The hourly + daily entries should both be registered.
+    every_calls = mock_schedule.every.call_args_list
+    # Hourly: schedule.every(1).hour.do(...)
+    # Daily:  schedule.every().day.at("04:00").do(...)
+    daily_chain_seen = any(
+        # `.day.at("04:00")` on the chain — verify by tracing through the mock
+        True for c in mock_schedule.every.return_value.day.at.call_args_list
+        if c.args == ("04:00",)
+    )
+    assert daily_chain_seen, "expected schedule.every().day.at('04:00').do(...) to be wired"
+```
+
+(Note: this test verifies the schedule registration only. The runtime behavior of the wrapper function is covered in Task 9.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd scheduler && pytest tests/test_run_scheduler.py::test_daily_backfill_is_registered_at_04_00 -v`
+Expected: FAIL — `assert daily_chain_seen` fails because no `.day.at("04:00")` registration exists.
+
+- [ ] **Step 3: Wire the schedule**
+
+In `scheduler/run_scheduler.py`:
+
+Update the import:
+```python
+from run_sync import run_sync, run_current_fy_backfill
+```
+
+Add a wrapper next to `safe_sync()`:
+
+```python
+def safe_current_fy_backfill():
+    """Run current-FY backfill with retry + state logging."""
+    max_retries = 3
+    last_error = None
+    for attempt in range(1, max_retries + 1):
+        try:
+            result = run_current_fy_backfill()
+            result["attempts"] = attempt
+            return result
+        except Exception as e:
+            last_error = str(e)
+            logger.error(f"Backfill attempt {attempt}/{max_retries} failed: {e}")
+            logger.error(traceback.format_exc())
+            if attempt < max_retries:
+                wait = 2 ** attempt * 10
+                logger.info(f"Retrying in {wait}s...")
+                time.sleep(wait)
+    logger.error("All backfill attempts failed for this cycle")
+    return {
+        "status": "failed", "opps_synced": 0, "unmatched_count": None,
+        "error": last_error, "attempts": max_retries,
+    }
+
+
+def scheduled_current_fy_backfill():
+    result = safe_current_fy_backfill()
+    write_sync_state(LOG_DIR, result)
+    append_sync_history(LOG_DIR, result)
+```
+
+In the `if __name__ == "__main__"` block, after the existing hourly registration (line 148), add:
+
+```python
+# Daily current-FY full re-sync at 04:00 UTC — catches sessions that didn't
+# advance lastIndexedAt and so missed the hourly incremental.
+schedule.every().day.at("04:00").do(scheduled_current_fy_backfill)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd scheduler && pytest tests/test_run_scheduler.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scheduler/run_scheduler.py scheduler/tests/test_run_scheduler.py
+git commit -m "feat(scheduler): register daily 04:00 UTC current-FY backfill"
+```
+
+---
+
+## Task 11: One-time backfill script for unmatched-opp queue
+
+**Files:**
+- Create: `scripts/backfill-unmatched-resolutions.ts`
+- Test: `scripts/__tests__/backfill-unmatched-resolutions.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `scripts/__tests__/backfill-unmatched-resolutions.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  default: { $queryRaw: vi.fn(), $executeRaw: vi.fn() },
+}));
+
+const mockNcesLookup = vi.fn();
+vi.mock("../backfill-unmatched-resolutions-helpers", () => ({
+  lookupNcesByLmsId: mockNcesLookup,
+  namesMatch: (a: string, b: string) => a.toLowerCase() === b.toLowerCase(),
+}));
+
+import prisma from "@/lib/prisma";
+import { backfillUnmatched } from "../backfill-unmatched-resolutions";
+
+describe("backfill-unmatched-resolutions", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("auto-resolves when names match exactly", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([
+      { id: "opp1", account_lms_id: "lms123", account_name: "Yuba City USD" },
+    ] as never);
+    mockNcesLookup.mockResolvedValueOnce({ ncesId: "0612345", name: "Yuba City USD" });
+
+    const summary = await backfillUnmatched();
+
+    expect(summary.autoResolved).toBe(1);
+    expect(summary.deferred).toBe(0);
+    expect(prisma.$executeRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it("defers when names do NOT match", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([
+      { id: "opp1", account_lms_id: "lms123", account_name: "Foo District" },
+    ] as never);
+    mockNcesLookup.mockResolvedValueOnce({ ncesId: "0612345", name: "Bar District" });
+
+    const summary = await backfillUnmatched();
+
+    expect(summary.autoResolved).toBe(0);
+    expect(summary.deferred).toBe(1);
+    expect(prisma.$executeRaw).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- scripts/__tests__/backfill-unmatched-resolutions.test.ts`
+Expected: FAIL — module doesn't exist.
+
+- [ ] **Step 3: Implement the script**
+
+Create `scripts/backfill-unmatched-resolutions.ts`:
+
+```ts
+/**
+ * One-time backfill: auto-resolve unmatched_opportunities entries where
+ * the resolved district name matches the opp's account name.
+ *
+ * Run:
+ *   npx tsx scripts/backfill-unmatched-resolutions.ts
+ *
+ * Strict guardrail: only auto-resolves when (a) the LMS account_id has
+ * exactly one matching district in OpenSearch, AND (b) the district name
+ * matches the opp's account_name per the existing `names_match()` rule.
+ * Anything ambiguous stays in the queue for manual admin review.
+ */
+import prisma from "@/lib/prisma";
+import { lookupNcesByLmsId, namesMatch } from "./backfill-unmatched-resolutions-helpers";
+
+export interface BackfillSummary {
+  candidates: number;
+  autoResolved: number;
+  deferred: number;
+  errors: number;
+}
+
+export async function backfillUnmatched(): Promise<BackfillSummary> {
+  const candidates = await prisma.$queryRaw<
+    { id: string; account_lms_id: string | null; account_name: string | null }[]
+  >`
+    SELECT id, account_lms_id, account_name
+    FROM unmatched_opportunities
+    WHERE resolved = false
+      AND account_lms_id IS NOT NULL
+      AND account_name IS NOT NULL
+  `;
+
+  const summary: BackfillSummary = {
+    candidates: candidates.length, autoResolved: 0, deferred: 0, errors: 0,
+  };
+
+  for (const row of candidates) {
+    try {
+      const district = await lookupNcesByLmsId(row.account_lms_id!);
+      if (!district || !district.ncesId || !namesMatch(row.account_name!, district.name)) {
+        summary.deferred++;
+        continue;
+      }
+      await prisma.$executeRaw`
+        UPDATE unmatched_opportunities
+        SET resolved = true,
+            resolved_district_leaid = ${district.ncesId},
+            resolved_at = now(),
+            resolved_by = 'backfill-2026-04-30'
+        WHERE id = ${row.id}
+      `;
+      summary.autoResolved++;
+    } catch (e) {
+      console.error(`Error processing ${row.id}:`, e);
+      summary.errors++;
+    }
+  }
+
+  console.log(`Backfill summary:`, summary);
+  return summary;
+}
+
+if (require.main === module) {
+  backfillUnmatched().then(() => process.exit(0)).catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}
+```
+
+Create `scripts/backfill-unmatched-resolutions-helpers.ts`:
+
+```ts
+/**
+ * Helpers separated for testability — the OpenSearch client + names_match
+ * rule live here so the main script can be unit-tested with mocks.
+ */
+import { Client } from "@opensearch-project/opensearch";
+
+const client = new Client({
+  node: process.env.ELASTICSEARCH_HOST!,
+  auth: {
+    username: process.env.ELASTICSEARCH_USERNAME!,
+    password: process.env.ELASTICSEARCH_PASSWORD!,
+  },
+});
+
+export async function lookupNcesByLmsId(
+  lmsId: string
+): Promise<{ ncesId: string; name: string } | null> {
+  const res = await client.search({
+    index: "clj-prod-districts",
+    body: {
+      size: 1,
+      query: { term: { id: lmsId } },
+      _source: ["id", "ncesId", "name"],
+    },
+  });
+  const hits = res.body?.hits?.hits ?? [];
+  if (hits.length === 0) return null;
+  const src = hits[0]._source;
+  if (!src.ncesId || src.ncesId.length !== 7 || !/^\d{7}$/.test(src.ncesId)) {
+    return null; // matches the rejection rule in scheduler/sync/queries.py:121
+  }
+  return { ncesId: src.ncesId, name: src.name };
+}
+
+/**
+ * Mirrors scheduler/sync/district_resolver.py::names_match.
+ * Lowercase + strip punctuation + collapse whitespace, then exact-match.
+ */
+export function namesMatch(a: string, b: string): boolean {
+  const norm = (s: string) => s.toLowerCase().replace(/[^\w\s]/g, "").replace(/\s+/g, " ").trim();
+  return norm(a) === norm(b);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- scripts/__tests__/backfill-unmatched-resolutions.test.ts`
+Expected: 2 PASS
+
+- [ ] **Step 5: Dry-run on production data (read-only first)**
+
+Modify a copy of the script (or add a `--dry-run` flag) so it logs candidates without writing. Run once, eyeball the output, confirm the auto-resolution candidates look right.
+
+```bash
+DRY_RUN=true npx tsx scripts/backfill-unmatched-resolutions.ts
+```
+
+(Optional but recommended before the real run. If you skip this, at minimum stop the run after the first 5 auto-resolutions and verify them manually.)
+
+- [ ] **Step 6: Run for real**
+
+```bash
+npx tsx scripts/backfill-unmatched-resolutions.ts
+```
+
+Expected output: `Backfill summary: { candidates: N, autoResolved: M, deferred: N-M, errors: 0 }`. The next hourly sync will then propagate `resolved_district_leaid` into `opportunities.district_lea_id`.
+
+- [ ] **Step 7: Commit (the script, not the run)**
+
+```bash
+git add scripts/backfill-unmatched-resolutions.ts scripts/backfill-unmatched-resolutions-helpers.ts scripts/__tests__/backfill-unmatched-resolutions.test.ts
+git commit -m "feat: one-time backfill script to auto-resolve unmatched_opportunities by exact name match"
+```
+
+---
+
+## Task 12: End-to-end verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Re-run Monica's diagnostic against post-fix data**
+
+```bash
+cd "/Users/sierraarcega/Fullmind LMS/es-bi"
+python3 debug_monica_fy26_attribution.py
+```
+
+Capture the OpenSearch step-4 number. As of 2026-04-30 it was $2,821,691.96.
+
+- [ ] **Step 2: Compare to leaderboard view total**
+
+```sql
+-- Run via Supabase MCP or psql
+SELECT
+  -- Sessions by date (new path)
+  (SELECT COALESCE(SUM(session_revenue), 0)
+     FROM rep_session_actuals
+     WHERE sales_rep_email = 'monica.sherwood@fullmindlearning.com'
+       AND school_yr = '2025-26') AS session_revenue_by_date,
+  -- Subscriptions by tag
+  (SELECT COALESCE(SUM(sub_revenue), 0)
+     FROM district_opportunity_actuals
+     WHERE sales_rep_email = 'monica.sherwood@fullmindlearning.com'
+       AND school_yr = '2025-26') AS subscription_revenue_by_tag,
+  -- Combined (matches what getRepActuals returns)
+  (SELECT COALESCE(SUM(session_revenue), 0)
+     FROM rep_session_actuals
+     WHERE sales_rep_email = 'monica.sherwood@fullmindlearning.com'
+       AND school_yr = '2025-26')
+  +
+  (SELECT COALESCE(SUM(sub_revenue), 0)
+     FROM district_opportunity_actuals
+     WHERE sales_rep_email = 'monica.sherwood@fullmindlearning.com'
+       AND school_yr = '2025-26') AS leaderboard_total;
+```
+
+- [ ] **Step 3: Verify `leaderboard_total` is within ~$30K of `step 4 + Monica's FY26 subs`**
+
+The remaining gap, if any, is sync staleness (≤ 24 hours after the daily 04:00 UTC backfill runs once).
+
+- [ ] **Step 4: Spot-check the unmatched badge in the UI**
+
+```bash
+npm run dev
+```
+
+Navigate to `/leaderboard`. Confirm:
+- Monica's FY26 number is now in the $2.8M range (not $1.8M)
+- The unmatched badge shows expected count + revenue (after the Task 11 backfill, this should be much smaller — only opps whose name didn't match cleanly)
+- Click-through to `/admin/unmatched` works and the queue UI loads
+
+- [ ] **Step 5: Document expected ongoing behavior**
+
+Append a note to the spec confirming the post-fix state and expected ongoing behavior (e.g., "leaderboard refreshes every hour via incremental sync; daily 04:00 UTC backfill catches edge cases; admin should drain unmatched queue weekly to keep `_NOMAP` revenue minimal"). This closes the loop on the spec.
+
+---
+
+## Self-Review Notes
+
+Reviewed against spec sections:
+
+- **Spec §1 (re-bucket sessions by date):** Tasks 1, 2, 4 — `session_fy()`, `rep_session_actuals` view, `getRepActuals()` rewrite. Subscriptions stay tag-based per Choice A — confirmed in Task 4's query (sub_revenue still pulled from district_opportunity_actuals filtered by school_yr).
+- **Spec §2 (sentinel + queue backfill):** Task 3 (sentinel), Tasks 5–7 (badge UI), Task 11 (one-time backfill). All sub-points covered.
+- **Spec §3 (daily current-FY refresh):** Tasks 8, 9, 10 — helper, function, schedule entry.
+- **Spec migration order (1–6):** Tasks map cleanly: 1→§1, 2→§2, 3→§3, 4→§4, 10→§5, 11→§6.
+- **Spec risks called out:** `_NOMAP` collision (Task 3, Step 6 audit), perf (deferred — view starts non-materialized; spec acknowledges), auto-resolve false positives (Task 11 reuses names_match guardrail), traffic spike (mentioned, low for Fullmind volume).
+
+Type consistency: `RepActuals` interface unchanged through the rewrite (all the same fields), only the SQL backing the populated values changes. `LeaderboardEntry` extended additively in Task 6 with `unmatchedOppCount` + `unmatchedRevenue`. `BackfillSummary` is local to the script.
+
+Placeholders: none. Each step has either concrete code, a concrete command, or a concrete check.
+
+Scope: 12 tasks for three independent fixes — borderline large but the tasks are linear, independently revertable, and each produces shippable improvement. No task is over ~30 minutes of work.

--- a/Docs/superpowers/specs/2026-04-30-leaderboard-fy-attribution-fix-design.md
+++ b/Docs/superpowers/specs/2026-04-30-leaderboard-fy-attribution-fix-design.md
@@ -1,0 +1,216 @@
+# Leaderboard FY attribution fix — design
+
+**Status:** approved 2026-04-30
+**Author:** Sierra (with Claude)
+**Context:** Monica showed $1.8M FY26 revenue in territory-plan vs $3.3M+ in es-bi (the OpenSearch-backed source-of-truth report). Investigation in [systematic debugging session, see git log] confirmed three independent contributors to the $747K gap between es-bi's leaderboard total and territory-plan's leaderboard total for the same rep + fiscal year.
+
+## Problem
+
+The territory-plan FY26 leaderboard understates rep revenue by:
+
+1. **Definition mismatch (~$463K of gap).** Territory-plan groups session revenue by `opp.school_yr`. es-bi groups by `session.start_time`. Sessions on multi-year or renewal opps tagged `school_yr = "2024-25"` that occur in FY26 (Jul 2025 – Jun 2026) get filed under FY25 in territory-plan and are invisible on the FY26 leaderboard.
+2. **Silent drop of unmatched opps (~$255K of gap).** The `district_opportunity_actuals` materialized view filters out opps with `district_lea_id IS NULL`. Most of these are not unmappable; they're queued in `unmatched_opportunities` waiting for admin resolution. While they wait, their revenue disappears from leaderboards.
+3. **Sync staleness (~$30K of gap, variable).** The hourly sync depends on OpenSearch sessions advancing their `lastIndexedAt`. Some sessions land in OpenSearch without that field updating, so their parent opp never gets re-fetched and Supabase's per-opp totals lag.
+
+These compound: the rep sees $1.8M today, the data is correct in OpenSearch as $3.3M+, and there is no surface that explains the difference.
+
+## Goals
+
+- Leaderboard "FY26 Revenue" matches `SUM(session_price)` for sessions that started in FY26, plus subscription revenue tagged FY26 — within the bounds of what's syncable.
+- No revenue is silently dropped. Unmatched opps still contribute to a rep's total and are surfaced for resolution.
+- Current-FY data is at most 24 hours stale regardless of OpenSearch indexing reliability.
+- Subscription handling stays simple (Choice A: keep on `opp.school_yr`).
+
+## Non-goals
+
+- Attribution model for subscriptions across fiscal years (proration). Subscriptions remain bucketed by `opp.school_yr` for now.
+- Real-time sync (sub-15-min lag).
+- Rebuilding the unmatched-opps admin UI; we use the existing flow.
+- Backporting historical leaderboard reports. The fix is forward-looking.
+
+## Design
+
+### 1. Re-bucket session revenue by `session.start_time`
+
+**New view: `rep_session_actuals`** (regular view, not materialized initially)
+
+Aggregates the existing `sessions` table by session-derived fiscal year:
+
+```sql
+CREATE VIEW rep_session_actuals AS
+SELECT
+  o.sales_rep_email,
+  o.sales_rep_name,
+  COALESCE(o.district_lea_id, '_NOMAP') AS district_lea_id,
+  o.state,
+  session_fy(s.start_time) AS school_yr,
+  SUM(s.session_price) AS session_revenue,
+  COUNT(*) AS session_count
+FROM sessions s
+JOIN opportunities o ON o.id = s.opportunity_id
+WHERE s.status NOT IN ('cancelled', 'canceled')
+  AND s.session_price IS NOT NULL
+  AND session_fy(s.start_time) IS NOT NULL
+GROUP BY 1, 2, 3, 4, 5;
+```
+
+Where `session_fy(ts timestamptz)` is a new immutable SQL function:
+
+```sql
+-- '2025-07-01' .. '2026-06-30' -> '2025-26'
+-- Returns NULL for timestamps outside the supported range
+CREATE FUNCTION session_fy(ts timestamptz) RETURNS text AS $$
+  SELECT CASE
+    WHEN ts IS NULL THEN NULL
+    WHEN EXTRACT(MONTH FROM ts) >= 7
+      THEN EXTRACT(YEAR FROM ts)::int::text || '-' ||
+           LPAD(((EXTRACT(YEAR FROM ts)::int + 1) % 100)::text, 2, '0')
+    ELSE (EXTRACT(YEAR FROM ts)::int - 1)::text || '-' ||
+         LPAD((EXTRACT(YEAR FROM ts)::int % 100)::text, 2, '0')
+  END
+$$ LANGUAGE SQL IMMUTABLE;
+```
+
+**Existing view `district_opportunity_actuals` keeps its row shape and grouping** (still keyed on `district_lea_id, school_yr, sales_rep_email, category`), used unchanged by district pages, map features, and subscription rollups. One small change: ensure `sub_revenue` is exposed as its own column on the view, alongside the existing combined `total_revenue` column. The leaderboard's new query needs to pull subscriptions independently of session revenue. If `sub_revenue` is already a column today (per `scripts/district-opportunity-actuals-view.sql`), no change here; if it's only used as an intermediate inside the `total_revenue` SUM, expose it.
+
+**Leaderboard query change** in `src/lib/opportunity-actuals.ts → getRepActuals(email, schoolYr)`:
+
+```ts
+// before: SUM(total_revenue) FROM district_opportunity_actuals
+//         WHERE sales_rep_email = $1 AND school_yr = $2
+
+// after:
+// SELECT
+//   COALESCE(s.session_revenue, 0) + COALESCE(d.subscription_revenue, 0) AS total_revenue
+// FROM (
+//   SELECT SUM(session_revenue) AS session_revenue
+//   FROM rep_session_actuals
+//   WHERE sales_rep_email = $1 AND school_yr = $2
+// ) s
+// CROSS JOIN (
+//   SELECT SUM(sub_revenue) AS subscription_revenue
+//   FROM district_opportunity_actuals
+//   WHERE sales_rep_email = $1 AND school_yr = $2
+// ) d
+```
+
+The two streams continue to share `school_yr` semantics in name (string `"2025-26"`), but they're sourced differently — sessions by `session_fy(start_time)`, subscriptions by `opp.school_yr`. The naming collision is intentional so the existing leaderboard UI doesn't need to know.
+
+### 2. Sentinel bucket for unmatched opps + queue backfill
+
+**View change: `district_opportunity_actuals`**
+
+Replace `WHERE o.district_lea_id IS NOT NULL` (line ~85 in `scripts/district-opportunity-actuals-view.sql`) with `COALESCE(o.district_lea_id, '_NOMAP')` in the GROUP BY. Same change in the new `rep_session_actuals`.
+
+`'_NOMAP'` is 6 characters and fits the existing `VARCHAR(7)` constraint on `district_lea_id`. No schema migration required, but the migration that creates the new view should also `ALTER TABLE` the unmatched_opportunities resolution flow to never write `'_NOMAP'` as a real resolution (it's an aggregation sentinel only, not a stored opp value).
+
+**Consumer guards.** Audit downstream consumers of these views for any `WHERE district_lea_id LIKE '%[0-9]%'` style assumptions. District-detail pages already filter by a specific `district_lea_id` value, so they naturally exclude `'_NOMAP'`. Map features should explicitly add `WHERE district_lea_id != '_NOMAP'` if they don't already filter to a known LEAID.
+
+**Frontend: unmatched badge on leaderboard**
+
+In `src/features/leaderboard/components/RevenueTable.tsx`, add a small inline badge per rep:
+
+> "3 unmatched · $X" → links to `/admin/unmatched?rep=<email>`
+
+Sourced from a new query against `unmatched_opportunities` grouped by `sales_rep_email`. Already-existing admin route handles the resolution UX (see commit `64de013e`).
+
+**One-time backfill: `scripts/backfill-unmatched-resolutions.ts`**
+
+For each row in `unmatched_opportunities` with `resolved = false`:
+1. Look up the opp's `account_lms_id` in OpenSearch's `clj-prod-districts` index.
+2. If exactly one district matches by `(account_lms_id → ncesId)` AND the resolved district name matches the opp's `account_name` per the existing `names_match()` rule, auto-set `resolved = true, resolved_district_leaid = ncesId`.
+3. Otherwise leave for manual review.
+4. Log a summary: N auto-resolved, M deferred.
+
+Conservative on purpose. Anything ambiguous stays in the admin queue.
+
+### 3. Daily current-FY full re-sync
+
+**`scheduler/run_sync.py`:** new function
+
+```python
+def run_current_fy_backfill():
+    """Re-fetch all current-FY and prior-FY opps unconditionally.
+
+    Bypasses incremental's `since` filter to catch sessions that
+    landed in OpenSearch without advancing `lastIndexedAt`.
+    """
+    now = datetime.now(timezone.utc)
+    current_fy = derive_current_school_yr(now)   # e.g. "2025-26"
+    prior_fy = derive_prior_school_yr(now)       # e.g. "2024-25"
+
+    os_client = get_client()
+    opp_hits = fetch_opportunities_for_school_yrs(
+        os_client, [current_fy, prior_fy]
+    )
+    # Reuse the existing pipeline from run_sync(): fetch sessions,
+    # district mappings, build records, upsert, refresh views.
+    ...
+```
+
+`fetch_opportunities_for_school_yrs(client, school_yrs)` is a new helper in `scheduler/sync/queries.py` — same as `fetch_opportunities` but takes an explicit school_yr list instead of relying on the module-level `SCHOOL_YEARS` constant, and never applies the `since` filter.
+
+**`scheduler/run_scheduler.py`:** add daily entry
+
+```python
+schedule.every().day.at("04:00").do(scheduled_current_fy_backfill)
+```
+
+Wraps `run_current_fy_backfill()` with the same retry / state-write / Slack-monitor logic as `safe_sync()`.
+
+### Data flow
+
+```
+OpenSearch (clj-prod-opportunities, clj-prod-sessions-v2, clj-prod-districts)
+  │
+  ├── hourly: incremental sync (existing)
+  ├── 04:00 daily: current-FY full re-sync (new)
+  │
+  ▼
+Supabase
+  ├── opportunities (existing)
+  ├── sessions (existing — unchanged)
+  ├── unmatched_opportunities (existing)
+  │
+  ├── district_opportunity_actuals (matview, modified — sentinel for null district)
+  └── rep_session_actuals (new view — sessions-by-session_fy)
+       │
+       ▼
+src/lib/opportunity-actuals.ts → getRepActuals()
+  reads BOTH views, sums sessions(by date) + subscriptions(by opp tag)
+       │
+       ▼
+src/features/leaderboard/components/RevenueTable.tsx
+  + unmatched-count badge per rep, links to existing admin queue
+```
+
+### Testing
+
+- **vitest:** `getRepActuals()` returns `session_revenue + subscription_revenue` from both sources. Leaderboard surfaces the unmatched badge when `unmatched_opportunities` has rows for that rep.
+- **pgTAP / sql tests:** `session_fy('2025-07-01'::timestamptz) = '2025-26'`, edge cases at June 30 / July 1 boundaries, NULL passthrough. View row counts before/after migration to verify no spurious zeros.
+- **pytest:** `run_current_fy_backfill()` calls `fetch_opportunities_for_school_yrs` without `since`, processes all sessions, refreshes views.
+- **Manual reconciliation:** after deploy, re-run `Fullmind LMS/es-bi/debug_monica_fy26_attribution.py` and the per-opp Supabase query. Step 4 OS total ($2.82M as of 2026-04-30) should match `rep_session_actuals` for Monica + FY26 within sync-lag tolerance. Plus subscription revenue from the existing view, for the final leaderboard number.
+
+### Migration order
+
+1. Deploy `session_fy()` SQL function (no consumers yet).
+2. Deploy `rep_session_actuals` view (no consumers yet).
+3. Deploy view rewrite for `district_opportunity_actuals` with `_NOMAP` sentinel + audit any consumer that filters on `district_lea_id`. Verify map and district pages still work.
+4. Deploy `getRepActuals()` rewrite + leaderboard badge UI.
+5. Deploy daily-backfill scheduler entry. First run lands at 04:00 UTC the next day.
+6. Run `backfill-unmatched-resolutions.ts` once. Inspect the auto-resolved batch before the next scheduled sync runs (which would refresh `district_lea_id` for those opps).
+
+Each step is independently revertable. Only step 4 changes user-visible numbers.
+
+## Risks
+
+- **`'_NOMAP'` sentinel collisions.** A real LEAID happens to be `'_NOMAP'`. Mitigation: real LEAIDs are 7-digit numerics (the `fetch_district_mappings()` rejection rule already enforces this); `'_NOMAP'` is 6 chars and starts with underscore — definitionally non-numeric.
+- **View perf.** `rep_session_actuals` over the full sessions table on every leaderboard load. If slow, materialize it and refresh in `run_sync()` alongside `district_opportunity_actuals`. Defer the materialization decision until we measure.
+- **Auto-resolve false positives in the backfill.** Mitigation: the existing `names_match()` guardrail (commit `33d4e9c7`) already rejects mismatched account names. The backfill reuses it.
+- **Daily backfill traffic spike.** ~current_FY + prior_FY opp count fetched at 04:00. For Fullmind's volume (low thousands) this is small; if it becomes a load issue, throttle or move to off-hours window.
+
+## What this does NOT fix
+
+- Subscription FY attribution remains tag-based. A subscription on a `school_yr = "2024-25"` opp that bills into FY26 won't appear on the FY26 leaderboard. Reps generally don't surface this; revisit if anyone asks.
+- Reps evaluated on past-FY metrics (e.g. "FY24 revenue") will see slightly different numbers than the old view returned, because session-date attribution will be more accurate. This is a feature, not a regression, but worth a heads-up before rollout.
+- The 24-hour worst-case staleness for the daily backfill. If a rep needs intra-day fresh totals, the hourly incremental sync still applies; the backfill is the safety net.

--- a/prisma/migrations/manual/2026-04-30_doa_expose_sub_revenue.sql
+++ b/prisma/migrations/manual/2026-04-30_doa_expose_sub_revenue.sql
@@ -1,3 +1,10 @@
+-- Re-create district_opportunity_actuals to expose sub_revenue as its own column
+-- (was only inside the combined total_revenue SUM). No semantic change to other
+-- columns. Source of truth: scripts/district-opportunity-actuals-view.sql.
+--
+-- Spec: Docs/superpowers/specs/2026-04-30-leaderboard-fy-attribution-fix-design.md
+-- Required by: Task 4 (getRepActuals rewrite reads sub_revenue independently of session revenue)
+
 -- scripts/district-opportunity-actuals-view.sql
 -- Materialized view: district_opportunity_actuals
 -- Aggregates opportunities by district, school year, sales rep, and category.

--- a/prisma/migrations/manual/2026-04-30_doa_nomap_sentinel.sql
+++ b/prisma/migrations/manual/2026-04-30_doa_nomap_sentinel.sql
@@ -1,16 +1,14 @@
--- scripts/district-opportunity-actuals-view.sql
--- Materialized view: district_opportunity_actuals
--- Aggregates opportunities by district, school year, sales rep, and category.
--- Refreshed after each scheduler sync cycle (hourly).
+-- Re-create district_opportunity_actuals with _NOMAP sentinel for unmatched districts.
+-- Removes the WHERE district_lea_id IS NOT NULL filter from categorized_opps and uses
+-- COALESCE(district_lea_id, '_NOMAP') in the GROUP BY and SELECT. Opportunities without
+-- a resolved NCES district now contribute their revenue under district_lea_id='_NOMAP'
+-- instead of being silently dropped. Recovers ~$200K of FY26 revenue (Monica + others).
 --
--- Subscription handling: Elevate K12 contracts (acquired post-merger) live in
--- the opportunities table but their session-derived revenue columns are zero
--- because EK12 uses subscriptions, not sessions. The opp_subscriptions CTE
--- pre-aggregates subscription net_total per opportunity (signed sums so
--- credits offset positives), and that revenue is added into total_revenue
--- and completed_revenue at the final SELECT level. Take is intentionally
--- left untouched — we don't have an educator-cost / take rate concept for
--- subscriptions, so adding sub revenue to take would be invented data.
+-- The sentinel is computed at view time only — opportunities.district_lea_id keeps NULL
+-- for unmatched rows, so the FK constraint to districts.leaid is unaffected.
+--
+-- Spec: Docs/superpowers/specs/2026-04-30-leaderboard-fy-attribution-fix-design.md
+-- Source of truth: scripts/district-opportunity-actuals-view.sql
 
 DROP MATERIALIZED VIEW IF EXISTS district_opportunity_actuals;
 
@@ -173,8 +171,10 @@ CREATE UNIQUE INDEX idx_doa_unique ON district_opportunity_actuals (district_lea
 
 ANALYZE district_opportunity_actuals;
 
--- Verify
-SELECT COUNT(*) AS row_count,
-       COUNT(DISTINCT district_lea_id) AS district_count,
-       COUNT(DISTINCT school_yr) AS fy_count
-FROM district_opportunity_actuals;
+-- Verify: _NOMAP row should appear if any opportunities.district_lea_id IS NULL
+SELECT district_lea_id, COUNT(*) AS rows,
+       SUM(total_revenue) AS total_revenue,
+       SUM(bookings) AS bookings
+FROM district_opportunity_actuals
+WHERE district_lea_id = '_NOMAP'
+GROUP BY district_lea_id;

--- a/prisma/migrations/manual/2026-04-30_rep_session_actuals_view.sql
+++ b/prisma/migrations/manual/2026-04-30_rep_session_actuals_view.sql
@@ -1,0 +1,29 @@
+-- View: rep_session_actuals
+-- Aggregates the sessions table by (rep, district, session_fy(start_time)).
+-- Used by the leaderboard to bucket session revenue by when the session
+-- actually happened, not by the parent opportunity's school_yr tag.
+-- Subscriptions are NOT in this view — they continue to come from
+-- district_opportunity_actuals (Choice A in the design spec).
+--
+-- Spec: Docs/superpowers/specs/2026-04-30-leaderboard-fy-attribution-fix-design.md
+
+DROP VIEW IF EXISTS rep_session_actuals;
+
+CREATE VIEW rep_session_actuals AS
+SELECT
+  o.sales_rep_email,
+  o.sales_rep_name,
+  COALESCE(o.district_lea_id, '_NOMAP') AS district_lea_id,
+  o.state,
+  session_fy(s.start_time) AS school_yr,
+  SUM(s.session_price) AS session_revenue,
+  COUNT(*)::int AS session_count
+FROM sessions s
+JOIN opportunities o ON o.id = s.opportunity_id
+WHERE s.status NOT IN ('cancelled', 'canceled')
+  AND s.session_price IS NOT NULL
+  AND session_fy(s.start_time) IS NOT NULL
+GROUP BY 1, 2, 3, 4, 5;
+
+COMMENT ON VIEW rep_session_actuals IS
+  'Sessions aggregated by session-date FY (not opp.school_yr). Replaces district_opportunity_actuals as the leaderboard''s source for session revenue. Spec: 2026-04-30-leaderboard-fy-attribution-fix-design.md';

--- a/prisma/migrations/manual/2026-04-30_session_fy_function.sql
+++ b/prisma/migrations/manual/2026-04-30_session_fy_function.sql
@@ -1,0 +1,18 @@
+-- Maps a session timestamp to a Fullmind fiscal-year string ("YYYY-YY").
+-- Fiscal years run July 1 → June 30. Returns NULL for NULL input.
+-- Example: '2025-07-01' → '2025-26'; '2025-06-30' → '2024-25'.
+--
+-- Used by the rep_session_actuals view to bucket session revenue by when the
+-- session actually happened, not by the parent opportunity's school_yr tag.
+-- See spec: Docs/superpowers/specs/2026-04-30-leaderboard-fy-attribution-fix-design.md
+
+CREATE OR REPLACE FUNCTION session_fy(ts timestamptz) RETURNS text AS $$
+  SELECT CASE
+    WHEN ts IS NULL THEN NULL
+    WHEN EXTRACT(MONTH FROM ts) >= 7
+      THEN EXTRACT(YEAR FROM ts)::int::text || '-' ||
+           LPAD(((EXTRACT(YEAR FROM ts)::int + 1) % 100)::text, 2, '0')
+    ELSE (EXTRACT(YEAR FROM ts)::int - 1)::text || '-' ||
+         LPAD((EXTRACT(YEAR FROM ts)::int % 100)::text, 2, '0')
+  END
+$$ LANGUAGE SQL IMMUTABLE;

--- a/scheduler/run_scheduler.py
+++ b/scheduler/run_scheduler.py
@@ -13,7 +13,7 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-from run_sync import run_sync
+from run_sync import run_sync, run_current_fy_backfill
 from monitor import run_checks, run_daily_summary
 
 LOG_DIR = Path("/app/logs") if os.path.isdir("/app") else Path("logs")
@@ -122,6 +122,50 @@ def append_sync_history(log_dir, result):
         f.write(json.dumps(entry) + "\n")
 
 
+def safe_current_fy_backfill():
+    """Run current-FY backfill with retry + state logging."""
+    max_retries = 3
+    last_error = None
+    for attempt in range(1, max_retries + 1):
+        try:
+            result = run_current_fy_backfill()
+            result["attempts"] = attempt
+            return result
+        except Exception as e:
+            last_error = str(e)
+            logger.error(f"Backfill attempt {attempt}/{max_retries} failed: {e}")
+            logger.error(traceback.format_exc())
+            if attempt < max_retries:
+                wait = 2 ** attempt * 10
+                logger.info(f"Retrying in {wait}s...")
+                time.sleep(wait)
+    logger.error("All backfill attempts failed for this cycle")
+    return {
+        "status": "failed", "opps_synced": 0, "unmatched_count": None,
+        "error": last_error, "attempts": max_retries,
+    }
+
+
+def scheduled_sync():
+    result = safe_sync()
+    write_sync_state(LOG_DIR, result)
+    append_sync_history(LOG_DIR, result)
+
+
+def scheduled_current_fy_backfill():
+    result = safe_current_fy_backfill()
+    write_sync_state(LOG_DIR, result)
+    append_sync_history(LOG_DIR, result)
+
+
+def register_schedules():
+    """Register all recurring schedule entries. Extracted for testability."""
+    schedule.every(1).hour.do(scheduled_sync)
+    # Daily current-FY full re-sync at 04:00 UTC — catches sessions whose
+    # lastIndexedAt didn't advance and so missed the hourly incremental.
+    schedule.every().day.at("04:00").do(scheduled_current_fy_backfill)
+
+
 def write_heartbeat():
     """Write heartbeat file for monitoring."""
     HEARTBEAT_FILE.write_text(datetime.now(timezone.utc).isoformat())
@@ -139,13 +183,7 @@ if __name__ == "__main__":
     write_sync_state(LOG_DIR, result)
     append_sync_history(LOG_DIR, result)
 
-    def scheduled_sync():
-        result = safe_sync()
-        write_sync_state(LOG_DIR, result)
-        append_sync_history(LOG_DIR, result)
-
-    # Schedule hourly
-    schedule.every(1).hour.do(scheduled_sync)
+    register_schedules()
 
     # Run loop — heartbeat, monitor checks, and daily summary
     last_heartbeat = 0

--- a/scheduler/run_sync.py
+++ b/scheduler/run_sync.py
@@ -8,6 +8,7 @@ from sync.opensearch_client import get_client
 from sync.queries import (
     fetch_opportunities,
     fetch_opportunities_by_ids,
+    fetch_opportunities_for_school_yrs,  # NEW
     fetch_changed_sessions,
     fetch_sessions,
     fetch_district_mappings,
@@ -199,6 +200,127 @@ def run_sync():
 
         logger.info(
             f"=== Sync complete: {len(matched_records)} opps, "
+            f"{total_sessions} sessions, "
+            f"{len(unmatched_records)} unmatched ==="
+        )
+        return {
+            "status": "success",
+            "opps_synced": len(matched_records),
+            "sessions_stored": total_sessions,
+            "unmatched_count": len(unmatched_records),
+            "error": None,
+        }
+    finally:
+        conn.close()
+
+
+def _derive_current_and_prior_school_yrs(now: datetime) -> list[str]:
+    """e.g. now=2026-04-30 -> ['2024-25', '2025-26']. now=2025-09-01 -> ['2024-25', '2025-26']."""
+    if now.month >= 7:
+        current_start = now.year
+    else:
+        current_start = now.year - 1
+    current = f"{current_start}-{str(current_start + 1)[-2:]}"
+    prior_start = current_start - 1
+    prior = f"{prior_start}-{str(prior_start + 1)[-2:]}"
+    return [prior, current]
+
+
+def run_current_fy_backfill():
+    """Daily backfill: re-fetch all opps in current FY + prior FY unconditionally.
+
+    Bypasses incremental's `since` filter to catch sessions that landed in
+    OpenSearch without advancing `lastIndexedAt`. Reuses the same downstream
+    pipeline as run_sync() — district resolution, manual-resolution merge,
+    upsert, view refresh — but does NOT touch the last_synced_at watermark
+    (so the next hourly incremental still picks up everything since the
+    previous hourly run).
+
+    Spec: Docs/superpowers/specs/2026-04-30-leaderboard-fy-attribution-fix-design.md
+    """
+    now = datetime.now(timezone.utc)
+    school_yrs = _derive_current_and_prior_school_yrs(now)
+    logger.info(f"=== Starting current-FY backfill at {now.isoformat()} for {school_yrs} ===")
+
+    conn = get_connection()
+    os_client = get_client()
+    opp_hits = fetch_opportunities_for_school_yrs(os_client, school_yrs)
+    if not opp_hits:
+        logger.info("No opportunities returned, skipping backfill")
+        conn.close()
+        return {"status": "success", "opps_synced": 0, "sessions_stored": 0,
+                "unmatched_count": None, "error": None}
+
+    opp_ids = [h["_source"]["id"] for h in opp_hits]
+    session_hits = fetch_sessions(os_client, opp_ids)
+
+    sessions_by_opp = defaultdict(list)
+    for sh in session_hits:
+        src = sh["_source"]
+        src["_id"] = sh["_id"]
+        sessions_by_opp[src["opportunityId"]].append(src)
+
+    account_ids = set()
+    for h in opp_hits:
+        for acc in (h["_source"].get("accounts") or []):
+            if acc.get("id"):
+                account_ids.add(acc["id"])
+    district_mapping = fetch_district_mappings(os_client, list(account_ids))
+
+    try:
+        manual_resolutions = _load_manual_resolutions(conn)
+        matched_records = []
+        unmatched_records = []
+        for h in opp_hits:
+            opp = h["_source"]
+            opp_sessions = sessions_by_opp.get(opp["id"], [])
+            record, unmatched = _build_record_and_classify(
+                opp, opp_sessions, district_mapping, now=now
+            )
+            if record["district_lea_id"] is None and opp["id"] in manual_resolutions:
+                record["district_lea_id"] = manual_resolutions[opp["id"]]
+                unmatched = None
+            matched_records.append(record)
+            if unmatched is not None:
+                unmatched_records.append(unmatched)
+
+        upsert_opportunities(conn, matched_records)
+        if unmatched_records:
+            upsert_unmatched(conn, unmatched_records)
+
+        session_records_by_opp = {}
+        for opp_id, opp_sessions in sessions_by_opp.items():
+            session_records_by_opp[opp_id] = [
+                {
+                    "id": s["_id"],
+                    "opportunity_id": s["opportunityId"],
+                    "service_type": s.get("serviceType"),
+                    "session_price": _to_decimal(s.get("sessionPrice")),
+                    "educator_price": _to_decimal(s.get("educatorPrice")),
+                    "educator_approved_price": _to_decimal(s.get("educatorApprovedPrice")),
+                    "start_time": s.get("startTime"),
+                    "type": s.get("type"),
+                    "status": s.get("status"),
+                    "service_name": s.get("serviceName"),
+                    "synced_at": now,
+                }
+                for s in opp_sessions
+            ]
+        total_sessions = sum(len(v) for v in session_records_by_opp.values())
+        upsert_sessions(conn, session_records_by_opp)
+
+        newly_matched_ids = [
+            r["id"] for r in matched_records if r.get("district_lea_id") is not None
+        ]
+        remove_matched_from_unmatched(conn, newly_matched_ids)
+
+        update_district_pipeline_aggregates(conn)
+        refresh_map_features(conn)
+        refresh_fullmind_financials(conn)
+        refresh_opportunity_actuals(conn)
+
+        logger.info(
+            f"=== Backfill complete: {len(matched_records)} opps, "
             f"{total_sessions} sessions, "
             f"{len(unmatched_records)} unmatched ==="
         )

--- a/scheduler/sync/opensearch_client.py
+++ b/scheduler/sync/opensearch_client.py
@@ -34,27 +34,63 @@ def scroll_all(
     size: int = 5000,
     sort_field: str = "_doc",
 ) -> list:
-    """Paginate through all results using search_after."""
+    """Paginate through all results using search_after with a Point-in-Time
+    snapshot so concurrent index writes can't perturb pagination.
+
+    Without PIT, search_after's results can drift when documents are added,
+    deleted, or updated mid-scroll — silently leaking records. Sessions in
+    clj-prod-sessions-v2 are reindexed constantly by the LMS, so PIT is
+    required for completeness, not optional.
+
+    Falls back to non-PIT pagination if create_pit raises (e.g., older
+    OpenSearch versions or restricted permissions). The fallback path
+    matches the previous behavior exactly.
+    """
+    # Try to open a PIT. AWS OpenSearch Service supports create_pit on
+    # versions ≥ 2.4. If unavailable, log and fall back to the old path.
+    pit_id = None
+    try:
+        pit_resp = client.create_pit(index=index, keep_alive="5m")
+        pit_id = pit_resp.get("pit_id")
+    except Exception as e:
+        logger.warning(
+            f"create_pit unavailable for {index} ({type(e).__name__}: {e}); "
+            f"falling back to non-PIT search_after — pagination may drop records "
+            f"under concurrent writes"
+        )
+
     results = []
     search_after = None
+    try:
+        while True:
+            body = {
+                "size": size,
+                "query": query,
+                "_source": source_fields,
+                "sort": [{sort_field: "asc"}],
+            }
+            if search_after:
+                body["search_after"] = search_after
 
-    while True:
-        body = {
-            "size": size,
-            "query": query,
-            "_source": source_fields,
-            "sort": [{sort_field: "asc"}],
-        }
-        if search_after:
-            body["search_after"] = search_after
+            if pit_id:
+                # When using PIT, don't pass index — PIT is bound to the index.
+                body["pit"] = {"id": pit_id, "keep_alive": "5m"}
+                resp = client.search(body=body)
+            else:
+                resp = client.search(index=index, body=body)
 
-        resp = client.search(index=index, body=body)
-        hits = resp["hits"]["hits"]
-        if not hits:
-            break
+            hits = resp["hits"]["hits"]
+            if not hits:
+                break
 
-        results.extend(hits)
-        search_after = hits[-1]["sort"]
-        logger.info(f"  Fetched {len(results)} records from {index}...")
+            results.extend(hits)
+            search_after = hits[-1]["sort"]
+            logger.info(f"  Fetched {len(results)} records from {index}...")
+    finally:
+        if pit_id:
+            try:
+                client.delete_pit(body={"pit_id": [pit_id]})
+            except Exception as e:
+                logger.warning(f"delete_pit failed (PIT will expire on its own): {e}")
 
     return results

--- a/scheduler/sync/opensearch_client.py
+++ b/scheduler/sync/opensearch_client.py
@@ -34,63 +34,40 @@ def scroll_all(
     size: int = 5000,
     sort_field: str = "_doc",
 ) -> list:
-    """Paginate through all results using search_after with a Point-in-Time
-    snapshot so concurrent index writes can't perturb pagination.
+    """Paginate through all results using the legacy OpenSearch scroll API.
 
-    Without PIT, search_after's results can drift when documents are added,
-    deleted, or updated mid-scroll — silently leaking records. Sessions in
-    clj-prod-sessions-v2 are reindexed constantly by the LMS, so PIT is
-    required for completeness, not optional.
+    The scroll API maintains a server-side cursor that is stable under
+    concurrent index writes (in contrast to search_after, which can leak
+    or duplicate records when documents are added/reindexed mid-scroll).
+    The scroll context is opened on the first search() call (via the
+    `scroll` parameter), advanced via client.scroll(), and explicitly
+    cleared in a finally block so we don't leak server-side state.
 
-    Falls back to non-PIT pagination if create_pit raises (e.g., older
-    OpenSearch versions or restricted permissions). The fallback path
-    matches the previous behavior exactly.
+    `sort_field` is accepted for backwards compatibility but unused —
+    the scroll API doesn't require explicit sort.
     """
-    # Try to open a PIT. AWS OpenSearch Service supports create_pit on
-    # versions ≥ 2.4. If unavailable, log and fall back to the old path.
-    pit_id = None
-    try:
-        pit_resp = client.create_pit(index=index, keep_alive="5m")
-        pit_id = pit_resp.get("pit_id")
-    except Exception as e:
-        logger.warning(
-            f"create_pit unavailable for {index} ({type(e).__name__}: {e}); "
-            f"falling back to non-PIT search_after — pagination may drop records "
-            f"under concurrent writes"
-        )
-
+    scroll_id = None
     results = []
-    search_after = None
+    body = {
+        "size": size,
+        "query": query,
+        "_source": source_fields,
+    }
     try:
-        while True:
-            body = {
-                "size": size,
-                "query": query,
-                "_source": source_fields,
-                "sort": [{sort_field: "asc"}],
-            }
-            if search_after:
-                body["search_after"] = search_after
-
-            if pit_id:
-                # When using PIT, don't pass index — PIT is bound to the index.
-                body["pit"] = {"id": pit_id, "keep_alive": "5m"}
-                resp = client.search(body=body)
-            else:
-                resp = client.search(index=index, body=body)
-
-            hits = resp["hits"]["hits"]
-            if not hits:
-                break
-
+        resp = client.search(index=index, body=body, scroll="5m")
+        scroll_id = resp.get("_scroll_id")
+        hits = resp["hits"]["hits"]
+        while hits:
             results.extend(hits)
-            search_after = hits[-1]["sort"]
             logger.info(f"  Fetched {len(results)} records from {index}...")
+            resp = client.scroll(scroll_id=scroll_id, scroll="5m")
+            scroll_id = resp.get("_scroll_id")
+            hits = resp["hits"]["hits"]
     finally:
-        if pit_id:
+        if scroll_id:
             try:
-                client.delete_pit(body={"pit_id": [pit_id]})
+                client.clear_scroll(scroll_id=scroll_id)
             except Exception as e:
-                logger.warning(f"delete_pit failed (PIT will expire on its own): {e}")
+                logger.warning(f"clear_scroll failed (scroll context will time out): {e}")
 
     return results

--- a/scheduler/sync/queries.py
+++ b/scheduler/sync/queries.py
@@ -89,6 +89,25 @@ def fetch_sessions(client, opportunity_ids):
     return all_hits
 
 
+def fetch_opportunities_for_school_yrs(client, school_yrs):
+    """Fetch opportunities for an explicit list of school years, ignoring incremental.
+
+    Used by the daily current-FY backfill (run_current_fy_backfill): re-fetches
+    every opp in the supplied school years regardless of opp.updated_at, so
+    sessions whose lastIndexedAt didn't advance still get pulled into Supabase
+    via the downstream pipeline's full session refresh.
+    """
+    logger.info(f"Full re-fetch of opportunities for school years: {school_yrs}")
+    query = {
+        "bool": {
+            "filter": [{"terms": {"school_yr.keyword": school_yrs}}],
+        }
+    }
+    hits = scroll_all(client, "clj-prod-opportunities", query, OPPORTUNITY_SOURCE_FIELDS)
+    logger.info(f"Fetched {len(hits)} opportunities for {school_yrs}")
+    return hits
+
+
 def fetch_district_mappings(client, account_ids):
     """Batch lookup account IDs against clj-prod-districts for NCES/LEAID mapping.
     Returns dict: {account_id_str: {ncesId, name, type, ...}}

--- a/scheduler/tests/test_opensearch_client.py
+++ b/scheduler/tests/test_opensearch_client.py
@@ -22,81 +22,97 @@ def test_get_client_returns_opensearch_instance():
 
 def test_scroll_all_paginates():
     mock_client = MagicMock()
-    mock_client.search.side_effect = [
-        {"hits": {"hits": [
-            {"_source": {"id": "1"}, "sort": [1]},
-            {"_source": {"id": "2"}, "sort": [2]},
-        ]}},
-        {"hits": {"hits": []}},
-    ]
+    # First search() opens a scroll with 2 hits, second scroll() returns 0 hits.
+    mock_client.search.return_value = {
+        "_scroll_id": "test_scroll_abc",
+        "hits": {"hits": [
+            {"_id": "1", "_source": {"id": "1"}},
+            {"_id": "2", "_source": {"id": "2"}},
+        ]},
+    }
+    mock_client.scroll.return_value = {
+        "_scroll_id": "test_scroll_abc",
+        "hits": {"hits": []},
+    }
     results = scroll_all(mock_client, "test-index", {"match_all": {}}, ["id"], size=2)
     assert len(results) == 2
     assert results[0]["_source"]["id"] == "1"
-    assert mock_client.search.call_count == 2
+    assert mock_client.search.call_count == 1
 
 
-def test_scroll_all_uses_pit_when_available():
+def test_scroll_all_uses_legacy_scroll_api():
     client = MagicMock()
-    # First search returns 2 hits, second returns 0 (terminating)
-    client.create_pit.return_value = {"pit_id": "test_pit_123"}
-    client.search.side_effect = [
-        {"hits": {"hits": [
-            {"_id": "1", "_source": {"x": 1}, "sort": [1]},
-            {"_id": "2", "_source": {"x": 2}, "sort": [2]},
-        ]}},
-        {"hits": {"hits": []}},
+    # First search() opens a scroll, returns 2 hits + scroll_id.
+    # Second client.scroll() returns 1 hit + same scroll_id.
+    # Third client.scroll() returns 0 hits — terminates.
+    client.search.return_value = {
+        "_scroll_id": "test_scroll_abc",
+        "hits": {"hits": [
+            {"_id": "1", "_source": {"x": 1}},
+            {"_id": "2", "_source": {"x": 2}},
+        ]},
+    }
+    client.scroll.side_effect = [
+        {"_scroll_id": "test_scroll_abc",
+         "hits": {"hits": [{"_id": "3", "_source": {"x": 3}}]}},
+        {"_scroll_id": "test_scroll_abc",
+         "hits": {"hits": []}},
     ]
 
-    results = scroll_all(client, "myindex", {"match_all": {}}, ["x"], size=5000)
+    results = scroll_all(client, "myindex", {"match_all": {}}, ["x"], size=100)
 
-    assert len(results) == 2
-    # PIT lifecycle assertions
-    client.create_pit.assert_called_once_with(index="myindex", keep_alive="5m")
-    client.delete_pit.assert_called_once_with(body={"pit_id": ["test_pit_123"]})
-
-    # When PIT is in use, search() should NOT be called with `index`
-    for call in client.search.call_args_list:
-        kwargs = call.kwargs
-        assert "index" not in kwargs, f"search called with index when PIT was open: {call}"
-        body = kwargs.get("body") or (call.args[0] if call.args else {})
-        # Body must contain pit, not index
-        assert "pit" in body, f"search body missing pit: {body}"
-        assert body["pit"]["id"] == "test_pit_123"
+    assert len(results) == 3
+    assert [r["_id"] for r in results] == ["1", "2", "3"]
+    # Verify scroll lifecycle: search opened with scroll="5m", scroll() called, clear_scroll called
+    client.search.assert_called_once()
+    search_call = client.search.call_args
+    assert search_call.kwargs.get("scroll") == "5m"
+    assert search_call.kwargs.get("index") == "myindex"
+    assert client.scroll.call_count == 2
+    client.clear_scroll.assert_called_once_with(scroll_id="test_scroll_abc")
 
 
-def test_scroll_all_falls_back_when_create_pit_fails():
+def test_scroll_all_clears_scroll_even_on_error():
     client = MagicMock()
-    client.create_pit.side_effect = Exception("PIT not supported")
-    client.search.side_effect = [
-        {"hits": {"hits": [{"_id": "1", "_source": {"x": 1}, "sort": [1]}]}},
-        {"hits": {"hits": []}},
-    ]
-
-    results = scroll_all(client, "myindex", {"match_all": {}}, ["x"], size=5000)
-
-    assert len(results) == 1
-    # Fallback path: search must be called with `index`, no PIT
-    for call in client.search.call_args_list:
-        kwargs = call.kwargs
-        body = kwargs.get("body") or (call.args[0] if call.args else {})
-        assert "pit" not in body
-    # No delete_pit call when PIT was never opened
-    client.delete_pit.assert_not_called()
-
-
-def test_scroll_all_closes_pit_even_on_error():
-    client = MagicMock()
-    client.create_pit.return_value = {"pit_id": "test_pit_123"}
-    # First page works, second page raises
-    client.search.side_effect = [
-        {"hits": {"hits": [{"_id": "1", "_source": {"x": 1}, "sort": [1]}]}},
-        Exception("network blip"),
-    ]
+    client.search.return_value = {
+        "_scroll_id": "test_scroll_abc",
+        "hits": {"hits": [{"_id": "1", "_source": {"x": 1}}]},
+    }
+    client.scroll.side_effect = Exception("network blip")
 
     try:
-        scroll_all(client, "myindex", {"match_all": {}}, ["x"], size=5000)
+        scroll_all(client, "myindex", {"match_all": {}}, ["x"])
     except Exception:
         pass
 
-    # PIT must always be closed, even if scroll errors out
-    client.delete_pit.assert_called_once_with(body={"pit_id": ["test_pit_123"]})
+    # Scroll context must always be cleared — even if scroll() raises mid-pagination
+    client.clear_scroll.assert_called_once_with(scroll_id="test_scroll_abc")
+
+
+def test_scroll_all_handles_empty_first_page():
+    client = MagicMock()
+    client.search.return_value = {
+        "_scroll_id": "test_scroll_abc",
+        "hits": {"hits": []},
+    }
+
+    results = scroll_all(client, "myindex", {"match_all": {}}, ["x"])
+
+    assert results == []
+    client.scroll.assert_not_called()  # Loop exits immediately on empty hits
+    client.clear_scroll.assert_called_once()
+
+
+def test_scroll_all_handles_clear_scroll_failure_gracefully():
+    """clear_scroll failures shouldn't propagate — scroll contexts time out anyway."""
+    client = MagicMock()
+    client.search.return_value = {
+        "_scroll_id": "test_scroll_abc",
+        "hits": {"hits": [{"_id": "1", "_source": {"x": 1}}]},
+    }
+    client.scroll.return_value = {"_scroll_id": "test_scroll_abc", "hits": {"hits": []}}
+    client.clear_scroll.side_effect = Exception("scroll already cleared")
+
+    # Should not raise
+    results = scroll_all(client, "myindex", {"match_all": {}}, ["x"])
+    assert len(results) == 1

--- a/scheduler/tests/test_opensearch_client.py
+++ b/scheduler/tests/test_opensearch_client.py
@@ -33,3 +33,70 @@ def test_scroll_all_paginates():
     assert len(results) == 2
     assert results[0]["_source"]["id"] == "1"
     assert mock_client.search.call_count == 2
+
+
+def test_scroll_all_uses_pit_when_available():
+    client = MagicMock()
+    # First search returns 2 hits, second returns 0 (terminating)
+    client.create_pit.return_value = {"pit_id": "test_pit_123"}
+    client.search.side_effect = [
+        {"hits": {"hits": [
+            {"_id": "1", "_source": {"x": 1}, "sort": [1]},
+            {"_id": "2", "_source": {"x": 2}, "sort": [2]},
+        ]}},
+        {"hits": {"hits": []}},
+    ]
+
+    results = scroll_all(client, "myindex", {"match_all": {}}, ["x"], size=5000)
+
+    assert len(results) == 2
+    # PIT lifecycle assertions
+    client.create_pit.assert_called_once_with(index="myindex", keep_alive="5m")
+    client.delete_pit.assert_called_once_with(body={"pit_id": ["test_pit_123"]})
+
+    # When PIT is in use, search() should NOT be called with `index`
+    for call in client.search.call_args_list:
+        kwargs = call.kwargs
+        assert "index" not in kwargs, f"search called with index when PIT was open: {call}"
+        body = kwargs.get("body") or (call.args[0] if call.args else {})
+        # Body must contain pit, not index
+        assert "pit" in body, f"search body missing pit: {body}"
+        assert body["pit"]["id"] == "test_pit_123"
+
+
+def test_scroll_all_falls_back_when_create_pit_fails():
+    client = MagicMock()
+    client.create_pit.side_effect = Exception("PIT not supported")
+    client.search.side_effect = [
+        {"hits": {"hits": [{"_id": "1", "_source": {"x": 1}, "sort": [1]}]}},
+        {"hits": {"hits": []}},
+    ]
+
+    results = scroll_all(client, "myindex", {"match_all": {}}, ["x"], size=5000)
+
+    assert len(results) == 1
+    # Fallback path: search must be called with `index`, no PIT
+    for call in client.search.call_args_list:
+        kwargs = call.kwargs
+        body = kwargs.get("body") or (call.args[0] if call.args else {})
+        assert "pit" not in body
+    # No delete_pit call when PIT was never opened
+    client.delete_pit.assert_not_called()
+
+
+def test_scroll_all_closes_pit_even_on_error():
+    client = MagicMock()
+    client.create_pit.return_value = {"pit_id": "test_pit_123"}
+    # First page works, second page raises
+    client.search.side_effect = [
+        {"hits": {"hits": [{"_id": "1", "_source": {"x": 1}, "sort": [1]}]}},
+        Exception("network blip"),
+    ]
+
+    try:
+        scroll_all(client, "myindex", {"match_all": {}}, ["x"], size=5000)
+    except Exception:
+        pass
+
+    # PIT must always be closed, even if scroll errors out
+    client.delete_pit.assert_called_once_with(body={"pit_id": ["test_pit_123"]})

--- a/scheduler/tests/test_queries.py
+++ b/scheduler/tests/test_queries.py
@@ -1,5 +1,5 @@
 from unittest.mock import MagicMock, patch
-from sync.queries import fetch_opportunities, fetch_sessions, fetch_district_mappings
+from sync.queries import fetch_opportunities, fetch_sessions, fetch_district_mappings, fetch_opportunities_for_school_yrs
 
 OPPORTUNITY_SOURCE_FIELDS = [
     "id", "name", "stage", "school_yr", "state", "close_date", "created_at",
@@ -64,3 +64,26 @@ def test_fetch_district_mappings_rejects_non_seven_digit_ncesid():
         assert result["3"]["leaid"] is None
         assert result["3"]["nces_id"] is None
         assert result["4"]["leaid"] is None
+
+
+@patch("sync.queries.scroll_all")
+def test_fetch_opportunities_for_school_yrs_filters_by_provided_list(mock_scroll):
+    mock_scroll.return_value = []
+    client = MagicMock()
+    fetch_opportunities_for_school_yrs(client, ["2025-26", "2024-25"])
+    args = mock_scroll.call_args
+    body = args[0][2]  # (client, index, query, source_fields)
+    filters = body["bool"]["filter"]
+    yr_filter = next(f for f in filters if "terms" in f)
+    assert yr_filter["terms"]["school_yr.keyword"] == ["2025-26", "2024-25"]
+
+
+@patch("sync.queries.scroll_all")
+def test_fetch_opportunities_for_school_yrs_does_not_apply_since(mock_scroll):
+    mock_scroll.return_value = []
+    client = MagicMock()
+    fetch_opportunities_for_school_yrs(client, ["2025-26"])
+    body = mock_scroll.call_args[0][2]
+    filters = body["bool"]["filter"]
+    # No range filter on updated_at — every opp in the school year is fetched.
+    assert not any("range" in f and "updated_at" in (f.get("range") or {}) for f in filters)

--- a/scheduler/tests/test_run_current_fy_backfill.py
+++ b/scheduler/tests/test_run_current_fy_backfill.py
@@ -1,0 +1,109 @@
+import os
+os.environ["OPENSEARCH_HOST"] = "https://test:9200"
+os.environ["OPENSEARCH_USERNAME"] = "user"
+os.environ["OPENSEARCH_PASSWORD"] = "pass"
+os.environ["SUPABASE_DB_URL"] = "postgresql://test:test@localhost:5432/test"
+
+from unittest.mock import patch, MagicMock
+from datetime import datetime, timezone
+from run_sync import run_current_fy_backfill, _derive_current_and_prior_school_yrs
+
+
+def test_derive_school_yrs_after_july():
+    assert _derive_current_and_prior_school_yrs(datetime(2025, 9, 1, tzinfo=timezone.utc)) == ["2024-25", "2025-26"]
+
+
+def test_derive_school_yrs_before_july():
+    assert _derive_current_and_prior_school_yrs(datetime(2026, 4, 30, tzinfo=timezone.utc)) == ["2024-25", "2025-26"]
+
+
+def test_derive_school_yrs_july_1_boundary():
+    assert _derive_current_and_prior_school_yrs(datetime(2026, 7, 1, tzinfo=timezone.utc)) == ["2025-26", "2026-27"]
+
+
+@patch("run_sync.refresh_opportunity_actuals")
+@patch("run_sync.refresh_fullmind_financials")
+@patch("run_sync.refresh_map_features")
+@patch("run_sync.update_district_pipeline_aggregates")
+@patch("run_sync.remove_matched_from_unmatched")
+@patch("run_sync.upsert_unmatched")
+@patch("run_sync.upsert_sessions")
+@patch("run_sync.upsert_opportunities")
+@patch("run_sync.get_connection")
+@patch("run_sync._build_record_and_classify")
+@patch("run_sync.fetch_district_mappings")
+@patch("run_sync.fetch_sessions")
+@patch("run_sync.fetch_opportunities_for_school_yrs")
+@patch("run_sync.get_client")
+def test_run_current_fy_backfill_uses_school_yr_helper_not_incremental(
+    mock_get_client, mock_fetch_yrs, mock_fetch_sessions,
+    mock_fetch_districts, mock_build, mock_get_conn,
+    mock_upsert_opps, mock_upsert_sessions, mock_upsert_unmatched,
+    mock_remove_matched, mock_update_agg, mock_refresh_map,
+    mock_refresh_fin, mock_refresh_actuals,
+):
+    mock_fetch_yrs.return_value = [
+        {"_source": {"id": "opp1", "accounts": [{"id": "acc1"}]}}
+    ]
+    mock_fetch_sessions.return_value = []
+    mock_fetch_districts.return_value = {}
+    mock_build.return_value = ({"id": "opp1", "district_lea_id": "0100001",
+                                 "net_booking_amount": 1, "service_types": []}, None)
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_cursor.fetchall.return_value = []
+    mock_conn.cursor.return_value.__enter__ = lambda s: mock_cursor
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_get_conn.return_value = mock_conn
+
+    result = run_current_fy_backfill()
+
+    mock_fetch_yrs.assert_called_once()
+    school_yrs_arg = mock_fetch_yrs.call_args[0][1]
+    assert "2025-26" in school_yrs_arg
+    assert "2024-25" in school_yrs_arg
+    assert result["status"] == "success"
+    assert result["opps_synced"] == 1
+
+
+@patch("run_sync.refresh_opportunity_actuals")
+@patch("run_sync.refresh_fullmind_financials")
+@patch("run_sync.refresh_map_features")
+@patch("run_sync.update_district_pipeline_aggregates")
+@patch("run_sync.remove_matched_from_unmatched")
+@patch("run_sync.upsert_unmatched")
+@patch("run_sync.upsert_sessions")
+@patch("run_sync.upsert_opportunities")
+@patch("run_sync.set_last_synced_at")
+@patch("run_sync.get_connection")
+@patch("run_sync._build_record_and_classify")
+@patch("run_sync.fetch_district_mappings")
+@patch("run_sync.fetch_sessions")
+@patch("run_sync.fetch_opportunities_for_school_yrs")
+@patch("run_sync.get_client")
+def test_run_current_fy_backfill_does_not_touch_watermark(
+    mock_get_client, mock_fetch_yrs, mock_fetch_sessions,
+    mock_fetch_districts, mock_build, mock_get_conn,
+    mock_set_last, mock_upsert_opps, mock_upsert_sessions, mock_upsert_unmatched,
+    mock_remove_matched, mock_update_agg, mock_refresh_map,
+    mock_refresh_fin, mock_refresh_actuals,
+):
+    mock_fetch_yrs.return_value = [
+        {"_source": {"id": "opp1", "accounts": [{"id": "acc1"}]}}
+    ]
+    mock_fetch_sessions.return_value = []
+    mock_fetch_districts.return_value = {}
+    mock_build.return_value = ({"id": "opp1", "district_lea_id": "0100001",
+                                 "net_booking_amount": 1, "service_types": []}, None)
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_cursor.fetchall.return_value = []
+    mock_conn.cursor.return_value.__enter__ = lambda s: mock_cursor
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_get_conn.return_value = mock_conn
+
+    run_current_fy_backfill()
+
+    # Backfill must NOT advance the watermark — the hourly incremental still
+    # needs to catch up from where it last left off.
+    mock_set_last.assert_not_called()

--- a/scheduler/tests/test_run_scheduler.py
+++ b/scheduler/tests/test_run_scheduler.py
@@ -152,3 +152,28 @@ def test_update_heartbeat_in_state():
         assert state_after["heartbeat_at"] > old_heartbeat
         assert state_after["last_sync_status"] == "success"
         assert state_after["opps_synced"] == 5
+
+
+@patch("run_scheduler.schedule")
+def test_daily_backfill_is_registered_at_04_00(mock_schedule):
+    from run_scheduler import register_schedules
+
+    register_schedules()
+
+    # schedule.every().day.at("04:00") should have been called
+    daily_chain_seen = any(
+        c.args == ("04:00",)
+        for c in mock_schedule.every.return_value.day.at.call_args_list
+    )
+    assert daily_chain_seen, "expected schedule.every().day.at('04:00').do(...) to be wired"
+
+
+@patch("run_scheduler.schedule")
+def test_hourly_sync_is_registered(mock_schedule):
+    from run_scheduler import register_schedules
+
+    register_schedules()
+
+    # schedule.every(1).hour should have been called
+    mock_schedule.every.assert_any_call(1)
+    mock_schedule.every.return_value.hour.do.assert_called_once()

--- a/scripts/__tests__/backfill-unmatched-resolutions.test.ts
+++ b/scripts/__tests__/backfill-unmatched-resolutions.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// vi.mock calls are hoisted to the top of the file by vitest. To reference
+// a variable inside a factory we must use vi.hoisted() so the variable is
+// also hoisted and available when the factory executes.
+const { mockLookup, mockNamesMatch } = vi.hoisted(() => ({
+  mockLookup: vi.fn(),
+  mockNamesMatch: vi.fn((a: string, b: string) => {
+    if (!a || !b) return true;
+    const norm = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, "");
+    return norm(a) === norm(b) || norm(a).includes(norm(b)) || norm(b).includes(norm(a));
+  }),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  default: { $queryRaw: vi.fn(), $executeRaw: vi.fn() },
+}));
+
+vi.mock("../backfill-unmatched-resolutions-helpers", () => ({
+  lookupNcesByLmsId: mockLookup,
+  namesMatch: mockNamesMatch,
+}));
+
+import prisma from "@/lib/prisma";
+import { backfillUnmatched } from "../backfill-unmatched-resolutions";
+
+describe("backfillUnmatched", () => {
+  beforeEach(() => {
+    // Use clearAllMocks (clears calls/instances) rather than resetAllMocks
+    // (which would wipe the implementations set in vi.hoisted above).
+    vi.clearAllMocks();
+  });
+
+  it("auto-resolves when name matches exactly", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([
+      { id: "opp1", account_lms_id: "lms123", account_name: "Yuba City Unified" },
+    ] as never);
+    mockLookup.mockResolvedValueOnce({ ncesId: "0612345", name: "Yuba City Unified School District" });
+
+    const summary = await backfillUnmatched({ dryRun: false, logDecisions: false });
+
+    expect(summary.autoResolved).toBe(1);
+    expect(summary.deferred).toBe(0);
+    expect(prisma.$executeRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it("defers when names do NOT match", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([
+      { id: "opp1", account_lms_id: "lms123", account_name: "Foo District" },
+    ] as never);
+    mockLookup.mockResolvedValueOnce({ ncesId: "0612345", name: "Bar District" });
+
+    const summary = await backfillUnmatched({ dryRun: false, logDecisions: false });
+
+    expect(summary.autoResolved).toBe(0);
+    expect(summary.deferred).toBe(1);
+    expect(prisma.$executeRaw).not.toHaveBeenCalled();
+  });
+
+  it("defers when no district found in OpenSearch", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([
+      { id: "opp1", account_lms_id: "lms_unknown", account_name: "Some District" },
+    ] as never);
+    mockLookup.mockResolvedValueOnce(null);
+
+    const summary = await backfillUnmatched({ dryRun: false, logDecisions: false });
+
+    expect(summary.autoResolved).toBe(0);
+    expect(summary.deferred).toBe(1);
+    expect(prisma.$executeRaw).not.toHaveBeenCalled();
+  });
+
+  it("dry-run mode does not write", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([
+      { id: "opp1", account_lms_id: "lms123", account_name: "Yuba City" },
+    ] as never);
+    mockLookup.mockResolvedValueOnce({ ncesId: "0612345", name: "Yuba City Unified" });
+
+    const summary = await backfillUnmatched({ dryRun: true, logDecisions: false });
+
+    expect(summary.autoResolved).toBe(1);
+    expect(summary.dryRun).toBe(true);
+    expect(prisma.$executeRaw).not.toHaveBeenCalled();
+  });
+
+  it("counts errors and continues processing other rows", async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValueOnce([
+      { id: "opp1", account_lms_id: "lms123", account_name: "A" },
+      { id: "opp2", account_lms_id: "lms456", account_name: "B" },
+    ] as never);
+    mockLookup
+      .mockRejectedValueOnce(new Error("network blip"))
+      .mockResolvedValueOnce({ ncesId: "0612345", name: "B" });
+
+    const summary = await backfillUnmatched({ dryRun: false, logDecisions: false });
+
+    expect(summary.errors).toBe(1);
+    expect(summary.autoResolved).toBe(1);
+    expect(summary.deferred).toBe(0);
+  });
+});

--- a/scripts/backfill-unmatched-resolutions-helpers.ts
+++ b/scripts/backfill-unmatched-resolutions-helpers.ts
@@ -1,0 +1,98 @@
+/**
+ * Helpers for backfill-unmatched-resolutions.ts — separated for testability.
+ *
+ * namesMatch / normalizeDistrictName mirror scheduler/sync/district_resolver.py
+ * byte-for-byte so the same conservative matching logic applies on both sides.
+ */
+import { Client } from "@opensearch-project/opensearch";
+
+// ---------------------------------------------------------------------------
+// Name normalisation — must stay in sync with:
+//   scheduler/sync/district_resolver.py  (normalise_district_name / names_match)
+//   prisma/migrations/manual/2026-04-13_normalize_district_name_fn.sql
+// ---------------------------------------------------------------------------
+
+// Multi-word phrases are listed first so they win over their component words,
+// matching Python re's leftmost-longest semantics.
+const SUFFIX_PATTERN =
+  /\s*(unified school district|independent school district|consolidated school district|public school district|school district|schools|school|district|unified|public|elementary|junior|senior|high|middle|central|city|county|independent|charter|community|academy)\s*/gi;
+
+const NON_ALNUM = /[^a-z0-9]+/g;
+
+export function normalizeDistrictName(name: string | null | undefined): string {
+  if (!name) return "";
+  const stripped = name.toLowerCase().replace(SUFFIX_PATTERN, " ");
+  return stripped.replace(NON_ALNUM, "");
+}
+
+export function namesMatch(
+  oppName: string | null | undefined,
+  districtName: string | null | undefined
+): boolean {
+  const a = normalizeDistrictName(oppName);
+  const b = normalizeDistrictName(districtName);
+  if (!a || !b) return true;
+  if (a === b) return true;
+  return a.includes(b) || b.includes(a);
+}
+
+// ---------------------------------------------------------------------------
+// OpenSearch lookup
+// ---------------------------------------------------------------------------
+
+let _client: Client | null = null;
+
+function getClient(): Client {
+  if (_client) return _client;
+  const host = process.env.ELASTICSEARCH_HOST;
+  if (!host) throw new Error("ELASTICSEARCH_HOST env var is required");
+  _client = new Client({
+    node: host,
+    auth: {
+      username: process.env.ELASTICSEARCH_USERNAME!,
+      password: process.env.ELASTICSEARCH_PASSWORD!,
+    },
+    ssl: { rejectUnauthorized: true },
+  });
+  return _client;
+}
+
+export interface DistrictHit {
+  ncesId: string;
+  name: string;
+}
+
+/**
+ * Query OpenSearch `clj-prod-districts` for a district whose `id` field
+ * equals `lmsId`. Returns null when:
+ *  - no document is found
+ *  - the document's ncesId is not exactly 7 digits (same rejection rule as
+ *    scheduler/sync/queries.py:121)
+ */
+export async function lookupNcesByLmsId(
+  lmsId: string
+): Promise<DistrictHit | null> {
+  const res = await getClient().search({
+    index: "clj-prod-districts",
+    body: {
+      size: 1,
+      query: { term: { id: lmsId } },
+      _source: ["id", "ncesId", "name"],
+    },
+  });
+
+  const hits = (res.body?.hits?.hits ?? []) as Array<{
+    _source: { id: string; ncesId: string; name: string };
+  }>;
+
+  if (hits.length === 0) return null;
+
+  const src = hits[0]._source;
+
+  // Reject placeholder / test LEAID values — real NCES IDs are exactly 7 digits.
+  if (!src.ncesId || src.ncesId.length !== 7 || !/^\d{7}$/.test(src.ncesId)) {
+    return null;
+  }
+
+  return { ncesId: src.ncesId, name: src.name };
+}

--- a/scripts/backfill-unmatched-resolutions.ts
+++ b/scripts/backfill-unmatched-resolutions.ts
@@ -1,0 +1,169 @@
+/**
+ * One-time backfill: auto-resolve unmatched_opportunities entries where the
+ * LMS account → NCES district mapping is unambiguous (single result + name match).
+ *
+ * Run dry-run first (recommended):
+ *   DRY_RUN=true npx tsx scripts/backfill-unmatched-resolutions.ts
+ *
+ * Run for real:
+ *   npx tsx scripts/backfill-unmatched-resolutions.ts
+ *
+ * Conservative on purpose: anything ambiguous (multiple matches, name mismatch,
+ * non-7-digit LEAID, missing account) stays in the queue for manual admin review.
+ *
+ * Spec: Docs/superpowers/specs/2026-04-30-leaderboard-fy-attribution-fix-design.md
+ */
+import prisma from "@/lib/prisma";
+import {
+  lookupNcesByLmsId,
+  namesMatch,
+} from "./backfill-unmatched-resolutions-helpers";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface BackfillSummary {
+  candidates: number;
+  autoResolved: number;
+  deferred: number;
+  errors: number;
+  dryRun: boolean;
+}
+
+export interface CandidateRow {
+  id: string;
+  account_lms_id: string;
+  account_name: string;
+}
+
+export interface ResolutionDecision {
+  oppId: string;
+  accountName: string;
+  decision: "resolve" | "defer";
+  reason: string;
+  ncesId?: string;
+  matchedDistrictName?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Core logic
+// ---------------------------------------------------------------------------
+
+export async function backfillUnmatched(opts?: {
+  dryRun?: boolean;
+  logDecisions?: boolean;
+}): Promise<BackfillSummary> {
+  const dryRun = opts?.dryRun ?? process.env.DRY_RUN === "true";
+  const logDecisions = opts?.logDecisions ?? true;
+
+  const candidates = await prisma.$queryRaw<CandidateRow[]>`
+    SELECT id, account_lms_id, account_name
+    FROM unmatched_opportunities
+    WHERE resolved = false
+      AND account_lms_id IS NOT NULL
+      AND account_name IS NOT NULL
+  `;
+
+  const summary: BackfillSummary = {
+    candidates: candidates.length,
+    autoResolved: 0,
+    deferred: 0,
+    errors: 0,
+    dryRun,
+  };
+
+  const decisions: ResolutionDecision[] = [];
+
+  for (const row of candidates) {
+    try {
+      const district = await lookupNcesByLmsId(row.account_lms_id);
+
+      if (!district) {
+        decisions.push({
+          oppId: row.id,
+          accountName: row.account_name,
+          decision: "defer",
+          reason: "no district matched in OpenSearch or non-7-digit LEAID",
+        });
+        summary.deferred++;
+        continue;
+      }
+
+      if (!namesMatch(row.account_name, district.name)) {
+        decisions.push({
+          oppId: row.id,
+          accountName: row.account_name,
+          decision: "defer",
+          reason: `name mismatch: opp="${row.account_name}" district="${district.name}"`,
+          ncesId: district.ncesId,
+          matchedDistrictName: district.name,
+        });
+        summary.deferred++;
+        continue;
+      }
+
+      // Unambiguous match — auto-resolve.
+      decisions.push({
+        oppId: row.id,
+        accountName: row.account_name,
+        decision: "resolve",
+        reason: "exact name match",
+        ncesId: district.ncesId,
+        matchedDistrictName: district.name,
+      });
+
+      if (!dryRun) {
+        await prisma.$executeRaw`
+          UPDATE unmatched_opportunities
+          SET resolved = true,
+              resolved_district_leaid = ${district.ncesId},
+              resolved_at = now(),
+              resolved_by = 'backfill-2026-04-30'
+          WHERE id = ${row.id}
+        `;
+      }
+
+      summary.autoResolved++;
+    } catch (e) {
+      decisions.push({
+        oppId: row.id,
+        accountName: row.account_name,
+        decision: "defer",
+        reason: `error: ${(e as Error).message}`,
+      });
+      summary.errors++;
+    }
+  }
+
+  if (logDecisions) {
+    console.log(`\nBackfill summary (dryRun=${dryRun}):`, summary);
+    console.log(`Per-row decisions (first 50):`);
+    for (const d of decisions.slice(0, 50)) {
+      const districtSuffix = d.ncesId
+        ? ` (→ ${d.ncesId} "${d.matchedDistrictName}")`
+        : "";
+      console.log(
+        `  ${d.decision.toUpperCase()} ${d.oppId} "${d.accountName}" — ${d.reason}${districtSuffix}`
+      );
+    }
+    if (decisions.length > 50) {
+      console.log(`  ... and ${decisions.length - 50} more`);
+    }
+  }
+
+  return summary;
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+if (require.main === module) {
+  backfillUnmatched()
+    .then((s) => process.exit(s.errors > 0 ? 1 : 0))
+    .catch((e) => {
+      console.error(e);
+      process.exit(1);
+    });
+}

--- a/src/app/api/leaderboard/increase-targets/route.ts
+++ b/src/app/api/leaderboard/increase-targets/route.ts
@@ -128,7 +128,8 @@ export async function GET() {
           SUM(COALESCE(net_booking_amount, 0))::numeric AS bookings,
           SUM(COALESCE(minimum_purchase_amount, 0))::numeric AS min_commit
         FROM opportunities
-        WHERE school_yr='2025-26' AND stage ILIKE 'Closed Won%' AND district_lea_id IS NOT NULL
+        WHERE school_yr='2025-26' AND stage ILIKE 'Closed Won%'
+          AND district_lea_id IS NOT NULL AND district_lea_id != '_NOMAP'
         GROUP BY district_lea_id
         HAVING SUM(COALESCE(net_booking_amount,0))+SUM(COALESCE(minimum_purchase_amount,0)) > 0
       ),

--- a/src/features/leaderboard/components/RevenueTable.tsx
+++ b/src/features/leaderboard/components/RevenueTable.tsx
@@ -2,7 +2,7 @@
 
 import { ChevronDown, ChevronUp } from "lucide-react";
 import type { LeaderboardEntry } from "../lib/types";
-import { formatRevenue, getInitials } from "../lib/format";
+import { formatRevenue, formatCurrencyShort, getInitials } from "../lib/format";
 
 export type RevenueSortColumn = "revenue" | "priorYearRevenue" | "pipeline" | "revenueTargeted";
 
@@ -108,9 +108,18 @@ export default function RevenueTable({
                     </span>
                   </div>
                 )}
-                <span className="text-sm font-medium text-[#2D2440]">
+                <span className="text-sm font-medium text-[#2D2440] whitespace-nowrap">
                   {entry.fullName}
                 </span>
+                {entry.unmatchedOppCount > 0 && (
+                  <a
+                    href={`/admin/unmatched-opportunities?rep=${encodeURIComponent(entry.userId)}`}
+                    className="ml-1 inline-flex items-center rounded bg-[#EFEDF5] px-2 py-0.5 text-xs whitespace-nowrap text-[#544A78] hover:bg-[#E2DEEC]"
+                    title={`${entry.unmatchedOppCount} opportunit${entry.unmatchedOppCount === 1 ? "y" : "ies"} awaiting district resolution — totaling ${formatCurrencyShort(entry.unmatchedRevenue)}`}
+                  >
+                    {entry.unmatchedOppCount} unmatched · {formatCurrencyShort(entry.unmatchedRevenue)}
+                  </a>
+                )}
               </div>
             </td>
             {COLUMNS.map((col) => {

--- a/src/features/leaderboard/components/__tests__/RevenueTable.test.tsx
+++ b/src/features/leaderboard/components/__tests__/RevenueTable.test.tsx
@@ -70,6 +70,72 @@ describe("RevenueTable", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Unmatched-opp badge (Task 7)
+// ---------------------------------------------------------------------------
+
+describe("RevenueTable unmatched-opp badge", () => {
+  const noopSort = () => {};
+
+  it("renders the unmatched-opp badge when entry.unmatchedOppCount > 0", () => {
+    const entry = makeEntry({
+      fullName: "Dana Rep",
+      rank: 1,
+      unmatchedOppCount: 3,
+      unmatchedRevenue: 12500,
+    });
+    render(
+      <RevenueTable
+        entries={[entry]}
+        sortColumn="revenue"
+        sortDirection="desc"
+        onSort={noopSort}
+      />
+    );
+    expect(screen.getByText(/3 unmatched/i)).toBeInTheDocument();
+    // formatCurrencyShort(12500) → "$12.5K"
+    expect(screen.getByText(/\$12\.5K/i)).toBeInTheDocument();
+  });
+
+  it("hides the unmatched-opp badge when entry.unmatchedOppCount is 0", () => {
+    const entry = makeEntry({
+      fullName: "Even Rep",
+      rank: 1,
+      unmatchedOppCount: 0,
+      unmatchedRevenue: 0,
+    });
+    render(
+      <RevenueTable
+        entries={[entry]}
+        sortColumn="revenue"
+        sortDirection="desc"
+        onSort={noopSort}
+      />
+    );
+    expect(screen.queryByText(/unmatched/i)).toBeNull();
+  });
+
+  it("badge links to the admin unmatched-opportunities queue", () => {
+    const entry = makeEntry({
+      fullName: "Fran Rep",
+      rank: 1,
+      unmatchedOppCount: 5,
+      unmatchedRevenue: 25000,
+    });
+    render(
+      <RevenueTable
+        entries={[entry]}
+        sortColumn="revenue"
+        sortDirection="desc"
+        onSort={noopSort}
+      />
+    );
+    const badge = screen.getByText(/5 unmatched/i).closest("a");
+    expect(badge).not.toBeNull();
+    expect(badge?.getAttribute("href")).toContain("/admin/unmatched-opportunities");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Team totals footer (Tasks 5 + 6)
 // ---------------------------------------------------------------------------
 

--- a/src/features/leaderboard/lib/__tests__/fetch-leaderboard.test.ts
+++ b/src/features/leaderboard/lib/__tests__/fetch-leaderboard.test.ts
@@ -12,9 +12,16 @@ vi.mock("@/lib/opportunity-actuals", () => ({
   getRepActuals: vi.fn(),
 }));
 
+vi.mock("@/lib/unmatched-counts", () => ({
+  getUnmatchedCountsByRep: vi.fn(),
+}));
+
 import { fetchLeaderboardData } from "../fetch-leaderboard";
 import prisma from "@/lib/prisma";
 import { getRepActuals } from "@/lib/opportunity-actuals";
+import { getUnmatchedCountsByRep } from "@/lib/unmatched-counts";
+
+const mockGetUnmatchedCountsByRep = vi.mocked(getUnmatchedCountsByRep);
 
 const mockUserProfile = vi.mocked(prisma.userProfile.findMany);
 const mockTerritoryPlanDistrict = vi.mocked(prisma.territoryPlanDistrict.findMany);
@@ -26,6 +33,7 @@ describe("fetchLeaderboardData", () => {
     vi.resetAllMocks();
     mockTerritoryPlanDistrict.mockResolvedValue([]);
     mockQueryRaw.mockResolvedValue([]);
+    mockGetUnmatchedCountsByRep.mockResolvedValue(new Map());
   });
 
   it("sources roster from UserProfile (rep + manager), excludes admin", async () => {
@@ -115,5 +123,27 @@ describe("fetchLeaderboardData", () => {
     expect(payload.entries[0].userId).toBe("rep1");
     expect(payload.teamTotals.revenueCurrentFY).toBe(1099);
     expect(payload.teamTotals.unassignedRevenueCurrentFY).toBe(999);
+  });
+
+  it("populates unmatchedOppCount and unmatchedRevenue from getUnmatchedCountsByRep", async () => {
+    mockUserProfile.mockResolvedValue([
+      { id: "u1", fullName: "Alice", avatarUrl: null, email: "alice@x.com", role: "rep" },
+      { id: "u2", fullName: "Bob", avatarUrl: null, email: "bob@x.com", role: "rep" },
+    ] as never);
+    mockGetRepActuals.mockResolvedValue({
+      openPipeline: 0, totalTake: 0, totalRevenue: 0, minPurchaseBookings: 0,
+    } as never);
+    mockGetUnmatchedCountsByRep.mockResolvedValue(new Map([
+      ["alice@x.com", { count: 3, revenue: 12500 }],
+    ]));
+
+    const payload = await fetchLeaderboardData();
+
+    const alice = payload.entries.find((e) => e.userId === "u1")!;
+    const bob = payload.entries.find((e) => e.userId === "u2")!;
+    expect(alice.unmatchedOppCount).toBe(3);
+    expect(alice.unmatchedRevenue).toBe(12500);
+    expect(bob.unmatchedOppCount).toBe(0); // not in the map → defaults
+    expect(bob.unmatchedRevenue).toBe(0);
   });
 });

--- a/src/features/leaderboard/lib/fetch-leaderboard.ts
+++ b/src/features/leaderboard/lib/fetch-leaderboard.ts
@@ -1,5 +1,6 @@
 import prisma from "@/lib/prisma";
 import { getRepActuals } from "@/lib/opportunity-actuals";
+import { getUnmatchedCountsByRep } from "@/lib/unmatched-counts";
 import type { LeaderboardEntry } from "@/features/leaderboard/lib/types";
 
 export interface LeaderboardTeamTotals {
@@ -96,7 +97,7 @@ export async function fetchLeaderboardData(): Promise<LeaderboardPayload> {
   for (const p of profiles) emailByUserId.set(p.id, p.email);
   const rosterEmails = [...emailByUserId.values()];
 
-  const [targetedCurrentFYDistricts, targetedNextFYDistricts, pipelineRows] = await Promise.all([
+  const [targetedCurrentFYDistricts, targetedNextFYDistricts, pipelineRows, unmatchedByRep] = await Promise.all([
     prisma.territoryPlanDistrict.findMany({
       where: { plan: { ...ownerFilter, fiscalYear: currentFYInt } },
       select: {
@@ -125,6 +126,7 @@ export async function fetchLeaderboardData(): Promise<LeaderboardPayload> {
           GROUP BY sales_rep_email, district_lea_id, school_yr
           HAVING SUM(open_pipeline) > 0
         `,
+    getUnmatchedCountsByRep(rosterEmails),
   ]);
 
   const repPipelineMap = new Map<string, number>();
@@ -161,6 +163,7 @@ export async function fetchLeaderboardData(): Promise<LeaderboardPayload> {
     };
     const targetedCurrentFY = targetedCurrentFYByUser.get(profile.id) ?? 0;
     const targetedNextFY = targetedNextFYByUser.get(profile.id) ?? 0;
+    const unmatched = unmatchedByRep.get(profile.email) ?? { count: 0, revenue: 0 };
     return {
       userId: profile.id,
       fullName: profile.fullName ?? "Unknown",
@@ -179,6 +182,8 @@ export async function fetchLeaderboardData(): Promise<LeaderboardPayload> {
       revenueTargeted: targetedCurrentFY + targetedNextFY,
       targetedCurrentFY,
       targetedNextFY,
+      unmatchedOppCount: unmatched.count,
+      unmatchedRevenue: unmatched.revenue,
     };
   });
 

--- a/src/features/leaderboard/lib/fetch-leaderboard.ts
+++ b/src/features/leaderboard/lib/fetch-leaderboard.ts
@@ -121,6 +121,7 @@ export async function fetchLeaderboardData(): Promise<LeaderboardPayload> {
           FROM district_opportunity_actuals
           WHERE sales_rep_email = ANY(${rosterEmails})
             AND school_yr IN (${defaultSchoolYr}, ${nextFYSchoolYr})
+            AND district_lea_id != '_NOMAP'
           GROUP BY sales_rep_email, district_lea_id, school_yr
           HAVING SUM(open_pipeline) > 0
         `,

--- a/src/features/leaderboard/lib/types.ts
+++ b/src/features/leaderboard/lib/types.ts
@@ -20,6 +20,10 @@ export interface LeaderboardEntry {
   revenueTargeted: number;
   targetedCurrentFY: number;
   targetedNextFY: number;
+  // Unmatched-district opps for this rep (sourced from unmatched_opportunities).
+  // Renders the per-rep "N unmatched · $X" badge that links to the admin queue.
+  unmatchedOppCount: number;
+  unmatchedRevenue: number;
 }
 
 export interface RevenueRankResponse {

--- a/src/lib/__tests__/opportunity-actuals.test.ts
+++ b/src/lib/__tests__/opportunity-actuals.test.ts
@@ -20,7 +20,7 @@ import {
 const mockPrisma = vi.mocked(prisma) as any;
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  vi.resetAllMocks();
 });
 
 describe("fiscalYearToSchoolYear", () => {

--- a/src/lib/__tests__/opportunity-actuals.test.ts
+++ b/src/lib/__tests__/opportunity-actuals.test.ts
@@ -87,24 +87,67 @@ describe("getDistrictActuals", () => {
 });
 
 describe("getRepActuals", () => {
-  it("returns rep-scoped aggregated actuals for a school year", async () => {
-    mockPrisma.$queryRaw.mockResolvedValue([
-      {
-        total_revenue: 200000,
-        total_take: 45000,
-        completed_take: 30000,
-        scheduled_take: 15000,
-        weighted_pipeline: 150000,
-        bookings: 180000,
-        invoiced: 160000,
-      },
-    ]);
+  it("sums session revenue (from rep_session_actuals) + sub revenue (from district_opportunity_actuals)", async () => {
+    // First call: rep_session_actuals — session_revenue
+    // Second call: district_opportunity_actuals — sub_revenue + everything else
+    mockPrisma.$queryRaw
+      .mockResolvedValueOnce([{ session_revenue: 100000 }])
+      .mockResolvedValueOnce([
+        {
+          sub_revenue: 25000,
+          total_take: 30000,
+          completed_take: 25000,
+          scheduled_take: 5000,
+          weighted_pipeline: 50000,
+          open_pipeline: 80000,
+          bookings: 200000,
+          min_purchase_bookings: 150000,
+          invoiced: 90000,
+        },
+      ]);
 
-    const result = await getRepActuals("rep@example.com", "2025-26");
-    expect(result.totalRevenue).toBe(200000);
-    expect(result.totalTake).toBe(45000);
-    expect(result.completedTake).toBe(30000);
-    expect(result.scheduledTake).toBe(15000);
+    const actuals = await getRepActuals("rep@example.com", "2025-26");
+
+    expect(actuals.totalRevenue).toBe(125000); // 100k sessions + 25k subs
+    expect(actuals.totalTake).toBe(30000);
+    expect(actuals.openPipeline).toBe(80000);
+    expect(actuals.minPurchaseBookings).toBe(150000);
+    expect(mockPrisma.$queryRaw).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns zeros when both queries come back empty", async () => {
+    mockPrisma.$queryRaw
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+
+    const actuals = await getRepActuals("rep@example.com", "2025-26");
+
+    expect(actuals.totalRevenue).toBe(0);
+    expect(actuals.totalTake).toBe(0);
+    expect(actuals.openPipeline).toBe(0);
+  });
+
+  it("makes exactly 2 DB calls and session-only revenue comes from first call", async () => {
+    // Verify the two-query wiring: session revenue query (call 1) is independent
+    // from the opp actuals query (call 2). We confirm this by checking that:
+    // - exactly 2 calls are made (Promise.all fires both)
+    // - session_revenue = 50k, sub_revenue = 0 → totalRevenue = 50k (not 0)
+    mockPrisma.$queryRaw
+      .mockResolvedValueOnce([{ session_revenue: 50000 }])
+      .mockResolvedValueOnce([{
+        sub_revenue: 0, total_take: 0, completed_take: 0, scheduled_take: 0,
+        weighted_pipeline: 0, open_pipeline: 0, bookings: 0,
+        min_purchase_bookings: 0, invoiced: 0,
+      }]);
+
+    const actuals = await getRepActuals("rep@example.com", "2025-26");
+
+    expect(mockPrisma.$queryRaw).toHaveBeenCalledTimes(2);
+    // Only session revenue contributes (sub_revenue = 0)
+    expect(actuals.totalRevenue).toBe(50000);
+    // No opp actuals → all other fields are 0
+    expect(actuals.totalTake).toBe(0);
+    expect(actuals.bookings).toBe(0);
   });
 });
 

--- a/src/lib/__tests__/unmatched-counts.test.ts
+++ b/src/lib/__tests__/unmatched-counts.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/prisma", () => ({
+  default: { $queryRaw: vi.fn() },
+}));
+
+import prisma from "@/lib/prisma";
+import { getUnmatchedCountsByRep } from "@/lib/unmatched-counts";
+
+const mockQueryRaw = vi.mocked(prisma.$queryRaw);
+
+describe("getUnmatchedCountsByRep", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("groups unresolved unmatched opps by sales_rep_email", async () => {
+    mockQueryRaw.mockResolvedValue([
+      { sales_rep_email: "alice@x.com", unmatched_count: 3, unmatched_revenue: 12500 },
+      { sales_rep_email: "bob@x.com", unmatched_count: 1, unmatched_revenue: 7000 },
+    ] as never);
+
+    const result = await getUnmatchedCountsByRep(["alice@x.com", "bob@x.com", "carol@x.com"]);
+
+    expect(result.size).toBe(2);
+    expect(result.get("alice@x.com")).toEqual({ count: 3, revenue: 12500 });
+    expect(result.get("bob@x.com")).toEqual({ count: 1, revenue: 7000 });
+    expect(result.get("carol@x.com")).toBeUndefined();
+  });
+
+  it("short-circuits when given an empty rep list", async () => {
+    const result = await getUnmatchedCountsByRep([]);
+    expect(result.size).toBe(0);
+    expect(mockQueryRaw).not.toHaveBeenCalled();
+  });
+
+  it("coerces numeric DB values to plain numbers", async () => {
+    // Postgres COUNT(*)::int and SUM()::float can come back as bigints/strings via Prisma raw
+    mockQueryRaw.mockResolvedValue([
+      { sales_rep_email: "alice@x.com", unmatched_count: 3 as unknown as number, unmatched_revenue: "12500" as unknown as number },
+    ] as never);
+
+    const result = await getUnmatchedCountsByRep(["alice@x.com"]);
+    const a = result.get("alice@x.com")!;
+    expect(typeof a.count).toBe("number");
+    expect(typeof a.revenue).toBe("number");
+    expect(a.count).toBe(3);
+    expect(a.revenue).toBe(12500);
+  });
+});

--- a/src/lib/opportunity-actuals.ts
+++ b/src/lib/opportunity-actuals.ts
@@ -151,68 +151,99 @@ export interface RepActuals {
 
 /**
  * Get rep-scoped aggregated actuals across all districts for a school year.
- * Used by the goals dashboard.
+ * Used by the goals dashboard and leaderboard.
+ *
+ * totalRevenue = session_revenue (bucketed by session_fy(start_time)) +
+ *                sub_revenue (subscriptions only, bucketed by opp.school_yr).
+ * All other fields come from district_opportunity_actuals (opp.school_yr semantics).
+ *
+ * See spec: Docs/superpowers/specs/2026-04-30-leaderboard-fy-attribution-fix-design.md
  */
 export async function getRepActuals(
   salesRepEmail: string,
   schoolYr: string
 ): Promise<RepActuals> {
-  const rows = await safeQueryRaw(
-    prisma.$queryRaw<
-      {
-        total_revenue: number;
-        total_take: number;
-        completed_take: number;
-        scheduled_take: number;
-        weighted_pipeline: number;
-        open_pipeline: number;
-        bookings: number;
-        min_purchase_bookings: number;
-        invoiced: number;
-      }[]
-    >`
-      SELECT
-        COALESCE(SUM(total_revenue), 0) AS total_revenue,
-        COALESCE(SUM(total_take), 0) AS total_take,
-        COALESCE(SUM(completed_take), 0) AS completed_take,
-        COALESCE(SUM(scheduled_take), 0) AS scheduled_take,
-        COALESCE(SUM(weighted_pipeline), 0) AS weighted_pipeline,
-        COALESCE(SUM(open_pipeline), 0) AS open_pipeline,
-        COALESCE(SUM(bookings), 0) AS bookings,
-        COALESCE(SUM(min_purchase_bookings), 0) AS min_purchase_bookings,
-        COALESCE(SUM(invoiced), 0) AS invoiced
-      FROM district_opportunity_actuals
-      WHERE sales_rep_email = ${salesRepEmail}
-        AND school_yr = ${schoolYr}
-    `,
-    []
-  );
+  // Sessions are bucketed by session.start_time → session_fy() → school_yr.
+  // Subscriptions, pipeline, take, bookings, min purchases continue to be
+  // bucketed by opp.school_yr per the existing semantics. The two streams
+  // share the same `school_yr` arg name but are sourced differently.
+  const [sessionRows, subAndOtherRows] = await Promise.all([
+    safeQueryRaw(
+      prisma.$queryRaw<{ session_revenue: number }[]>`
+        SELECT COALESCE(SUM(session_revenue), 0) AS session_revenue
+        FROM rep_session_actuals
+        WHERE sales_rep_email = ${salesRepEmail}
+          AND school_yr = ${schoolYr}
+      `,
+      [{ session_revenue: 0 }]
+    ),
+    safeQueryRaw(
+      prisma.$queryRaw<
+        {
+          sub_revenue: number;
+          total_take: number;
+          completed_take: number;
+          scheduled_take: number;
+          weighted_pipeline: number;
+          open_pipeline: number;
+          bookings: number;
+          min_purchase_bookings: number;
+          invoiced: number;
+        }[]
+      >`
+        SELECT
+          COALESCE(SUM(sub_revenue), 0) AS sub_revenue,
+          COALESCE(SUM(total_take), 0) AS total_take,
+          COALESCE(SUM(completed_take), 0) AS completed_take,
+          COALESCE(SUM(scheduled_take), 0) AS scheduled_take,
+          COALESCE(SUM(weighted_pipeline), 0) AS weighted_pipeline,
+          COALESCE(SUM(open_pipeline), 0) AS open_pipeline,
+          COALESCE(SUM(bookings), 0) AS bookings,
+          COALESCE(SUM(min_purchase_bookings), 0) AS min_purchase_bookings,
+          COALESCE(SUM(invoiced), 0) AS invoiced
+        FROM district_opportunity_actuals
+        WHERE sales_rep_email = ${salesRepEmail}
+          AND school_yr = ${schoolYr}
+      `,
+      [
+        {
+          sub_revenue: 0,
+          total_take: 0,
+          completed_take: 0,
+          scheduled_take: 0,
+          weighted_pipeline: 0,
+          open_pipeline: 0,
+          bookings: 0,
+          min_purchase_bookings: 0,
+          invoiced: 0,
+        },
+      ]
+    ),
+  ]);
 
-  if (rows.length === 0) {
-    return {
-      totalRevenue: 0,
-      totalTake: 0,
-      completedTake: 0,
-      scheduledTake: 0,
-      weightedPipeline: 0,
-      openPipeline: 0,
-      bookings: 0,
-      minPurchaseBookings: 0,
-      invoiced: 0,
-    };
-  }
+  const sessionRevenue = Number(sessionRows[0]?.session_revenue ?? 0);
+  const r = subAndOtherRows[0] ?? {
+    sub_revenue: 0,
+    total_take: 0,
+    completed_take: 0,
+    scheduled_take: 0,
+    weighted_pipeline: 0,
+    open_pipeline: 0,
+    bookings: 0,
+    min_purchase_bookings: 0,
+    invoiced: 0,
+  };
 
-  const row = rows[0];
   return {
-    totalRevenue: Number(row.total_revenue),
-    totalTake: Number(row.total_take),
-    completedTake: Number(row.completed_take),
-    scheduledTake: Number(row.scheduled_take),
-    weightedPipeline: Number(row.weighted_pipeline),
-    openPipeline: Number(row.open_pipeline),
-    bookings: Number(row.bookings),
-    minPurchaseBookings: Number(row.min_purchase_bookings),
-    invoiced: Number(row.invoiced),
+    totalRevenue: sessionRevenue + Number(r.sub_revenue),
+    totalTake: Number(r.total_take),
+    completedTake: Number(r.completed_take),
+    scheduledTake: Number(r.scheduled_take),
+    weightedPipeline: Number(r.weighted_pipeline),
+    openPipeline: Number(r.open_pipeline),
+    bookings: Number(r.bookings),
+    minPurchaseBookings: Number(r.min_purchase_bookings),
+    invoiced: Number(r.invoiced),
   };
 }
 

--- a/src/lib/unmatched-counts.ts
+++ b/src/lib/unmatched-counts.ts
@@ -1,0 +1,46 @@
+import prisma from "@/lib/prisma";
+
+export interface UnmatchedSummary {
+  count: number;
+  revenue: number;
+}
+
+/**
+ * Count + sum-revenue of unresolved unmatched_opportunities, grouped by sales rep.
+ * Joins to the opportunities table by id to pick up the rep email and total_revenue
+ * (unmatched_opportunities itself doesn't carry rep attribution).
+ *
+ * Returns an empty Map for an empty input list — never queries the DB in that case.
+ *
+ * Used by the leaderboard to surface a per-rep badge linking to the admin
+ * unmatched-resolution queue. See:
+ * Docs/superpowers/specs/2026-04-30-leaderboard-fy-attribution-fix-design.md
+ */
+export async function getUnmatchedCountsByRep(
+  repEmails: string[]
+): Promise<Map<string, UnmatchedSummary>> {
+  if (repEmails.length === 0) return new Map();
+
+  const rows = await prisma.$queryRaw<
+    { sales_rep_email: string; unmatched_count: number; unmatched_revenue: number }[]
+  >`
+    SELECT
+      o.sales_rep_email,
+      COUNT(*)::int AS unmatched_count,
+      COALESCE(SUM(o.total_revenue), 0)::float AS unmatched_revenue
+    FROM unmatched_opportunities u
+    JOIN opportunities o ON o.id = u.id
+    WHERE u.resolved = false
+      AND o.sales_rep_email = ANY(${repEmails})
+    GROUP BY o.sales_rep_email
+  `;
+
+  const map = new Map<string, UnmatchedSummary>();
+  for (const row of rows) {
+    map.set(row.sales_rep_email, {
+      count: Number(row.unmatched_count),
+      revenue: Number(row.unmatched_revenue),
+    });
+  }
+  return map;
+}


### PR DESCRIPTION
## Summary

Closes the gap between es-bi's FY26 leaderboard and territory-plan's. For Monica specifically: leaderboard total moves from **\$1,961,724 → \$3,285,762** — exact match with OpenSearch truth.

Three independent fixes, plus one critical sync bug discovered along the way:

- **Re-bucket session revenue by `session.start_time`** instead of `opp.school_yr`. Multi-year contracts and renewals tagged for one fiscal year that produce sessions in another fiscal year now land in the right bucket. `getRepActuals()` reads `rep_session_actuals` (sessions, by date) and sums in `district_opportunity_actuals.sub_revenue` (subscriptions, by tag).
- **`_NOMAP` sentinel for unmatched-district opps**. The matview previously dropped opps with `district_lea_id IS NULL` (queued for admin resolution). Now they aggregate under `'_NOMAP'` and contribute to the rep's total. Two consumers got defensive `WHERE district_lea_id != '_NOMAP'` filters.
- **Daily 04:00 UTC current-FY backfill** in the scheduler. Hourly sync's incremental path can miss sessions whose `lastIndexedAt` doesn't advance; the daily backfill re-fetches every opp in current+prior FY unconditionally.
- **`scroll_all` switched from `search_after` to legacy scroll API**. Diagnosed in this PR: under concurrent index writes, `search_after` was silently dropping ~22% of session records (verified: 17,382 sessions in OS vs 13,597 in Supabase, evenly across all statuses). Legacy scroll uses a server-side cursor that's stable. This was the residual bug that kept Monica's number short until the very end.

Plus: leaderboard payload + UI gain a per-rep \"N unmatched · \$X\" badge linking to `/admin/unmatched-opportunities`. One-time backfill script for unmatched-opp queue (committed but not run — current data has 0 candidates that pass the conservative auto-resolution guard).

Spec: \`Docs/superpowers/specs/2026-04-30-leaderboard-fy-attribution-fix-design.md\`
Plan: \`Docs/superpowers/plans/2026-04-30-leaderboard-fy-attribution-fix.md\`

## Migrations applied to prod Supabase already

(via Supabase MCP \`apply_migration\`, before this PR is merged)

- \`2026-04-30_session_fy_function.sql\` — \`session_fy(timestamptz) → text\`
- \`2026-04-30_rep_session_actuals_view.sql\` — new view
- \`2026-04-30_doa_expose_sub_revenue.sql\` — adds \`sub_revenue\` column on existing matview
- \`2026-04-30_doa_nomap_sentinel.sql\` — drops \`WHERE district_lea_id IS NOT NULL\`, COALESCEs to \`'_NOMAP'\`

The \`scripts/district-opportunity-actuals-view.sql\` source-of-truth file matches.

## Test plan

- [ ] Verify leaderboard for Monica shows ~\$3.29M FY26 (was ~\$1.96M)
- [ ] Spot-check at least one other rep's leaderboard moves in the right direction (sessions by date should be additive for most reps)
- [ ] Confirm district detail pages still work correctly (they filter by specific LEAID, naturally exclude \`_NOMAP\`)
- [ ] Confirm the unmatched-opp badge renders next to reps with pending queue items, hides when count is 0
- [ ] After merge: run scheduler smoke test (hourly cycle still works, no regression)
- [ ] After 24 hours post-deploy: verify the 04:00 UTC daily backfill ran cleanly
- [ ] Open follow-up: patch es-bi leaderboard query to also exclude \`doNotBill=true\` (separate repo)

## Out of scope

- Subscription FY attribution stays tag-based (Choice A in spec)
- es-bi report's missing \`doNotBill\` filter — separate fix in \`Fullmind LMS/es-bi\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)