### PR TITLE
fix(scheduler): heal manual mappings on daily backfill, keep queue clean

### DIFF
--- a/scheduler/run_sync.py
+++ b/scheduler/run_sync.py
@@ -36,6 +36,44 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
+def _process_opp_hits(opp_hits, sessions_by_opp, district_mapping, manual_resolutions, now):
+    """Build records for each opp and classify into matched / unmatched.
+
+    Manual resolutions in unmatched_opportunities are AUTHORITATIVE — they
+    override whatever the natural resolver derived (NULL or any leaid).
+    Without this, an upstream change that suddenly returns a leaid for a
+    previously rep-curated opp would silently revert the rep's choice.
+
+    This helper exists so that run_sync (hourly incremental) and
+    run_current_fy_backfill (daily) cannot drift on this rule again — they
+    used to duplicate ~30 lines of nearly-identical logic, and a previous
+    fix patched only one copy. Single source of truth = single place to fix.
+
+    Returns (matched_records, unmatched_records, healed_count).
+    """
+    matched_records = []
+    unmatched_records = []
+    healed_count = 0
+    for h in opp_hits:
+        opp = h["_source"]
+        opp_sessions = sessions_by_opp.get(opp["id"], [])
+        record, unmatched = _build_record_and_classify(
+            opp, opp_sessions, district_mapping, now=now
+        )
+        # opp["id"] arrives from OpenSearch as int for numeric IDs; manual
+        # resolutions are keyed by str (Postgres text column) — coerce so
+        # the lookup matches.
+        opp_id_str = str(opp["id"])
+        if opp_id_str in manual_resolutions:
+            record["district_lea_id"] = manual_resolutions[opp_id_str]
+            unmatched = None
+            healed_count += 1
+        matched_records.append(record)
+        if unmatched is not None:
+            unmatched_records.append(unmatched)
+    return matched_records, unmatched_records, healed_count
+
+
 def _build_record_and_classify(opp, opp_sessions, district_mapping, now):
     """Build an opportunity record and classify the unmatched reason.
 
@@ -136,43 +174,20 @@ def run_sync():
     district_mapping = fetch_district_mappings(os_client, list(account_ids))
 
     try:
-        # Check for manual resolutions from unmatched_opportunities
+        # Phase 4: Compute metrics and build records (manual resolutions are
+        # authoritative — see _process_opp_hits).
         manual_resolutions = _load_manual_resolutions(conn)
-
-        # Phase 4: Compute metrics and build records
-        matched_records = []
-        unmatched_records = []
-        healed_count = 0
-
-        for h in opp_hits:
-            opp = h["_source"]
-            opp_sessions = sessions_by_opp.get(opp["id"], [])
-            record, unmatched = _build_record_and_classify(
-                opp, opp_sessions, district_mapping, now=now
-            )
-
-            # Manual resolutions are authoritative — they override whatever
-            # the sync derived (NULL or a different leaid). Without this, an
-            # upstream change that suddenly returns a leaid for a previously
-            # unmatched opp would silently revert the rep's curated mapping.
-            # opp["id"] arrives from OpenSearch as int for numeric IDs; dict
-            # keys come from a Postgres text column and are str — coerce so
-            # the lookup matches.
-            opp_id_str = str(opp["id"])
-            if opp_id_str in manual_resolutions:
-                record["district_lea_id"] = manual_resolutions[opp_id_str]
-                unmatched = None
-                healed_count += 1
-
-            matched_records.append(record)
-            if unmatched is not None:
-                unmatched_records.append(unmatched)
-
+        matched_records, unmatched_records, healed_count = _process_opp_hits(
+            opp_hits, sessions_by_opp, district_mapping, manual_resolutions, now
+        )
         if healed_count:
             logger.info(f"Healed {healed_count} opps via manual resolutions")
 
-        # Phase 5: Write to Supabase
-        upsert_opportunities(conn, matched_records)
+        # Phase 5: Write to Supabase. upsert_opportunities returns the ids
+        # whose POST-COALESCE leaid is non-NULL — that's the correct input
+        # to remove_matched_from_unmatched (a Python-level filter on the
+        # record value misses opps whose leaid was preserved by COALESCE).
+        matched_ids = upsert_opportunities(conn, matched_records)
         if unmatched_records:
             upsert_unmatched(conn, unmatched_records)
 
@@ -198,11 +213,8 @@ def run_sync():
         total_sessions = sum(len(v) for v in session_records_by_opp.values())
         upsert_sessions(conn, session_records_by_opp)
 
-        # Clean up: remove opps from unmatched that now have a district match
-        newly_matched_ids = [
-            r["id"] for r in matched_records if r.get("district_lea_id") is not None
-        ]
-        remove_matched_from_unmatched(conn, newly_matched_ids)
+        # Clean up: remove opps from unmatched that now have a district match.
+        remove_matched_from_unmatched(conn, matched_ids)
 
         update_district_pipeline_aggregates(conn)
         refresh_map_features(conn)
@@ -281,28 +293,13 @@ def run_current_fy_backfill():
 
     try:
         manual_resolutions = _load_manual_resolutions(conn)
-        matched_records = []
-        unmatched_records = []
-        healed_count = 0
-        for h in opp_hits:
-            opp = h["_source"]
-            opp_sessions = sessions_by_opp.get(opp["id"], [])
-            record, unmatched = _build_record_and_classify(
-                opp, opp_sessions, district_mapping, now=now
-            )
-            opp_id_str = str(opp["id"])
-            if record["district_lea_id"] is None and opp_id_str in manual_resolutions:
-                record["district_lea_id"] = manual_resolutions[opp_id_str]
-                unmatched = None
-                healed_count += 1
-            matched_records.append(record)
-            if unmatched is not None:
-                unmatched_records.append(unmatched)
-
+        matched_records, unmatched_records, healed_count = _process_opp_hits(
+            opp_hits, sessions_by_opp, district_mapping, manual_resolutions, now
+        )
         if healed_count:
             logger.info(f"Healed {healed_count} opps via manual resolutions")
 
-        upsert_opportunities(conn, matched_records)
+        matched_ids = upsert_opportunities(conn, matched_records)
         if unmatched_records:
             upsert_unmatched(conn, unmatched_records)
 
@@ -327,10 +324,7 @@ def run_current_fy_backfill():
         total_sessions = sum(len(v) for v in session_records_by_opp.values())
         upsert_sessions(conn, session_records_by_opp)
 
-        newly_matched_ids = [
-            r["id"] for r in matched_records if r.get("district_lea_id") is not None
-        ]
-        remove_matched_from_unmatched(conn, newly_matched_ids)
+        remove_matched_from_unmatched(conn, matched_ids)
 
         update_district_pipeline_aggregates(conn)
         refresh_map_features(conn)

--- a/scheduler/sync/supabase_writer.py
+++ b/scheduler/sync/supabase_writer.py
@@ -40,7 +40,8 @@ def get_connection():
 
 
 def upsert_opportunities(conn, records):
-    """Upsert opportunity records into the opportunities table.
+    """Upsert opportunity records and return ids whose post-COALESCE
+    district_lea_id is non-NULL.
 
     `district_lea_id` is COALESCE'd to preserve a previously-set value when
     the natural resolver returns NULL on a sync. The natural resolver fails
@@ -52,9 +53,15 @@ def upsert_opportunities(conn, records):
     failure to clobber a known-good value — admin-driven corrections can
     still write through `unmatched_opportunities.resolved_district_leaid`
     via the heal step in run_sync.
+
+    The returned id list is what the caller should pass to
+    `remove_matched_from_unmatched` — filtering on the Python-level record
+    value misses opps whose leaid was preserved by COALESCE (compute()
+    returned NULL this cycle but the prior leaid is still on the row),
+    leaving stale unresolved rows in `unmatched_opportunities` forever.
     """
     if not records:
