### PR TITLE
diag(reports): capture full agent-loop state on non-result returns

### DIFF
--- a/scripts/inspect-surrender-conversations.ts
+++ b/scripts/inspect-surrender-conversations.ts
@@ -1,0 +1,77 @@
+import prisma from "@/lib/prisma";
+
+async function main() {
+  const surrenders = await prisma.queryLog.findMany({
+    where: { error: "agent_surrender_no_sql_error" },
+    orderBy: { createdAt: "asc" },
+    select: {
+      id: true,
+      conversationId: true,
+      userId: true,
+      createdAt: true,
+      question: true,
+      sql: true,
+      error: true,
+      params: true,
+      user: { select: { fullName: true, email: true } },
+    },
+  });
+
+  console.log(`=== ${surrenders.length} surrender rows ===\n`);
+  for (const s of surrenders) {
+    const who = s.user?.fullName ?? s.user?.email ?? s.userId;
+    console.log(`#${s.id}  ${s.createdAt.toISOString()}  ${who}`);
+    console.log(`  conv=${s.conversationId}`);
+    console.log(`  Q: ${s.question}`);
+    console.log();
+  }
+
+  const convIds = Array.from(
+    new Set(surrenders.map((s) => s.conversationId).filter(Boolean) as string[]),
+  );
+  console.log(`=== ${convIds.length} unique conversations — full chronological dump ===\n`);
+
+  for (const convId of convIds) {
+    const turns = await prisma.queryLog.findMany({
+      where: { conversationId: convId },
+      orderBy: { createdAt: "asc" },
+      select: {
+        id: true,
+        createdAt: true,
+        question: true,
+        sql: true,
+        error: true,
+        params: true,
+        user: { select: { fullName: true, email: true } },
+      },
+    });
+    const who = turns[0]?.user?.fullName ?? turns[0]?.user?.email ?? "?";
+    console.log(`--- conversation ${convId} (${who}, ${turns.length} turns) ---`);
+    for (const t of turns) {
+      const surrendered = t.error === "agent_surrender_no_sql_error";
+      const marker = surrendered ? "** SURRENDER **" : t.sql ? "ran SQL" : "no-sql";
+      console.log(
+        `  [#${t.id}] ${t.createdAt.toISOString()}  ${marker}${t.error && !surrendered ? `  err=${t.error.slice(0, 60)}` : ""}`,
+      );
+      console.log(`     Q: ${t.question.replace(/\s+/g, " ").slice(0, 200)}`);
+      if (t.sql) {
+        console.log(`     SQL: ${t.sql.replace(/\s+/g, " ").slice(0, 200)}`);
+      }
+      const paramsKeys =
+        t.params && typeof t.params === "object" ? Object.keys(t.params as object) : [];
+      if (paramsKeys.length) {
+        const summary =
+          (t.params as { summary?: { source?: string } } | null)?.summary?.source;
+        console.log(`     params keys: [${paramsKeys.join(",")}]${summary ? `  summary.source="${summary}"` : ""}`);
+      }
+    }
+    console.log();
+  }
+
+  await prisma.$disconnect();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/repro-agent-surrender.ts
+++ b/scripts/repro-agent-surrender.ts
@@ -1,0 +1,97 @@
+// Direct invocation of the agent loop with the verbatim questions from the
+// 5 surrender rows. Bypasses the HTTP route + auth so we can see exactly what
+// the model returns.
+//
+// Run with: npx tsx scripts/repro-agent-surrender.ts
+//
+// USER_ID below is Sierra's; it only matters because saved_reports lookups
+// require a userId. The agent loop doesn't fabricate auth.
+import { getAnthropic } from "@/features/reports/lib/claude-client";
+import { runAgentLoop } from "@/features/reports/lib/agent/agent-loop";
+
+const USER_ID = process.env.REPRO_USER_ID ?? "00000000-0000-0000-0000-000000000000";
+
+interface QItem {
+  tag: string;
+  q: string;
+  priorTurns?: Array<{ question: string; sql: string | null; summary: null }>;
+}
+
+const QUESTIONS: QItem[] = [
+  { tag: "row131-ysiad-1", q: "how much pipeline does each rep have for FY27?" },
+  {
+    tag: "row132-ysiad-2-with-prior",
+    q: "how many districts are covered in FY27 territory plans? How many per rep?",
+    priorTurns: [
+      { question: "how much pipeline does each rep have for FY27?", sql: null, summary: null },
+    ],
+  },
+  { tag: "row99-stage-90d", q: "can you show me all opps that have been in their current stage for more than 90 days? only open pipeline, please" },
+  { tag: "row82-tx-pipeline", q: "Show me Texas districts with pipeline over $50K, top 20 by pipeline." },
+];
+
+async function runOne(item: QItem, attempt: number) {
+  const { tag, q } = item;
+  const startedAt = Date.now();
+  try {
+    const result = await runAgentLoop({
+      anthropic: getAnthropic(),
+      userMessage: q,
+      priorTurns: (item.priorTurns ?? []).map((t) => ({
+        ...t,
+        createdAt: new Date(),
+      })),
+      userId: USER_ID,
+    });
+    const elapsedMs = Date.now() - startedAt;
+    const summary =
+      result.kind === "result"
+        ? `rowCount=${result.rowCount}`
+        : `text=${result.text.replace(/\s+/g, " ").slice(0, 220)}`;
+    console.log(`[${tag} #${attempt}] ${result.kind}  ${elapsedMs}ms  ${summary}`);
+    return result.kind;
+  } catch (err) {
+    console.log(`[${tag} #${attempt}] THREW: ${err instanceof Error ? err.message : String(err)}`);
+    return "threw";
+  }
+}
+
+async function main() {
+  // Custom question mode: scripts/repro-agent-surrender.ts ask "<question>" [repeats]
+  if (process.argv[2] === "ask") {
+    const q = process.argv[3];
+    if (!q) {
+      console.error('usage: ... ask "<question>" [repeats]');
+      process.exit(1);
+    }
+    const repeats = Number(process.argv[4] ?? "1");
+    const item: QItem = { tag: "ask", q };
+    const runs: Promise<string>[] = [];
+    for (let i = 1; i <= repeats; i++) runs.push(runOne(item, i));
+    await Promise.all(runs);
+    return;
+  }
+
+  const filter = process.argv[2];
+  const repeats = Number(process.argv[3] ?? "1");
+  const counts: Record<string, Record<string, number>> = {};
+  for (const item of QUESTIONS) {
+    if (filter && !item.tag.includes(filter)) continue;
+    counts[item.tag] = {};
+    const runs: Promise<string>[] = [];
+    for (let i = 1; i <= repeats; i++) {
+      runs.push(runOne(item, i));
+    }
+    const kinds = await Promise.all(runs);
+    for (const k of kinds) counts[item.tag][k] = (counts[item.tag][k] ?? 0) + 1;
+  }
+  console.log("\n=== summary ===");
+  for (const [tag, kinds] of Object.entries(counts)) {
+    console.log(`  ${tag}: ${JSON.stringify(kinds)}`);
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/app/api/ai/query/chat/route.ts
+++ b/src/app/api/ai/query/chat/route.ts
@@ -37,6 +37,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     userMessage: body.message,
     priorTurns,
     userId: user.id,
+    conversationId,
   });
 
   if (result.kind === "result") {

--- a/src/features/reports/lib/agent/agent-loop.ts
+++ b/src/features/reports/lib/agent/agent-loop.ts
@@ -38,10 +38,24 @@ interface RunAgentLoopArgs {
   userMessage: string;
   priorTurns: PriorTurn[];
   userId: string;
+  conversationId?: string;
+}
+
+// Set AGENT_LOOP_DIAG=1 in the deployment env to capture full system-prompt +
+// messages + per-iteration responses every time the loop returns a non-result
+// outcome (clarifying / surrender). Used to root-cause the rare bug where the
+// agent answers a normal data question with a fabricated "the database is
+// down" message and zero tool_use blocks. Disabled by default — output is
+// large and only useful when investigating live failures.
+const DIAG_ENABLED = process.env.AGENT_LOOP_DIAG === "1";
+
+interface IterationDiag {
+  stopReason: string | null;
+  blocks: Array<{ type: string; name?: string; id?: string }>;
 }
 
 export async function runAgentLoop(args: RunAgentLoopArgs): Promise<AgentResult> {
-  const { anthropic, userMessage, priorTurns, userId } = args;
+  const { anthropic, userMessage, priorTurns, userId, conversationId } = args;
 
   const history: Anthropic.MessageParam[] = [];
   for (const t of priorTurns) {
@@ -61,6 +75,31 @@ export async function runAgentLoop(args: RunAgentLoopArgs): Promise<AgentResult>
   let exploratoryCalls = 0;
   let assistantText = "";
   const messages: Anthropic.MessageParam[] = [...history];
+  const iterations: IterationDiag[] = [];
+
+  const logDiag = (
+    reason: "no_tools" | "sql_retries_exhausted" | "exploration_cap",
+    kind: AgentResult["kind"],
+    finalText: string,
+  ): void => {
+    if (!DIAG_ENABLED) return;
+    console.warn(
+      "[AGENT-DIAG] " +
+        JSON.stringify({
+          ts: new Date().toISOString(),
+          conversationId: conversationId ?? null,
+          userId,
+          kind,
+          reason,
+          sqlRetriesUsed,
+          exploratoryCalls,
+          finalAssistantText: finalText,
+          iterations,
+          systemPrompt,
+          messagesSent: messages,
+        }),
+    );
+  };
 
   while (true) {
     const response = await anthropic.messages.create({
@@ -71,6 +110,20 @@ export async function runAgentLoop(args: RunAgentLoopArgs): Promise<AgentResult>
       tools: AGENT_TOOLS,
       messages,
     });
+
+    if (DIAG_ENABLED) {
+      iterations.push({
+        stopReason: (response as { stop_reason?: string | null }).stop_reason ?? null,
+        blocks: response.content.map((b) => {
+          const entry: { type: string; name?: string; id?: string } = { type: b.type };
+          if (b.type === "tool_use") {
+            entry.name = b.name;
+            entry.id = b.id;
+          }
+          return entry;
+        }),
+      });
+    }
 
     const textBlocks = response.content.filter(
       (b): b is Anthropic.TextBlock => b.type === "text",
@@ -84,7 +137,9 @@ export async function runAgentLoop(args: RunAgentLoopArgs): Promise<AgentResult>
     );
 
     if (toolUses.length === 0) {
-      return { kind: "clarifying", text: assistantText || "(no text)" };
+      const text = assistantText || "(no text)";
+      logDiag("no_tools", "clarifying", text);
+      return { kind: "clarifying", text };
     }
 
     messages.push({ role: "assistant", content: response.content });
@@ -120,12 +175,11 @@ export async function runAgentLoop(args: RunAgentLoopArgs): Promise<AgentResult>
       });
 
       if (sqlRetriesUsed >= MAX_SQL_RETRIES) {
-        return {
-          kind: "surrender",
-          text:
-            assistantText ||
-            "I tried a few times but couldn't run that query. Could you tell me more about what you're looking for?",
-        };
+        const text =
+          assistantText ||
+          "I tried a few times but couldn't run that query. Could you tell me more about what you're looking for?";
+        logDiag("sql_retries_exhausted", "surrender", text);
+        return { kind: "surrender", text };
       }
       sqlRetriesUsed++;
     }
@@ -150,11 +204,10 @@ export async function runAgentLoop(args: RunAgentLoopArgs): Promise<AgentResult>
 
       exploratoryCalls++;
       if (exploratoryCalls > MAX_EXPLORATORY_CALLS_PER_TURN) {
-        return {
-          kind: "surrender",
-          text:
-            "I'm having trouble narrowing this down. Could you give me more details about what you're looking for?",
-        };
+        const text =
+          "I'm having trouble narrowing this down. Could you give me more details about what you're looking for?";
+        logDiag("exploration_cap", "surrender", text);
+        return { kind: "surrender", text };
       }
       const toolResult = await executeExploratoryTool(tu, userId);
       toolResults.push({


### PR DESCRIPTION
## Summary

Adds gated diagnostic logging to `runAgentLoop` to root-cause the rare bug where the Reports query agent surrenders without trying any SQL and hallucinates a "the read-only pool isn't available right now" excuse to the user (5 confirmed `agent_surrender_no_sql_error` rows in production `query_log` so far, including both of Ysiad's questions on Apr 30).

Local repro failed in 38 attempts — bug rate is too low to drive a fix from a dev box, so per the handoff (`Docs/superpowers/handoff/2026-05-01-agent-surrender-bug-handoff.md`) the next step is capturing a real production failure.

## What changed

- `agent-loop.ts`
  - Optional `conversationId` on `RunAgentLoopArgs`.
  - Per-iteration capture of `stop_reason` + content-block kinds (`text` / `tool_use` name+id / `thinking`) for every model call.
  - `logDiag()` emits a single structured `[AGENT-DIAG]` JSON line at each of the three non-result return points: `no_tools` (clarifying), `sql_retries_exhausted` (surrender), `exploration_cap` (surrender). Includes timestamp, conversationId, userId, kind, reason, retry + exploratory counters, `finalAssistantText`, full `iterations[]`, full `systemPrompt`, full `messagesSent`.
  - **Gated behind `AGENT_LOOP_DIAG=1`. Off by default** — the prompt is ~30KB so we don't want it in every request.
- `route.ts` — threads `conversationId` into `runAgentLoop` so diag entries correlate directly with `query_log` rows.
- `scripts/inspect-surrender-conversations.ts` — pulls every surrender row plus every other turn in the same `conversation_id`.
- `scripts/repro-agent-surrender.ts` — replays the verbatim production questions against the local agent loop in parallel; useful for pre/post-fix A/B once we have a hypothesis.

## What this is *not*

This is **only** instrumentation — no behavioral change at flag-off, no hypothesis-fix yet. The actual fix (system-prompt drift, prior-turn poisoning, adaptive thinking misfire, …) still needs to be chosen from real captured data.

## Deployment plan

1. Merge.
2. Set `AGENT_LOOP_DIAG=1` in Vercel prod env, redeploy.
3. Wait for the next `agent_surrender_no_sql_error` row to land in `query_log`.
4. Grep Vercel logs for `[AGENT-DIAG]` near that timestamp + `conversationId`. The single JSON line carries the full system prompt, full messages array, and per-iteration response shape — enough to pinpoint the trigger.
5. Once root-caused and fixed, revert this PR (or just unset the env var until we want to capture again).

## Test plan

- [x] `npx vitest run src/features/reports/lib/agent/__tests__ src/app/api/ai/query/chat/__tests__` — 36/36 pass
- [x] `npx tsc --noEmit` clean for touched files (pre-existing leaderboard fixture errors are unrelated)
- [x] Synthetic end-to-end check: scripted clarifying response with flag on → `[AGENT-DIAG]` line emitted with all expected fields; flag off → silent
- [ ] Verify diag line appears in Next.js dev-server logs when the flag is set and a clarifying question is asked through the actual route (optional — synthetic test covers the same code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)