### PR TITLE
feat(district-card): plan membership owner display + click-to-open plan

### DIFF
--- a/Docs/superpowers/plans/2026-05-01-plan-membership-click-to-open.md
+++ b/Docs/superpowers/plans/2026-05-01-plan-membership-click-to-open.md
@@ -1,0 +1,210 @@
+# Plan Membership Click-to-Open — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Clicking a plan row in the Plan Membership section closes the district card modal and opens PlanWorkspace for that plan.
+
+**Architecture:** Two small changes in `DistrictExploreModal.tsx`: thread `onClose` into `FullmindTab` as a prop, and inside `FullmindTab` pull `viewPlan` from the Zustand store (`useMapV2Store`) then make each plan row a `button` that calls `onClose(); viewPlan(plan.id)`. No new files, no API changes.
+
+**Tech Stack:** React 19, TypeScript, Tailwind 4, Zustand (`useMapV2Store`)
+
+---
+
+### Task 1: Make plan membership rows clickable
+
+**Files:**
+- Modify: `src/features/map/components/SearchResults/DistrictExploreModal.tsx`
+- Test: `src/features/map/components/SearchResults/__tests__/DistrictExploreModal.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+  At the top of `DistrictExploreModal.test.tsx`, add two module-level spy variables and a store mock. Insert these **before** the existing `vi.mock("@/features/districts/lib/queries", ...)` line:
+
+  ```tsx
+  import { fireEvent } from "@testing-library/react";
+
+  const mockViewPlan = vi.fn();
+  const mockOnClose = vi.fn();
+
+  vi.mock("@/features/map/lib/store", () => ({
+    useMapV2Store: Object.assign(
+      vi.fn((selector: (s: any) => any) =>
+        selector({ exploreModalVacancyId: null, viewPlan: mockViewPlan })
+      ),
+      { getState: () => ({ exploreModalVacancyId: null }) }
+    ),
+  }));
+  ```
+
+  > `Object.assign` gives the mock both hook-selector behaviour (`useMapV2Store(s => s.viewPlan)`) and the static `.getState()` call already in the component at line 369.
+
+  Update the existing top-level `beforeEach` to also reset the spies:
+  ```tsx
+  beforeEach(() => {
+    vi.mocked(libApi.useTerritoryPlans).mockReturnValue({
+      data: [
+        {
+          id: "plan-1",
+          name: "Kleist Renewal",
+          color: "#7C3AED",
+          status: "working",
+          owner: { id: "user-1", fullName: "Sierra Arcega", avatarUrl: null },
+          description: null,
+          fiscalYear: 2026,
+        },
+      ],
+    } as any);
+    mockViewPlan.mockReset();
+    mockOnClose.mockReset();
+  });
+  ```
+
+  Then add this describe block at the bottom of the file:
+
+  ```tsx
+  describe("DistrictExploreModal — plan membership navigation", () => {
+    it("calls onClose and viewPlan with the plan id when a plan row is clicked", () => {
+      const { container } = renderWithClient(
+        <DistrictExploreModal leaid="1234567" onClose={mockOnClose} />
+      );
+      const planButton = container.querySelector("button[data-plan-id='plan-1']");
+      expect(planButton).not.toBeNull();
+      fireEvent.click(planButton!);
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+      expect(mockViewPlan).toHaveBeenCalledWith("plan-1");
+    });
+  });
+  ```
+
+  > The `data-plan-id` attribute is added in Step 3 to make the button selectable in tests.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+  ```bash
+  npm test -- DistrictExploreModal --run
+  ```
+
+  Expected: FAIL — `button[data-plan-id='plan-1']` not found.
+
+- [ ] **Step 3: Add `onClose` prop to `FullmindTab` and make rows clickable**
+
+  **3a — Thread `onClose` into the `FullmindTab` call site (line ~340):**
+
+  Find:
+  ```tsx
+  <FullmindTab
+    fullmindData={fullmindData ?? null}
+    tags={tags}
+    territoryPlanIds={territoryPlanIds}
+    plans={plans || []}
+    activities={activitiesData?.activities || []}
+  />
+  ```
+
+  Replace with:
+  ```tsx
+  <FullmindTab
+    fullmindData={fullmindData ?? null}
+    tags={tags}
+    territoryPlanIds={territoryPlanIds}
+    plans={plans || []}
+    activities={activitiesData?.activities || []}
+    onClose={onClose}
+  />
+  ```
+
+  **3b — Update `FullmindTab` props interface and add `viewPlan` (line ~456):**
+
+  Find:
+  ```tsx
+  function FullmindTab({
+    fullmindData,
+    tags,
+    territoryPlanIds,
+    plans,
+    activities,
+  }: {
+    fullmindData: FullmindData | null;
+    tags: Tag[];
+    territoryPlanIds: string[];
+    plans: TerritoryPlan[];
+    activities: ActivityListItem[];
+  }) {
+    const fmtMoney = (n: number) => (n > 0 ? `$${n.toLocaleString()}` : "—");
+    const memberPlans = plans.filter((p) => territoryPlanIds.includes(p.id));
+  ```
+
+  Replace with:
+  ```tsx
+  function FullmindTab({
+    fullmindData,
+    tags,
+    territoryPlanIds,
+    plans,
+    activities,
+    onClose,
+  }: {
+    fullmindData: FullmindData | null;
+    tags: Tag[];
+    territoryPlanIds: string[];
+    plans: TerritoryPlan[];
+    activities: ActivityListItem[];
+    onClose: () => void;
+  }) {
+    const viewPlan = useMapV2Store((s) => s.viewPlan);
+    const fmtMoney = (n: number) => (n > 0 ? `$${n.toLocaleString()}` : "—");
+    const memberPlans = plans.filter((p) => territoryPlanIds.includes(p.id));
+  ```
+
+  **3c — Change plan membership row `div` to `button` (line ~513):**
+
+  Find:
+  ```tsx
+  {memberPlans.map((plan) => (
+    <div key={plan.id} className="flex items-center gap-2.5 py-1.5 overflow-hidden">
+      <span className="w-2.5 h-2.5 rounded-full shrink-0" style={{ backgroundColor: plan.color }} />
+      <span className="text-sm font-medium text-[#544A78] whitespace-nowrap">{plan.name}</span>
+      <span className="text-[11px] text-[#A69DC0] capitalize whitespace-nowrap">{plan.status}</span>
+      {plan.owner?.fullName && (
+        <span className="text-[11px] text-[#A69DC0] truncate min-w-0">· {plan.owner.fullName}</span>
+      )}
+    </div>
+  ))}
+  ```
+
+  Replace with:
+  ```tsx
+  {memberPlans.map((plan) => (
+    <button
+      key={plan.id}
+      data-plan-id={plan.id}
+      onClick={() => { onClose(); viewPlan(plan.id); }}
+      className="w-full text-left flex items-center gap-2.5 py-1.5 overflow-hidden cursor-pointer rounded hover:bg-[#F7F5FA] transition-colors"
+    >
+      <span className="w-2.5 h-2.5 rounded-full shrink-0" style={{ backgroundColor: plan.color }} />
+      <span className="text-sm font-medium text-[#544A78] whitespace-nowrap">{plan.name}</span>
+      <span className="text-[11px] text-[#A69DC0] capitalize whitespace-nowrap">{plan.status}</span>
+      {plan.owner?.fullName && (
+        <span className="text-[11px] text-[#A69DC0] truncate min-w-0">· {plan.owner.fullName}</span>
+      )}
+    </button>
+  ))}
+  ```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+  ```bash
+  npm test -- DistrictExploreModal --run
+  ```
+
+  Expected: All 5 tests PASS (2 responsive sizing + 2 plan membership owner + 1 plan membership navigation).
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add src/features/map/components/SearchResults/DistrictExploreModal.tsx
+  git add src/features/map/components/SearchResults/__tests__/DistrictExploreModal.test.tsx
+  git commit -m "feat(district-card): clicking a plan in Plan Membership opens PlanWorkspace"
+  ```
+
+  Include `Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>` in the commit message.

--- a/Docs/superpowers/plans/2026-05-01-plan-membership-owner-display.md
+++ b/Docs/superpowers/plans/2026-05-01-plan-membership-owner-display.md
@@ -1,0 +1,141 @@
+# Plan Membership Owner Display — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show the plan owner's name in the Plan Membership section of the district card's Fullmind tab, displayed inline after the status as `· Owner Name`.
+
+**Architecture:** Single display-only change in `DistrictExploreModal.tsx`. Owner data is already present in the `TerritoryPlan` type returned by `useTerritoryPlans()` — no API or schema changes required. The owner segment is `truncate` so it absorbs width squeeze; name and status are `whitespace-nowrap` so they never break.
+
+**Tech Stack:** React 19, TypeScript, Tailwind 4
+
+---
+
+### Task 1: Add owner display to Plan Membership row
+
+**Files:**
+- Modify: `src/features/map/components/SearchResults/DistrictExploreModal.tsx:513-519`
+- Test: `src/features/map/components/SearchResults/__tests__/DistrictExploreModal.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+  Add a new `describe` block at the bottom of `DistrictExploreModal.test.tsx`:
+
+  ```tsx
+  import { screen } from "@testing-library/react";
+
+  // Add to the top-level vi.mock for @/lib/api — replace the existing mock:
+  vi.mock("@/lib/api", () => ({
+    useTerritoryPlans: () => ({
+      data: [
+        {
+          id: "plan-1",
+          name: "Kleist Renewal",
+          color: "#7C3AED",
+          status: "working",
+          owner: { id: "user-1", fullName: "Sierra Arcega", avatarUrl: null },
+          description: null,
+          fiscalYear: 2026,
+        },
+      ],
+    }),
+    useAddDistrictsToPlan: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  }));
+  ```
+
+  Then add this describe block after the existing ones:
+
+  ```tsx
+  describe("DistrictExploreModal — plan membership owner", () => {
+    it("shows plan owner name after a dot separator when owner exists", () => {
+      const { container } = renderWithClient(
+        <DistrictExploreModal leaid="1234567" onClose={vi.fn()} />
+      );
+      expect(container.textContent).toContain("· Sierra Arcega");
+    });
+
+    it("does not render a dot separator when owner is null", () => {
+      // Override for this test only — rendered via inline mock override isn't possible;
+      // owner null case is handled by conditional rendering (no span rendered).
+      // Verified via the conditional in the component: plan.owner?.fullName
+    });
+  });
+  ```
+
+  > Note: The `useDistrictDetail` mock returns `null` / loading, so `memberPlans` will be empty. To test the Plan Membership row renders, you'll need to also mock `useDistrictDetail` to return `territoryPlanIds: ["plan-1"]`. Update the mock at the top of the file:
+
+  ```tsx
+  vi.mock("@/features/districts/lib/queries", () => ({
+    useDistrictDetail: () => ({
+      data: {
+        leaid: "1234567",
+        name: "Test District",
+        territoryPlanIds: ["plan-1"],
+        state: "LA",
+        pipeline: {},
+        activities: [],
+      },
+      isLoading: false,
+    }),
+  }));
+  ```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+  ```bash
+  npm test -- DistrictExploreModal --run
+  ```
+
+  Expected: FAIL — `· Sierra Arcega` not found in rendered output.
+
+- [ ] **Step 3: Update the plan membership row in DistrictExploreModal.tsx**
+
+  Find lines 513–519 (the `memberPlans.map` block):
+
+  ```tsx
+  {memberPlans.map((plan) => (
+    <div key={plan.id} className="flex items-center gap-2.5 py-1.5">
+      <span className="w-2.5 h-2.5 rounded-full shrink-0" style={{ backgroundColor: plan.color }} />
+      <span className="text-sm font-medium text-[#544A78]">{plan.name}</span>
+      <span className="text-[11px] text-[#A69DC0] capitalize">{plan.status}</span>
+    </div>
+  ))}
+  ```
+
+  Replace with:
+
+  ```tsx
+  {memberPlans.map((plan) => (
+    <div key={plan.id} className="flex items-center gap-2.5 py-1.5 overflow-hidden">
+      <span className="w-2.5 h-2.5 rounded-full shrink-0" style={{ backgroundColor: plan.color }} />
+      <span className="text-sm font-medium text-[#544A78] whitespace-nowrap">{plan.name}</span>
+      <span className="text-[11px] text-[#A69DC0] capitalize whitespace-nowrap">{plan.status}</span>
+      {plan.owner?.fullName && (
+        <span className="text-[11px] text-[#A69DC0] truncate min-w-0">· {plan.owner.fullName}</span>
+      )}
+    </div>
+  ))}
+  ```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+  ```bash
+  npm test -- DistrictExploreModal --run
+  ```
+
+  Expected: All tests PASS.
+
+- [ ] **Step 5: Verify visually**
+
+  Start the dev server if not running:
+  ```bash
+  npm run dev
+  ```
+  Open the app at `http://localhost:3005`, click a district that belongs to a plan, open the Fullmind tab, and confirm the Plan Membership row shows `● Plan Name  Working · Owner Name`.
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git add src/features/map/components/SearchResults/DistrictExploreModal.tsx
+  git add src/features/map/components/SearchResults/__tests__/DistrictExploreModal.test.tsx
+  git commit -m "feat(district-card): show plan owner in Plan Membership section"
+  ```

--- a/Docs/superpowers/specs/2026-05-01-plan-membership-click-to-open-design.md
+++ b/Docs/superpowers/specs/2026-05-01-plan-membership-click-to-open-design.md
@@ -1,0 +1,35 @@
+# Plan Membership Click-to-Open Design
+
+**Date:** 2026-05-01  
+**Status:** Approved
+
+## Summary
+
+Clicking a plan row in the Plan Membership section of the district card's Fullmind tab closes the district card and opens the PlanWorkspace for that plan.
+
+## Behavior
+
+- Entire plan row is clickable (not just the name)
+- On click: `onClose()` then `viewPlan(plan.id)`
+- District modal closes first, then PlanWorkspace opens — same sequence used in `PlanDistrictsTab`
+
+## Visual Treatment
+
+Row `div` becomes a `button` element:
+- `w-full text-left flex items-center gap-2.5 py-1.5 overflow-hidden cursor-pointer rounded hover:bg-[#F7F5FA] transition-colors`
+- No other visual changes — color dot, plan name, status, and owner display unchanged
+
+## Component Changes
+
+**`FullmindTab` (in `DistrictExploreModal.tsx`):**
+- Add `onClose: () => void` prop
+- Pull `viewPlan` from Zustand store: `const viewPlan = useMapStore((s) => s.viewPlan)`
+- Change plan membership row `div` → `button` with `onClick={() => { onClose(); viewPlan(plan.id); }}`
+
+**`DistrictExploreModal` (same file):**
+- Thread `onClose` into the `<FullmindTab ... onClose={onClose} />` call
+- `onClose` is already available in scope at the call site (line 340)
+
+## Scope
+
+Two small changes in one file (`DistrictExploreModal.tsx`), no API or schema changes.

--- a/Docs/superpowers/specs/2026-05-01-plan-membership-owner-display-design.md
+++ b/Docs/superpowers/specs/2026-05-01-plan-membership-owner-display-design.md
@@ -1,0 +1,45 @@
+# Plan Membership Owner Display
+
+**Date:** 2026-05-01  
+**Status:** Approved
+
+## Summary
+
+Add plan owner visibility to the Plan Membership section in the district card's Fullmind tab. Currently each row shows a color dot, plan name, and status. This change appends the owner's full name after a `·` separator.
+
+## Current Behavior
+
+```
+● Kleist Renewal   Working
+```
+
+## Target Behavior
+
+```
+● Kleist Renewal   Working · Sierra Arcega
+```
+
+Owner is omitted (not shown as blank) when `plan.owner` is null.
+
+## Data
+
+Owner data is already fetched. `useTerritoryPlans()` returns `TerritoryPlan[]` where each plan includes `owner: { id, fullName, avatarUrl } | null`. No API or schema changes needed.
+
+## Component Change
+
+**File:** `src/features/map/components/SearchResults/DistrictExploreModal.tsx` (lines 513–519)
+
+Update the plan membership row to:
+
+- `plan.name` — `text-sm font-medium text-[#544A78] whitespace-nowrap`
+- `plan.status` — `text-[11px] text-[#A69DC0] capitalize whitespace-nowrap`
+- `· {plan.owner.fullName}` — `text-[11px] text-[#A69DC0] truncate` (rendered only when owner exists)
+- Row container gains `overflow-hidden` so the owner name absorbs any width squeeze
+
+## Narrow-Width Resilience
+
+Name and status are `whitespace-nowrap` — they never break. The owner segment is `truncate` with `min-w-0` ancestry, so it clips cleanly when the card is narrow.
+
+## Scope
+
+Single component, display-only. No API changes, no schema changes, no new queries.

--- a/src/features/map/components/SearchResults/DistrictExploreModal.tsx
+++ b/src/features/map/components/SearchResults/DistrictExploreModal.tsx
@@ -511,10 +511,13 @@ function FullmindTab({
           <SectionLabel>Plan Membership</SectionLabel>
           <div className="flex flex-col gap-1.5">
             {memberPlans.map((plan) => (
-              <div key={plan.id} className="flex items-center gap-2.5 py-1.5">
+              <div key={plan.id} className="flex items-center gap-2.5 py-1.5 overflow-hidden">
                 <span className="w-2.5 h-2.5 rounded-full shrink-0" style={{ backgroundColor: plan.color }} />
-                <span className="text-sm font-medium text-[#544A78]">{plan.name}</span>
-                <span className="text-[11px] text-[#A69DC0] capitalize">{plan.status}</span>
+                <span className="text-sm font-medium text-[#544A78] whitespace-nowrap">{plan.name}</span>
+                <span className="text-[11px] text-[#A69DC0] capitalize whitespace-nowrap">{plan.status}</span>
+                {plan.owner?.fullName && (
+                  <span className="text-[11px] text-[#A69DC0] truncate min-w-0">· {plan.owner.fullName}</span>
+                )}
               </div>
             ))}
           </div>

--- a/src/features/map/components/SearchResults/DistrictExploreModal.tsx
+++ b/src/features/map/components/SearchResults/DistrictExploreModal.tsx
@@ -343,6 +343,7 @@ export default function DistrictExploreModal({ leaid, onClose, onPrev, onNext, c
                   territoryPlanIds={territoryPlanIds}
                   plans={plans || []}
                   activities={activitiesData?.activities || []}
+                  onClose={onClose}
                 />
               ) : activeTab === "competitors" ? (
                 <CompetitorsTab competitorData={competitorData ?? null} />
@@ -459,13 +460,16 @@ function FullmindTab({
   territoryPlanIds,
   plans,
   activities,
+  onClose,
 }: {
   fullmindData: FullmindData | null;
   tags: Tag[];
   territoryPlanIds: string[];
   plans: TerritoryPlan[];
   activities: ActivityListItem[];
+  onClose: () => void;
 }) {
+  const viewPlan = useMapV2Store((s) => s.viewPlan);
   const fmtMoney = (n: number) => (n > 0 ? `$${n.toLocaleString()}` : "—");
   const memberPlans = plans.filter((p) => territoryPlanIds.includes(p.id));
 
@@ -511,14 +515,19 @@ function FullmindTab({
           <SectionLabel>Plan Membership</SectionLabel>
           <div className="flex flex-col gap-1.5">
             {memberPlans.map((plan) => (
-              <div key={plan.id} className="flex items-center gap-2.5 py-1.5 overflow-hidden">
+              <button
+                key={plan.id}
+                data-plan-id={plan.id}
+                onClick={() => { onClose(); viewPlan(plan.id); }}
+                className="w-full text-left flex items-center gap-2.5 py-1.5 overflow-hidden cursor-pointer rounded hover:bg-[#F7F5FA] transition-colors"
+              >
                 <span className="w-2.5 h-2.5 rounded-full shrink-0" style={{ backgroundColor: plan.color }} />
                 <span className="text-sm font-medium text-[#544A78] whitespace-nowrap">{plan.name}</span>
                 <span className="text-[11px] text-[#A69DC0] capitalize whitespace-nowrap">{plan.status}</span>
                 {plan.owner?.fullName && (
                   <span className="text-[11px] text-[#A69DC0] truncate min-w-0">· {plan.owner.fullName}</span>
                 )}
-              </div>
+              </button>
             ))}
           </div>
         </div>

--- a/src/features/map/components/SearchResults/DistrictExploreModal.tsx
+++ b/src/features/map/components/SearchResults/DistrictExploreModal.tsx
@@ -30,6 +30,7 @@ type Tab = "fullmind" | "competitors" | "finance" | "demographics" | "academics"
 interface DistrictExploreModalProps {
   leaid: string;
   onClose: () => void;
+  onNavigateToPlan?: (planId: string) => void;
   onPrev?: () => void;
   onNext?: () => void;
   currentIndex?: number;
@@ -37,7 +38,7 @@ interface DistrictExploreModalProps {
   initialTab?: Tab;
 }
 
-export default function DistrictExploreModal({ leaid, onClose, onPrev, onNext, currentIndex, totalCount, initialTab }: DistrictExploreModalProps) {
+export default function DistrictExploreModal({ leaid, onClose, onNavigateToPlan, onPrev, onNext, currentIndex, totalCount, initialTab }: DistrictExploreModalProps) {
   const { data, isLoading } = useDistrictDetail(leaid);
   const { data: plans } = useTerritoryPlans();
   const addDistricts = useAddDistrictsToPlan();
@@ -343,7 +344,7 @@ export default function DistrictExploreModal({ leaid, onClose, onPrev, onNext, c
                   territoryPlanIds={territoryPlanIds}
                   plans={plans || []}
                   activities={activitiesData?.activities || []}
-                  onClose={onClose}
+                  onNavigateToPlan={onNavigateToPlan}
                 />
               ) : activeTab === "competitors" ? (
                 <CompetitorsTab competitorData={competitorData ?? null} />
@@ -460,16 +461,15 @@ function FullmindTab({
   territoryPlanIds,
   plans,
   activities,
-  onClose,
+  onNavigateToPlan,
 }: {
   fullmindData: FullmindData | null;
   tags: Tag[];
   territoryPlanIds: string[];
   plans: TerritoryPlan[];
   activities: ActivityListItem[];
-  onClose: () => void;
+  onNavigateToPlan?: (planId: string) => void;
 }) {
-  const viewPlan = useMapV2Store((s) => s.viewPlan);
   const fmtMoney = (n: number) => (n > 0 ? `$${n.toLocaleString()}` : "—");
   const memberPlans = plans.filter((p) => territoryPlanIds.includes(p.id));
 
@@ -519,7 +519,7 @@ function FullmindTab({
                 key={plan.id}
                 type="button"
                 data-plan-id={plan.id}
-                onClick={() => { onClose(); viewPlan(plan.id); }}
+                onClick={() => onNavigateToPlan?.(plan.id)}
                 className="w-full text-left flex items-center gap-2.5 py-1.5 overflow-hidden cursor-pointer rounded hover:bg-[#F7F5FA] transition-colors focus:outline-none focus:ring-1 focus:ring-[#403770]/30"
               >
                 <span className="w-2.5 h-2.5 rounded-full shrink-0" style={{ backgroundColor: plan.color }} />

--- a/src/features/map/components/SearchResults/DistrictExploreModal.tsx
+++ b/src/features/map/components/SearchResults/DistrictExploreModal.tsx
@@ -517,9 +517,10 @@ function FullmindTab({
             {memberPlans.map((plan) => (
               <button
                 key={plan.id}
+                type="button"
                 data-plan-id={plan.id}
                 onClick={() => { onClose(); viewPlan(plan.id); }}
-                className="w-full text-left flex items-center gap-2.5 py-1.5 overflow-hidden cursor-pointer rounded hover:bg-[#F7F5FA] transition-colors"
+                className="w-full text-left flex items-center gap-2.5 py-1.5 overflow-hidden cursor-pointer rounded hover:bg-[#F7F5FA] transition-colors focus:outline-none focus:ring-1 focus:ring-[#403770]/30"
               >
                 <span className="w-2.5 h-2.5 rounded-full shrink-0" style={{ backgroundColor: plan.color }} />
                 <span className="text-sm font-medium text-[#544A78] whitespace-nowrap">{plan.name}</span>

--- a/src/features/map/components/SearchResults/__tests__/DistrictExploreModal.test.tsx
+++ b/src/features/map/components/SearchResults/__tests__/DistrictExploreModal.test.tsx
@@ -4,11 +4,33 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import DistrictExploreModal from "../DistrictExploreModal";
 
 vi.mock("@/features/districts/lib/queries", () => ({
-  useDistrictDetail: () => ({ data: null, isLoading: true }),
+  useDistrictDetail: () => ({
+    data: {
+      leaid: "1234567",
+      name: "Test District",
+      territoryPlanIds: ["plan-1"],
+      state: "LA",
+      pipeline: {},
+      activities: [],
+    },
+    isLoading: false,
+  }),
 }));
 
 vi.mock("@/lib/api", () => ({
-  useTerritoryPlans: () => ({ data: [] }),
+  useTerritoryPlans: () => ({
+    data: [
+      {
+        id: "plan-1",
+        name: "Kleist Renewal",
+        color: "#7C3AED",
+        status: "working",
+        owner: { id: "user-1", fullName: "Sierra Arcega", avatarUrl: null },
+        description: null,
+        fiscalYear: 2026,
+      },
+    ],
+  }),
   useAddDistrictsToPlan: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
@@ -46,5 +68,14 @@ describe("DistrictExploreModal — responsive sizing", () => {
     // Verify the 70vh height class is present
     const modalPanel = container.querySelector(".max-h-\\[745px\\]");
     expect(modalPanel?.className).toContain("h-[70vh]");
+  });
+});
+
+describe("DistrictExploreModal — plan membership owner", () => {
+  it("shows plan owner name after a dot separator when owner exists", () => {
+    const { container } = renderWithClient(
+      <DistrictExploreModal leaid="1234567" onClose={vi.fn()} />
+    );
+    expect(container.textContent).toContain("· Sierra Arcega");
   });
 });

--- a/src/features/map/components/SearchResults/__tests__/DistrictExploreModal.test.tsx
+++ b/src/features/map/components/SearchResults/__tests__/DistrictExploreModal.test.tsx
@@ -1,8 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render } from "@testing-library/react";
+import { render, fireEvent } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import DistrictExploreModal from "../DistrictExploreModal";
 import * as libApi from "@/lib/api";
+
+const mockViewPlan = vi.fn();
+const mockOnClose = vi.fn();
+
+vi.mock("@/features/map/lib/store", () => ({
+  useMapV2Store: Object.assign(
+    vi.fn((selector: (s: any) => any) =>
+      selector({ exploreModalVacancyId: null, viewPlan: mockViewPlan })
+    ),
+    { getState: () => ({ exploreModalVacancyId: null }) }
+  ),
+}));
 
 // All tests in this file render against a fully-loaded district + plan (not a loading skeleton)
 vi.mock("@/features/districts/lib/queries", () => ({
@@ -42,6 +54,8 @@ beforeEach(() => {
       },
     ],
   } as any);
+  mockViewPlan.mockReset();
+  mockOnClose.mockReset();
 });
 
 function renderWithClient(ui: React.ReactElement) {
@@ -103,5 +117,18 @@ describe("DistrictExploreModal — plan membership owner", () => {
       <DistrictExploreModal leaid="1234567" onClose={vi.fn()} />
     );
     expect(container.textContent).not.toContain("·");
+  });
+});
+
+describe("DistrictExploreModal — plan membership navigation", () => {
+  it("calls onClose and viewPlan with the plan id when a plan row is clicked", () => {
+    const { container } = renderWithClient(
+      <DistrictExploreModal leaid="1234567" onClose={mockOnClose} />
+    );
+    const planButton = container.querySelector("button[data-plan-id='plan-1']");
+    expect(planButton).not.toBeNull();
+    fireEvent.click(planButton!);
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+    expect(mockViewPlan).toHaveBeenCalledWith("plan-1");
   });
 });

--- a/src/features/map/components/SearchResults/__tests__/DistrictExploreModal.test.tsx
+++ b/src/features/map/components/SearchResults/__tests__/DistrictExploreModal.test.tsx
@@ -1,8 +1,10 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import DistrictExploreModal from "../DistrictExploreModal";
+import * as libApi from "@/lib/api";
 
+// All tests in this file render against a fully-loaded district + plan (not a loading skeleton)
 vi.mock("@/features/districts/lib/queries", () => ({
   useDistrictDetail: () => ({
     data: {
@@ -18,7 +20,16 @@ vi.mock("@/features/districts/lib/queries", () => ({
 }));
 
 vi.mock("@/lib/api", () => ({
-  useTerritoryPlans: () => ({
+  useTerritoryPlans: vi.fn(),
+  useAddDistrictsToPlan: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@/features/activities/lib/queries", () => ({
+  useActivities: () => ({ data: null }),
+}));
+
+beforeEach(() => {
+  vi.mocked(libApi.useTerritoryPlans).mockReturnValue({
     data: [
       {
         id: "plan-1",
@@ -30,13 +41,8 @@ vi.mock("@/lib/api", () => ({
         fiscalYear: 2026,
       },
     ],
-  }),
-  useAddDistrictsToPlan: () => ({ mutateAsync: vi.fn(), isPending: false }),
-}));
-
-vi.mock("@/features/activities/lib/queries", () => ({
-  useActivities: () => ({ data: null }),
-}));
+  } as any);
+});
 
 function renderWithClient(ui: React.ReactElement) {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -77,5 +83,25 @@ describe("DistrictExploreModal — plan membership owner", () => {
       <DistrictExploreModal leaid="1234567" onClose={vi.fn()} />
     );
     expect(container.textContent).toContain("· Sierra Arcega");
+  });
+
+  it("does not render a dot separator when owner is null", () => {
+    vi.mocked(libApi.useTerritoryPlans).mockReturnValueOnce({
+      data: [
+        {
+          id: "plan-1",
+          name: "Kleist Renewal",
+          color: "#7C3AED",
+          status: "working",
+          owner: null,
+          description: null,
+          fiscalYear: 2026,
+        },
+      ],
+    } as any);
+    const { container } = renderWithClient(
+      <DistrictExploreModal leaid="1234567" onClose={vi.fn()} />
+    );
+    expect(container.textContent).not.toContain("·");
   });
 });

--- a/src/features/map/components/SearchResults/__tests__/DistrictExploreModal.test.tsx
+++ b/src/features/map/components/SearchResults/__tests__/DistrictExploreModal.test.tsx
@@ -4,13 +4,12 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import DistrictExploreModal from "../DistrictExploreModal";
 import * as libApi from "@/lib/api";
 
-const mockViewPlan = vi.fn();
-const mockOnClose = vi.fn();
+const mockOnNavigateToPlan = vi.fn();
 
 vi.mock("@/features/map/lib/store", () => ({
   useMapV2Store: Object.assign(
     vi.fn((selector: (s: any) => any) =>
-      selector({ exploreModalVacancyId: null, viewPlan: mockViewPlan })
+      selector({ exploreModalVacancyId: null })
     ),
     { getState: () => ({ exploreModalVacancyId: null }) }
   ),
@@ -54,8 +53,7 @@ beforeEach(() => {
       },
     ],
   } as any);
-  mockViewPlan.mockReset();
-  mockOnClose.mockReset();
+  mockOnNavigateToPlan.mockReset();
 });
 
 function renderWithClient(ui: React.ReactElement) {
@@ -121,14 +119,14 @@ describe("DistrictExploreModal — plan membership owner", () => {
 });
 
 describe("DistrictExploreModal — plan membership navigation", () => {
-  it("calls onClose and viewPlan with the plan id when a plan row is clicked", () => {
+  it("calls onNavigateToPlan with the plan id when a plan row is clicked", () => {
     const { container } = renderWithClient(
-      <DistrictExploreModal leaid="1234567" onClose={mockOnClose} />
+      <DistrictExploreModal leaid="1234567" onClose={vi.fn()} onNavigateToPlan={mockOnNavigateToPlan} />
     );
     const planButton = container.querySelector("button[data-plan-id='plan-1']");
     expect(planButton).not.toBeNull();
     fireEvent.click(planButton!);
-    expect(mockOnClose).toHaveBeenCalledTimes(1);
-    expect(mockViewPlan).toHaveBeenCalledWith("plan-1");
+    expect(mockOnNavigateToPlan).toHaveBeenCalledTimes(1);
+    expect(mockOnNavigateToPlan).toHaveBeenCalledWith("plan-1");
   });
 });

--- a/src/features/map/components/SearchResults/index.tsx
+++ b/src/features/map/components/SearchResults/index.tsx
@@ -17,6 +17,7 @@ import type { DistrictFinancial } from "@/features/shared/types/api-types";
 import { useCrossFilter } from "@/features/map/lib/useCrossFilter";
 import DistrictSearchCard from "./DistrictSearchCard";
 import DistrictExploreModal from "./DistrictExploreModal";
+import PlanDetailModal from "./PlanDetailModal";
 import ResultsTabStrip from "./ResultsTabStrip";
 
 interface SearchResultDistrict {
@@ -90,6 +91,7 @@ export default function SearchResults() {
   const exploreModalLeaid = useMapV2Store((s) => s.exploreModalLeaid);
   const setExploreModalLeaid = useMapV2Store((s) => s.setExploreModalLeaid);
   const [showMyPlansOnly, setShowMyPlansOnly] = useState(true);
+  const [planModalId, setPlanModalId] = useState<string | null>(null);
 
   // Extract geographic state filters from searchFilters to apply to overlay layers
   const geoStates = useMemo(() => {
@@ -939,11 +941,19 @@ export default function SearchResults() {
       )}
 
       {/* Explore modal — rendered via portal into document.body to escape stacking context */}
-      {/* Explore modal — rendered via portal into document.body to escape stacking context */}
+      {planModalId && createPortal(
+        <PlanDetailModal
+          planId={planModalId}
+          onClose={() => setPlanModalId(null)}
+        />,
+        document.body
+      )}
+
       {exploreModalLeaid && createPortal(
         <DistrictExploreModal
           leaid={exploreModalLeaid}
           onClose={() => setExploreModalLeaid(null)}
+          onNavigateToPlan={(planId) => { setExploreModalLeaid(null); setPlanModalId(planId); }}
           onPrev={canGoPrev ? handleExplorePrev : undefined}
           onNext={canGoNext ? handleExploreNext : undefined}
           currentIndex={currentExploreIndex}


### PR DESCRIPTION
## Summary

- **Owner visibility** — Plan Membership rows in the district card's Fullmind tab now show the plan owner after a dot separator: `● Kleist Renewal  Working · Sierra Arcega`. Handles the null-owner case (no separator rendered).
- **Click-to-open** — Clicking a plan row now closes the district card modal and opens `PlanDetailModal` for that plan. Previously the click only closed the district card because `viewPlan()` was targeting dead `FloatingPanel` code that is never rendered.

## Technical notes

The navigation fix threads an `onNavigateToPlan` callback from `SearchResults` → `DistrictExploreModal` → `FullmindTab`. On click, the callback atomically closes the district modal (`setExploreModalLeaid(null)`) and opens `PlanDetailModal` via local state (`setPlanModalId`), matching the pattern used by `PlanCard` and `HomePanel`.

## Test Plan
- [ ] Open district card → Fullmind tab → Plan Membership section shows plan name, status, and owner name
- [ ] When plan has no owner, no dot separator is rendered
- [ ] Click a plan row → district card closes → PlanDetailModal opens for that plan
- [ ] All 5 `DistrictExploreModal` tests pass (`npm test -- DistrictExploreModal --run`)