-        return
+        return []
 
     cols = OPPORTUNITY_COLUMNS
     placeholders = ", ".join(["%s"] * len(cols))
@@ -72,15 +79,23 @@ def upsert_opportunities(conn, records):
         INSERT INTO opportunities ({", ".join(cols)})
         VALUES ({placeholders})
         ON CONFLICT (id) DO UPDATE SET {update_set}
+        RETURNING id, district_lea_id
     """
 
+    matched_ids = []
     with conn.cursor() as cur:
         for record in records:
             values = [record.get(c) for c in cols]
             cur.execute(sql, values)
+            row = cur.fetchone()
+            if row and row[1] is not None:
+                matched_ids.append(row[0])
 
     conn.commit()
-    logger.info(f"Upserted {len(records)} opportunities")
+    logger.info(
+        f"Upserted {len(records)} opportunities ({len(matched_ids)} now matched to a district)"
+    )
+    return matched_ids
 
 
 SESSION_COLUMNS = [

--- a/scheduler/tests/test_run_current_fy_backfill.py
+++ b/scheduler/tests/test_run_current_fy_backfill.py
@@ -107,3 +107,60 @@ def test_run_current_fy_backfill_does_not_touch_watermark(
     # Backfill must NOT advance the watermark — the hourly incremental still
     # needs to catch up from where it last left off.
     mock_set_last.assert_not_called()
+
+
+@patch("run_sync.refresh_opportunity_actuals")
+@patch("run_sync.refresh_fullmind_financials")
+@patch("run_sync.refresh_map_features")
+@patch("run_sync.update_district_pipeline_aggregates")
+@patch("run_sync.remove_matched_from_unmatched")
+@patch("run_sync.upsert_unmatched")
+@patch("run_sync.upsert_sessions")
+@patch("run_sync.upsert_opportunities")
+@patch("run_sync.get_connection")
+@patch("run_sync.build_opportunity_record")
+@patch("run_sync.fetch_district_mappings")
+@patch("run_sync.fetch_sessions")
+@patch("run_sync.fetch_opportunities_for_school_yrs")
+@patch("run_sync.get_client")
+def test_run_current_fy_backfill_manual_resolution_overrides_sync_leaid(
+    mock_get_client, mock_fetch_yrs, mock_fetch_sessions,
+    mock_fetch_districts, mock_build, mock_get_conn,
+    mock_upsert_opps, mock_upsert_sessions, mock_upsert_unmatched,
+    mock_remove_matched, mock_update_agg, mock_refresh_map,
+    mock_refresh_fin, mock_refresh_actuals,
+):
+    """The daily backfill must respect manual resolutions even when
+    OpenSearch produces a non-NULL leaid that disagrees. Mirrors the
+    run_sync regression in test_run_sync.py — the missing parallel for the
+    backfill is what let manual-mapping reverts slip through PR #158."""
+    OPP_ID = "opp-backfill-1"
+    REP_LEAID = "9999999"
+    SYNC_LEAID = "0100001"
+
+    mock_fetch_yrs.return_value = [
+        {"_source": {"id": OPP_ID, "accounts": [{"id": "acc1"}]}}
+    ]
+    mock_fetch_sessions.return_value = []
+    mock_fetch_districts.return_value = {"acc1": {"nces_id": "123", "leaid": SYNC_LEAID}}
+    # Sync derives a leaid; rep previously mapped this opp to a different one.
+    mock_build.return_value = {
+        "id": OPP_ID, "district_lea_id": SYNC_LEAID,
+        "net_booking_amount": 5000, "service_types": [],
+    }
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_cursor.fetchall.return_value = [(OPP_ID, REP_LEAID)]
+    mock_conn.cursor.return_value.__enter__ = lambda s: mock_cursor
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_get_conn.return_value = mock_conn
+    mock_upsert_opps.return_value = [OPP_ID]
+
+    run_current_fy_backfill()
+
+    upserted = mock_upsert_opps.call_args[0][1]
+    assert len(upserted) == 1
+    # Rep's choice MUST win — even though compute returned a non-NULL leaid.
+    assert upserted[0]["district_lea_id"] == REP_LEAID
+    # Resolved row must NOT be re-inserted as unmatched.
+    mock_upsert_unmatched.assert_not_called()

