### PR TITLE
fix(reports): stop logging chat replies as errors in query_log

### DIFF
--- a/src/app/api/ai/query/chat/__tests__/route.test.ts
+++ b/src/app/api/ai/query/chat/__tests__/route.test.ts
@@ -1,5 +1,5 @@
 // src/app/api/ai/query/chat/__tests__/route.test.ts
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/lib/supabase/server", () => ({
   getUser: vi.fn(async () => ({ id: "user-1" })),
@@ -12,20 +12,16 @@ vi.mock("@/features/reports/lib/agent/conversation", () => ({
   saveTurn: vi.fn(async () => 1),
 }));
 vi.mock("@/features/reports/lib/agent/agent-loop", () => ({
-  runAgentLoop: vi.fn(async () => ({
-    kind: "result",
-    sql: "SELECT 1 LIMIT 100",
-    summary: { source: "x", filters: [], columns: [{ id: "c1", label: "a" }], sort: null, limit: 100 },
-    columns: ["a"],
-    rows: [{ a: 1 }],
-    rowCount: 1,
-    executionTimeMs: 5,
-    assistantText: "",
-  })),
+  runAgentLoop: vi.fn(),
 }));
 
 import { POST } from "../route";
 import { NextRequest } from "next/server";
+import { saveTurn } from "@/features/reports/lib/agent/conversation";
+import { runAgentLoop } from "@/features/reports/lib/agent/agent-loop";
+
+const mockSaveTurn = vi.mocked(saveTurn);
+const mockRunAgentLoop = vi.mocked(runAgentLoop);
 
 function req(body: unknown): NextRequest {
   return new NextRequest("http://localhost/api/ai/query/chat", {
@@ -35,6 +31,11 @@ function req(body: unknown): NextRequest {
   });
 }
 
+beforeEach(() => {
+  mockSaveTurn.mockClear();
+  mockRunAgentLoop.mockReset();
+});
+
 describe("POST /api/ai/query/chat", () => {
   it("rejects missing message", async () => {
     const res = await POST(req({ message: "" }));
@@ -42,10 +43,48 @@ describe("POST /api/ai/query/chat", () => {
   });
 
   it("returns conversationId + result on success", async () => {
+    mockRunAgentLoop.mockResolvedValueOnce({
+      kind: "result",
+      sql: "SELECT 1 LIMIT 100",
+      summary: { source: "x", filters: [], columns: [{ id: "c1", label: "a" }], sort: null, limit: 100 },
+      columns: ["a"],
+      rows: [{ a: 1 }],
+      rowCount: 1,
+      executionTimeMs: 5,
+      assistantText: "",
+    });
     const res = await POST(req({ message: "show me districts" }));
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.conversationId).toBeTruthy();
     expect(json.result.rows).toBeDefined();
+  });
+
+  describe("query_log error column", () => {
+    it("does not set error for clarifying turns (chat-only responses)", async () => {
+      mockRunAgentLoop.mockResolvedValueOnce({
+        kind: "clarifying",
+        text: "Yep, I'm working! How can I help?",
+      });
+
+      const res = await POST(req({ message: "do you work" }));
+      expect(res.status).toBe(200);
+      expect(mockSaveTurn).toHaveBeenCalledTimes(1);
+      const args = mockSaveTurn.mock.calls[0][0];
+      expect(args.error).toBeUndefined();
+    });
+
+    it("sets sentinel error for surrender turns", async () => {
+      mockRunAgentLoop.mockResolvedValueOnce({
+        kind: "surrender",
+        text: "I tried a few times but couldn't run that query.",
+      });
+
+      const res = await POST(req({ message: "broken query" }));
+      expect(res.status).toBe(200);
+      expect(mockSaveTurn).toHaveBeenCalledTimes(1);
+      const args = mockSaveTurn.mock.calls[0][0];
+      expect(args.error).toBe("agent_surrender_no_sql_error");
+    });
   });
 });

--- a/src/app/api/ai/query/chat/route.ts
+++ b/src/app/api/ai/query/chat/route.ts
@@ -9,6 +9,11 @@ import type { ChatRequest } from "@/features/reports/lib/agent/types";
 export const dynamic = "force-dynamic";
 export const maxDuration = 300;
 
+// Sentinel for query_log.error when the agent surrendered without a recoverable
+// SQL error (e.g. exploration cap, agent declined to attempt SQL). Distinguishes
+// real failures from the agent giving up so dashboards can quantify both.
+const SURRENDER_NO_SQL_SENTINEL = "agent_surrender_no_sql_error";
+
 export async function POST(request: NextRequest): Promise<NextResponse> {
   const user = await getUser();
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -49,7 +54,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       userId: user.id,
       conversationId,
       question: body.message,
-      error: result.text,
+      error:
+        result.kind === "surrender" ? SURRENDER_NO_SQL_SENTINEL : undefined,
     });
   }
 


### PR DESCRIPTION
## Summary
- The chat route stored the agent's natural-language reply in `query_log.error` for any non-`result` outcome, conflating clarifying turns ("do you work?" → "Yep, I'm working!") with real failures
- Inflated the dashboard error rate to 28% when the real SQL-failure rate is ~14% (17 of 38 logged "errors" were chat-only responses)
- This PR: clarifying turns leave `error` null; surrender turns get a stable sentinel `agent_surrender_no_sql_error` so the agent-surrender pattern can be quantified distinctly from real SQL failures

## Why a sentinel for surrender (and not the real SQL error)
The richer events-based logging pipeline that captures the underlying SQL error on surrender lives on the in-progress reports rebuild branch and will land with that work. This PR is intentionally minimal — it fixes the immediate bookkeeping bug without splitting events-capture work out of the larger rebuild.

## Backfill
The 38 historical mis-classified rows in `query_log` were already cleaned up via a separate one-time backfill (heuristic-classified into 14 real SQL errors kept as-is, 5 marked as the same `agent_surrender_no_sql_error` sentinel, 19 cleared to null).

## Test plan
- [x] New test: clarifying turn → `saveTurn` called without `error`
- [x] New test: surrender turn → `saveTurn` called with `error: "agent_surrender_no_sql_error"`
- [x] All existing reports tests still pass (87 tests across `src/features/reports/`, `src/app/api/reports/`, `src/app/api/ai/`)
- [ ] After merge: re-run query_log stats and confirm new rows from prod no longer contain agent-chat text in `error`

🤖 Generated with [Claude Code](https://claude.com/claude-code)