--- a/scheduler/tests/test_run_sync.py
+++ b/scheduler/tests/test_run_sync.py
@@ -251,6 +251,9 @@ def test_manual_resolution_heals_when_opp_id_is_int(
     mock_conn.cursor.return_value.__enter__ = lambda s: mock_cursor
     mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
     mock_get_conn.return_value = mock_conn
+    # upsert_opportunities now returns the post-COALESCE matched-ids list;
+    # simulate the writer reporting this opp landed with a leaid set.
+    mock_upsert_opps.return_value = [OPP_ID_INT]
 
     result = run_sync()
 
@@ -265,3 +268,95 @@ def test_manual_resolution_heals_when_opp_id_is_int(
     # And the now-matched id must be sent to remove_matched_from_unmatched
     removed_ids = mock_remove_matched.call_args[0][1]
     assert OPP_ID_INT in removed_ids
+
+
+@patch("run_sync.refresh_opportunity_actuals")
+@patch("run_sync.refresh_fullmind_financials")
+@patch("run_sync.refresh_map_features")
+@patch("run_sync.set_last_synced_at")
+@patch("run_sync.get_last_synced_at", return_value=None)
+@patch("run_sync.update_district_pipeline_aggregates")
+@patch("run_sync.remove_matched_from_unmatched")
+@patch("run_sync.upsert_unmatched")
+@patch("run_sync.upsert_sessions")
+@patch("run_sync.upsert_opportunities")
+@patch("run_sync.get_connection")
+@patch("run_sync.build_opportunity_record")
+@patch("run_sync.fetch_district_mappings")
+@patch("run_sync.fetch_sessions")
+@patch("run_sync.fetch_opportunities")
+@patch("run_sync.get_client")
+def test_run_sync_uses_writer_returned_matched_ids_for_cleanup(
+    mock_get_client, mock_fetch_opps, mock_fetch_sessions,
+    mock_fetch_districts, mock_build, mock_get_conn,
+    mock_upsert_opps, mock_upsert_sessions, mock_upsert_unmatched,
+    mock_remove_matched, mock_update_agg, mock_get_last, mock_set_last,
+    mock_refresh, mock_refresh_fin, mock_refresh_actuals,
+):
+    """remove_matched_from_unmatched must be driven by the writer's RETURNING
+    list (post-COALESCE state), not by the Python record's district_lea_id.
+
+    Scenario: compute() returns NULL this cycle for an opp that already had
+    a leaid in the DB. The COALESCE in upsert_opportunities preserves the
+    prior leaid, and the writer reports this opp as still matched. The old
+    (pre-Bug-2) code filtered the cleanup list on the Python record value
+    and would have left a stale `resolved=false` row in unmatched_opportunities
+    every cycle — that's what made queue counts pile up for reps like Melodie.
+    """
+    mock_fetch_opps.return_value = [
+        {"_source": {"id": "opp-coalesced", "accounts": [{"id": "acc1"}]}}
+    ]
+    mock_fetch_sessions.return_value = []
+    mock_fetch_districts.return_value = {}  # natural resolver fails this cycle
+    mock_build.return_value = {
+        "id": "opp-coalesced",
+        "district_lea_id": None,  # compute returned NULL
+        "net_booking_amount": 0,
+        "service_types": [],
+    }
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_cursor.fetchall.return_value = []  # no manual resolutions
+    mock_conn.cursor.return_value.__enter__ = lambda s: mock_cursor
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_get_conn.return_value = mock_conn
+    # Writer reports the row landed with a leaid — preserved by COALESCE
+    # against the prior DB value.
+    mock_upsert_opps.return_value = ["opp-coalesced"]
+
+    run_sync()
+
+    removed_ids = mock_remove_matched.call_args[0][1]
+    assert "opp-coalesced" in removed_ids
+
+
+def test_process_opp_hits_manual_resolution_overrides_compute_leaid():
+    """Direct test of the shared helper: manual resolutions are authoritative
+    even when compute() returns a non-NULL leaid. Prevents the per-entrypoint
+    drift that produced Bug 1 (backfill missed PR #158's fix)."""
+    from run_sync import _process_opp_hits
+    from datetime import datetime, timezone
+
+    opp_hits = [
+        {"_source": {
+            "id": 17592305692725,  # int from OpenSearch
+            "name": "Yuba City",
+            "accounts": [{"id": "ACC", "name": "Yuba City Unified School District"}],
+            "stage": "3 - Proposal", "school_yr": "2025-26", "state": "CA",
+            "invoices": [], "credit_memos": [], "sales_rep": {},
+        }}
+    ]
+    mapping = {"ACC": {"nces_id": "0643470", "leaid": "0643470",
+                       "name": "Yuba City Unified School District", "type": "district"}}
+    # Rep's manual resolution disagrees with compute — must win.
+    manual_resolutions = {"17592305692725": "9999999"}
+    now = datetime(2026, 5, 1, tzinfo=timezone.utc)
+
+    matched, unmatched, healed = _process_opp_hits(
+        opp_hits, {}, mapping, manual_resolutions, now
+    )
+
+    assert healed == 1
+    assert len(matched) == 1
+    assert matched[0]["district_lea_id"] == "9999999"
+    assert unmatched == []  # heal collapses the unmatched classification

--- a/scheduler/tests/test_supabase_writer.py
+++ b/scheduler/tests/test_supabase_writer.py
@@ -86,6 +86,45 @@ def test_upsert_opportunities_coalesces_district_lea_id():
     assert sql.count("COALESCE(EXCLUDED") == 1
 
 
+def test_upsert_opportunities_returns_post_coalesce_matched_ids():
+    """The writer must report which opps ended up with a non-NULL leaid
+    AFTER the COALESCE in the UPDATE clause — not based on what the caller
+    passed in. A Python-level filter on the record value misses opps whose
+    leaid was preserved by COALESCE (compute returned NULL this cycle but
+    a prior leaid is still on the row), and those rows then keep getting
+    re-classified as unmatched on every sync. That's the Melodie symptom:
+    queue full of opps that already have a district_lea_id."""
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_conn.cursor.return_value.__enter__ = lambda s: mock_cursor
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+    # Two records — first ends up matched (COALESCE preserved a prior leaid),
+    # second stays NULL.
+    mock_cursor.fetchone.side_effect = [
+        ("opp-coalesced", "1234567"),  # post-COALESCE non-NULL
+        ("opp-unmatched", None),        # genuinely unmatched
+    ]
+
+    matched_ids = upsert_opportunities(mock_conn, [
+        {c: ("opp-coalesced" if c == "id" else None) for c in OPPORTUNITY_COLUMNS},
+        {c: ("opp-unmatched" if c == "id" else None) for c in OPPORTUNITY_COLUMNS},
+    ])
+
+    sql = mock_cursor.execute.call_args[0][0]
+    assert "RETURNING id, district_lea_id" in sql
+    assert matched_ids == ["opp-coalesced"]
+
+
+def test_upsert_opportunities_empty_returns_empty_list():
+    """No records → no DB call AND a sane empty list (caller passes the
+    return straight to remove_matched_from_unmatched which expects iterable)."""
+    mock_conn = MagicMock()
+    result = upsert_opportunities(mock_conn, [])
+    assert result == []
+    mock_conn.cursor.assert_not_called()
+
+
 def test_upsert_unmatched_preserves_resolutions():
     mock_conn = MagicMock()
     mock_cursor = MagicMock()


### PR DESCRIPTION
## Summary

- **Bug 1**: \`run_current_fy_backfill()\` (daily 04:00 UTC) ignored manual resolutions when \`compute()\` produced a non-NULL leaid. PR #158 fixed this for \`run_sync()\` (hourly) but the daily backfill was missed and could silently overwrite a rep's curated mapping with a wrong upstream leaid.
- **Bug 2**: \`newly_matched_ids\` was computed from the in-Python record value, missing opps whose leaid was preserved by the COALESCE in \`upsert_opportunities\`. Result: \`unmatched_opportunities\` filled up with \`resolved=false\` rows for opps that were already matched (Melodie had 80 such rows from one backfill alone).
- **Refactor**: both entrypoints now share a \`_process_opp_hits()\` helper. PR #158 patched only one of two near-identical loops; one source of truth makes that recurrence class go away.

## What changed

- \`scheduler/run_sync.py\` — extracted shared helper, both \`run_sync()\` and \`run_current_fy_backfill()\` delegate to it.
- \`scheduler/sync/supabase_writer.py\` — \`upsert_opportunities()\` now uses \`RETURNING id, district_lea_id\` and returns the post-COALESCE matched IDs. The cleanup pass is driven by that list.

## Test plan

- [x] \`test_run_current_fy_backfill_manual_resolution_overrides_sync_leaid\` — the parallel that PR #158 was missing.
- [x] \`test_run_sync_uses_writer_returned_matched_ids_for_cleanup\` — Bug 2 wiring.
- [x] \`test_process_opp_hits_manual_resolution_overrides_compute_leaid\` — helper invariant covers both entrypoints in one focused test.
- [x] \`test_upsert_opportunities_returns_post_coalesce_matched_ids\` — writer-side contract for Bug 2.
- [x] All 27 scheduler tests pass.

## Note on companion data fixes (already applied to prod)

Before this PR, two retroactive SQL ops were run:

1. \`UPDATE\` to heal 8 cohort-A opps (FY 2026-27) where \`unmatched_opportunities.resolved_district_leaid\` had been recorded but \`opportunities.district_lea_id\` was still NULL. Affected paul (2), brooke, hayley, lauren, liz, mike.odonnell + 1 unattributed.
2. \`DELETE\` of 821 stuck \`unmatched_opportunities\` rows where the corresponding opp already had a non-NULL \`district_lea_id\` — the Bug 2 fallout. \`resolved=true\` rows were preserved.

After: 0 still-divergent cohort-A rows, queue size 393 (335 resolved + 58 genuinely unmatched). This PR prevents the conditions that produced both cohorts going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)