### PR TITLE
fix(reports): default revenue includes subs, fix ghost report, fix currency aliases

### DIFF
--- a/src/features/reports/lib/__tests__/format-cell.test.ts
+++ b/src/features/reports/lib/__tests__/format-cell.test.ts
@@ -20,6 +20,28 @@ describe("formatCell — currency", () => {
   it("renders zero correctly", () => {
     expect(formatCell("invoiced", 0)).toBe("$0.00");
   });
+
+  it("formats commit aliases as currency", () => {
+    expect(formatCell("min_commit", 8399.6)).toBe("$8,399.60");
+    expect(formatCell("max_commit", 12500)).toBe("$12,500.00");
+    expect(formatCell("contracted_commit", 50000)).toBe("$50,000.00");
+  });
+
+  it("formats size aliases as currency", () => {
+    expect(formatCell("deal_size", 40859.5)).toBe("$40,859.50");
+    expect(formatCell("contract_size", "100000")).toBe("$100,000.00");
+  });
+
+  it("formats abbreviated revenue aliases as currency", () => {
+    expect(formatCell("rev", 1234.5)).toBe("$1,234.50");
+    expect(formatCell("total_rev", 5000)).toBe("$5,000.00");
+    expect(formatCell("net_rev", 2500.75)).toBe("$2,500.75");
+  });
+
+  it("formats fee/charge aliases as currency", () => {
+    expect(formatCell("setup_fee", 500)).toBe("$500.00");
+    expect(formatCell("monthly_charge", 99.99)).toBe("$99.99");
+  });
 });
 
 describe("formatCell — dates", () => {
@@ -67,6 +89,23 @@ describe("formatCell — other types", () => {
 
   it("renders text columns as-is", () => {
     expect(formatCell("name", "Houston ISD")).toBe("Houston ISD");
+  });
+
+  it("does NOT format these as currency (no false positives)", () => {
+    // size-but-not-money words
+    expect(formatCell("font_size", 14)).toBe("14");
+    expect(formatCell("page_size", 50)).toBe("50");
+    // rev-but-not-revenue words
+    expect(formatCell("revision", 3)).toBe("3");
+    expect(formatCell("reverse", 1)).toBe("1");
+    // commit-but-not-money words
+    expect(formatCell("commitment_level", 5)).toBe("5");
+    expect(formatCell("recommit", 2)).toBe("2");
+    expect(formatCell("commit_count", 100)).toBe("100");
+    // charge-but-rate (NOT a dollar amount)
+    expect(formatCell("charge_rate", 0.05)).toBe("5%");
+    // gross-but-margin (rate/percentage, not dollar amount)
+    expect(formatCell("gross_margin_pct", 0.27)).toBe("27%");
   });
 });
 

--- a/src/features/reports/lib/agent/__tests__/agent-loop.test.ts
+++ b/src/features/reports/lib/agent/__tests__/agent-loop.test.ts
@@ -373,4 +373,124 @@ describe("runAgentLoop", () => {
     }
     expect(runSqlMod.handleRunSql).toHaveBeenCalledTimes(1);
   });
+
+  describe("ghost-report retry", () => {
+    it("retries once when the model returns SQL in text but no tool_use", async () => {
+      const runSqlMod = await import("@/features/reports/lib/tools/run-sql");
+      vi.mocked(runSqlMod.handleRunSql).mockResolvedValueOnce({
+        kind: "ok",
+        sql: "SELECT name FROM districts LIMIT 100",
+        summary: { source: "Districts" },
+        columns: ["name"],
+        rows: [{ name: "Test ISD" }],
+        rowCount: 1,
+        executionTimeMs: 10,
+      });
+
+      const anthropic = makeScriptedAnthropic([
+        {
+          stop_reason: "end_turn",
+          usage: { input_tokens: 10, output_tokens: 5 },
+          content: [
+            {
+              type: "text",
+              text: "Here's the updated query:\n\n```sql\nSELECT name FROM districts LIMIT 100\n```\n\nThis pulls the names.",
+            },
+          ],
+        },
+        {
+          stop_reason: "tool_use",
+          usage: { input_tokens: 12, output_tokens: 8 },
+          content: [
+            { type: "text", text: "Pulling districts." },
+            {
+              type: "tool_use",
+              id: "t1",
+              name: "run_sql",
+              input: { sql: "SELECT name FROM districts LIMIT 100", summary: { source: "Districts" } },
+            },
+          ],
+        },
+      ]);
+
+      const result = await runAgentLoop({
+        anthropic: anthropic as never,
+        userMessage: "show me districts",
+        priorTurns: [],
+        userId: "u1",
+      });
+
+      expect(anthropic.messages.create).toHaveBeenCalledTimes(2);
+      expect(result.kind).toBe("result");
+      // Telemetry: an event marking the corrective injection
+      const correctiveEvent = result.events.find(
+        (e) => e.kind === "tool_result" && e.toolName === "ghost_report_retry",
+      );
+      expect(correctiveEvent).toBeDefined();
+      // Verify the second API call's messages include the corrective user turn.
+      // Note: messages is a shared mutable array, so we check via the corrective
+      // event's content rather than positional indexing.
+      const secondCallArgs = (anthropic.messages.create as ReturnType<typeof vi.fn>).mock.calls[1][0];
+      const allMessages = secondCallArgs.messages as Array<{ role: string; content: unknown }>;
+      const correctiveUserMsg = allMessages.find(
+        (m) => m.role === "user" && typeof m.content === "string" && (m.content as string).includes("run_sql"),
+      );
+      expect(correctiveUserMsg).toBeDefined();
+    });
+
+    it("surrenders after the corrective retry also fails to invoke run_sql", async () => {
+      const anthropic = makeScriptedAnthropic([
+        {
+          stop_reason: "end_turn",
+          usage: { input_tokens: 10, output_tokens: 5 },
+          content: [
+            {
+              type: "text",
+              text: "```sql\nSELECT * FROM districts\n```",
+            },
+          ],
+        },
+        {
+          stop_reason: "end_turn",
+          usage: { input_tokens: 10, output_tokens: 5 },
+          content: [
+            {
+              type: "text",
+              text: "```sql\nSELECT * FROM districts\n```",
+            },
+          ],
+        },
+      ]);
+
+      const result = await runAgentLoop({
+        anthropic: anthropic as never,
+        userMessage: "show me districts",
+        priorTurns: [],
+        userId: "u1",
+      });
+
+      expect(anthropic.messages.create).toHaveBeenCalledTimes(2); // initial + 1 corrective retry, then surrender
+      expect(result.kind).toBe("surrender"); // ghost-retry exhausted — real failure, not a clarifying turn
+    });
+
+    it("does NOT retry when text contains no SQL fence (true clarifying turn)", async () => {
+      const anthropic = makeScriptedAnthropic([
+        {
+          stop_reason: "end_turn",
+          usage: { input_tokens: 5, output_tokens: 3 },
+          content: [{ type: "text", text: "Did you mean closed-won or all stages?" }],
+        },
+      ]);
+
+      const result = await runAgentLoop({
+        anthropic: anthropic as never,
+        userMessage: "show me deals",
+        priorTurns: [],
+        userId: "u1",
+      });
+
+      expect(anthropic.messages.create).toHaveBeenCalledTimes(1);
+      expect(result.kind).toBe("clarifying");
+    });
+  });
 });

--- a/src/features/reports/lib/agent/__tests__/system-prompt.test.ts
+++ b/src/features/reports/lib/agent/__tests__/system-prompt.test.ts
@@ -51,6 +51,34 @@ describe("buildSystemPrompt", () => {
     expect(prompt).toContain("# districts");
   });
 
+  it("states the default-revenue rule (subscription fold-in)", async () => {
+    const prompt = await buildSystemPrompt();
+    expect(prompt.toLowerCase()).toMatch(/default[\s\S]{0,50}revenue/);
+    expect(prompt).toMatch(/COALESCE|fold[\s-]?in|subscription/i);
+  });
+
+  it("requires the agent to narrate what's shown including caveats", async () => {
+    const prompt = await buildSystemPrompt();
+    expect(prompt.toLowerCase()).toMatch(/caveat|surface|explain what/);
+  });
+
+  it("forbids text-only SQL output (anti-ghost-report)", async () => {
+    const prompt = await buildSystemPrompt();
+    // Anchor on the named failure mode 'ghost report' — most stable phrase
+    // that survives reasonable rule rewordings.
+    expect(prompt.toLowerCase()).toMatch(/ghost.?report/);
+    expect(prompt.toLowerCase()).toMatch(/must invoke[\s\S]{0,10}run_sql/);
+  });
+
+  it("instructs the agent to keep currency tokens in column aliases", async () => {
+    const prompt = await buildSystemPrompt();
+    // Pin the rule heading so the rule itself can't be silently removed.
+    expect(prompt.toLowerCase()).toMatch(/keep currency tokens in column aliases/);
+    // Spot-check that the enumerated token list survives — pick a less-common
+    // token (`bookings`) so a future trim that drops half the list still fails.
+    expect(prompt).toMatch(/`bookings`/);
+  });
+
   it("dedupes tables across prior turns and skips unknown ones", async () => {
     const prior: PriorTurn[] = [
       {

--- a/src/features/reports/lib/agent/__tests__/system-prompt.test.ts
+++ b/src/features/reports/lib/agent/__tests__/system-prompt.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { buildSystemPrompt, extractTablesFromSql } from "../system-prompt";
 import type { PriorTurn } from "../conversation";
+import { SEMANTIC_CONTEXT } from "@/lib/district-column-metadata";
 
 describe("buildSystemPrompt", () => {
   it("includes the never-show-SQL rule", async () => {
@@ -71,6 +72,22 @@ describe("buildSystemPrompt", () => {
     // districts schema appears exactly once
     expect(prompt.match(/^# districts$/gm)?.length).toBe(1);
     expect(prompt).not.toContain("unknown_made_up_table");
+  });
+});
+
+describe("SEMANTIC_CONTEXT", () => {
+  it("exposes default_revenue concept for the agent", () => {
+    const ctx = SEMANTIC_CONTEXT.conceptMappings.default_revenue;
+    expect(ctx).toBeDefined();
+    expect(ctx.dealLevel).toMatch(/COALESCE/);
+    expect(ctx.aggregated).toMatch(/district_opportunity_actuals|district_financials/);
+    expect(ctx.note).toMatch(/session_vs_subscription_revenue/);
+  });
+
+  it("session_vs_subscription_revenue points back to default_revenue for the combined default", () => {
+    const ctx = SEMANTIC_CONTEXT.conceptMappings.session_vs_subscription_revenue;
+    expect(ctx).toBeDefined();
+    expect(ctx.note).toMatch(/default_revenue/);
   });
 });
 

--- a/src/features/reports/lib/agent/agent-loop.ts
+++ b/src/features/reports/lib/agent/agent-loop.ts
@@ -15,6 +15,7 @@ import { buildSystemPrompt } from "./system-prompt";
 import type { PriorTurn } from "./conversation";
 import {
   MAX_EXPLORATORY_CALLS_PER_TURN,
+  MAX_GHOST_REPORT_RETRIES,
   MAX_SQL_RETRIES,
   ZERO_USAGE,
   addUsage,
@@ -84,6 +85,18 @@ function extractUsage(
   };
 }
 
+// Detects a SQL code fence in assistant text — the signature of a "ghost
+// report" turn where the model wrote SQL in prose instead of calling run_sql.
+// Matches ```sql ... ``` (case-insensitive) and bare ``` ... ``` blocks
+// containing SELECT/INSERT/UPDATE/DELETE/WITH at the start of a line.
+function containsSqlFence(text: string): boolean {
+  if (!text) return false;
+  if (/```sql/i.test(text)) return true;
+  // Bare fences with a SQL-looking opener
+  const bareFence = /```\s*\n\s*(SELECT|INSERT|UPDATE|DELETE|WITH)\b/i;
+  return bareFence.test(text);
+}
+
 export async function runAgentLoop(args: RunAgentLoopArgs): Promise<AgentResult> {
   const { anthropic, userMessage, priorTurns, userId, conversationId } = args;
 
@@ -103,6 +116,7 @@ export async function runAgentLoop(args: RunAgentLoopArgs): Promise<AgentResult>
   const systemPrompt = await buildSystemPrompt(priorTurns);
 
   let sqlRetriesUsed = 0;
+  let ghostReportRetriesUsed = 0;
   let exploratoryCalls = 0;
   let assistantText = "";
   let iteration = 0;
@@ -186,6 +200,46 @@ export async function runAgentLoop(args: RunAgentLoopArgs): Promise<AgentResult>
 
     if (toolUses.length === 0) {
       const text = assistantText || "(no text)";
+
+      // Ghost-report detection: model wrote SQL in text without calling
+      // run_sql. Inject a corrective user-turn message and let the loop
+      // continue — gives the model one chance to invoke the tool properly.
+      if (
+        containsSqlFence(text) &&
+        ghostReportRetriesUsed < MAX_GHOST_REPORT_RETRIES
+      ) {
+        ghostReportRetriesUsed++;
+        // Reset assistantText so the ghost turn's SQL prose doesn't leak
+        // into the user-visible output if the retry succeeds.
+        assistantText = "";
+        const corrective =
+          "You wrote SQL in a text block but did not call `run_sql`. " +
+          "The user cannot see SQL — the table only updates when you call " +
+          "`run_sql`. Call `run_sql` now with the query you just described.";
+        messages.push({ role: "assistant", content: response.content });
+        messages.push({ role: "user", content: corrective });
+        events.push({
+          kind: "tool_result",
+          toolUseId: "ghost-report-retry",
+          toolName: "ghost_report_retry",
+          isError: true,
+          content: corrective,
+        });
+        continue; // back to the top of while(true)
+      }
+
+      // After ghost-retry exhausted, classify as surrender (real failure)
+      // rather than clarifying (chat-only response).
+      if (ghostReportRetriesUsed > 0) {
+        logDiag("no_tools", "surrender", text);
+        return {
+          kind: "surrender",
+          text,
+          events,
+          usage: totalUsage,
+        };
+      }
+
       logDiag("no_tools", "clarifying", text);
       return {
         kind: "clarifying",

--- a/src/features/reports/lib/agent/system-prompt.ts
+++ b/src/features/reports/lib/agent/system-prompt.ts
@@ -53,9 +53,13 @@ Skipping steps 2 and 3 for unfamiliar tables is the most common cause of failed 
 
 **Never SELECT primary-key ID columns** (leaid, opportunity_id, uuid, *_id) unless the user explicitly asked for them by name. Always prefer the entity's name column (\`districts.name\`, \`opportunities.name\`). Reps see "Texas ISD," not "3100009."
 
+**Keep currency tokens in column aliases.** When you alias a money column, preserve a token the renderer recognizes as currency: \`amount\`, \`revenue\`, \`budget\`, \`bookings\`, \`commit\`, \`size\`, \`fee\`, \`charge\`, \`spend\`, or \`net_total\`. So \`net_booking_amount AS deal_size\` is fine (\`size\` is recognized) but \`net_booking_amount AS deal\` is NOT (would render as a plain number, not as a $ amount). When in doubt, keep the original column name unaliased — the humanizer will turn it into a clean header.
+
 **Ask clarifying questions when the request is ambiguous.** Don't guess. If the user says "show me wins," ask whether they mean bookings (signed contracts) or active opportunities. You can respond with plain text instead of calling a tool.
 
 **\`run_sql\` is terminal.** Only call it once per turn — after this, the turn ends and the user sees the results. If you need to refine further, that happens in the next user turn.
+
+**Never describe a query you intend to run — actually run it.** If the user asks to change the report (e.g. "switch to revenue", "now scope to TX", "include subscriptions"), you MUST invoke \`run_sql\`. Do NOT output SQL in a text block, do NOT write a "here's the new query" preamble without calling the tool. Outputting SQL in text without calling \`run_sql\` produces a "ghost report" — the user sees a confident reply but their table never updates. If you're unsure of column names or table shape, call \`describe_table\` first; do not stall in text.
 
 **Always include LIMIT ≤ 500** in \`run_sql\`. Default to 100 unless the user asked for more.
 
@@ -77,6 +81,18 @@ Good (chat-rail messages):
 Bad (too verbose / over-explained):
 - "I'll now construct a SQL query against the opportunities table to filter for stages 0-5 with created_at greater than 7 days ago, ordered by created_at descending, with a limit of 200."
 - "Sure! Let me help you with that. I'll need to..."
+
+**Explain what's showing — including caveats.** Your one-line preamble alongside \`run_sql\` is for *what's coming*. When relevant, also surface key caveats: subscription fold-in (or its absence), EK12 master/add-on overcounts, stage filters, FY interpretation, session vs subscription split. Reps trust the table because they trust your description of it.
+
+Good caveats:
+- "Pulling each rep's largest closed-won deal by revenue, with EK12 subscriptions folded in."
+- "Using DOA so rep totals are correct — that means category-scoped if you filter on category later."
+- "Excluding EK12 add-on rows because their min/max are cumulative — would over-count otherwise."
+
+Bad (just narrating SQL):
+- "Running SELECT name, total_revenue FROM opportunities WHERE..."
+
+**Default revenue means session+subscription, not session-only.** When a rep asks about "revenue" on a per-deal basis, the default expression is \`COALESCE(o.total_revenue, 0) + COALESCE((SELECT SUM(s.net_total) FROM subscriptions s WHERE s.opportunity_id = o.id), 0) AS revenue\`. Use raw \`o.total_revenue\` (session-only) ONLY when the rep explicitly asks for "session revenue" / "session-only" / "delivered vs scheduled". For aggregated revenue across many deals, use \`district_opportunity_actuals.total_revenue\` or \`district_financials.total_revenue\` (both fold subscriptions in already — don't re-add). When in doubt, search \`default_revenue\` in the metadata.
 
 **Refinement happens in chat — and you have the prior SQL.** When the user is following up on a prior turn (e.g. "now only TX", "exclude closed-won", "sort by bookings desc", "yes", "good, also add the rep name"), the previous turn's SQL is included in the conversation history under "SQL used (server-side only, not shown to user)". Use it:
 - Modify it minimally — preserve CTEs, joins, and column shape unless the user's change requires altering them.

--- a/src/features/reports/lib/agent/types.ts
+++ b/src/features/reports/lib/agent/types.ts
@@ -55,3 +55,4 @@ export const MAX_LIMIT = 500;
 export const DEFAULT_LIMIT = 100;
 export const MAX_EXPLORATORY_CALLS_PER_TURN = 20;
 export const MAX_SQL_RETRIES = 2;
+export const MAX_GHOST_REPORT_RETRIES = 1;

--- a/src/features/reports/lib/format-cell.ts
+++ b/src/features/reports/lib/format-cell.ts
@@ -1,6 +1,6 @@
 import { TABLE_REGISTRY, type DataFormat } from "@/lib/district-column-metadata";
 
-const CURRENCY_HINT = /(amount|budget|revenue|bookings|take|price|cost|value|pipeline|purchase|invoiced|credited|spend)/i;
+const CURRENCY_HINT = /(amount|budget|revenue|bookings|take|price|cost|value|pipeline|purchase|invoiced|credited|spend|_commit\b|deal_size|contract_size|\brev\b|_rev\b|fee|_charge\b|earnings|\bgross\b|net_total|net_booking)/i;
 const PERCENT_HINT = /(_pct|_rate|_ratio|percent)/i;
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:?\d{2})?)?$/;
 

--- a/src/lib/district-column-metadata.ts
+++ b/src/lib/district-column-metadata.ts
@@ -1906,8 +1906,8 @@ export const OPPORTUNITY_COLUMNS: ColumnMetadata[] = [
   {
     field: "totalRevenue",
     column: "total_revenue",
-    label: "Total Revenue (session-only)",
-    description: "completed_revenue + scheduled_revenue on this deal. The delivered-plus-committed total for a single session-based opportunity. SESSION-ONLY — missing EK12 subscription revenue. For inclusive 'total revenue' / 'how much revenue is this deal worth' questions that need to include EK12 subscriptions, use district_financials.total_revenue (rep-agnostic) or DOA.total_revenue (rep/category-scoped); both fold in EK12 subs via refresh_fullmind_financials(). For the delivered-vs-scheduled split, query completed_revenue and scheduled_revenue separately.",
+    label: "Total Revenue (deal, session-only)",
+    description: "Session-only deal revenue (completed_revenue + scheduled_revenue). DOES NOT include EK12 subscription revenue — subscriptions are a separate table linked by opportunity_id. RULE OF THUMB: when a rep asks about 'revenue' on a deal, default to the SUBSCRIPTION-FOLDED total: COALESCE(o.total_revenue, 0) + COALESCE((SELECT SUM(s.net_total) FROM subscriptions s WHERE s.opportunity_id = o.id), 0). Applies to single-deal lookups only — for multi-deal aggregates this correlated subquery is both slow and error-prone, so use district_opportunity_actuals.total_revenue instead. Skip the COALESCE fold and use this column directly ONLY when the rep explicitly asks for 'session revenue', 'session-only', or the delivered/scheduled split (in which case also pair with completed_revenue + scheduled_revenue). If the rep asks for the session-vs-subscription split rather than a folded total, see SEMANTIC_CONTEXT.conceptMappings.session_vs_subscription_revenue. For aggregated revenue across many deals, prefer district_opportunity_actuals.total_revenue or district_financials.total_revenue — both fold subscriptions in already.",
     domain: "opportunity",
     format: "currency",
     source: "opensearch",

--- a/src/lib/district-column-metadata.ts
+++ b/src/lib/district-column-metadata.ts
@@ -36,7 +36,8 @@ export type ColumnDomain =
   | "state"
   | "history"
   | "unmatched"
-  | "audit";
+  | "audit"
+  | "news";
 
 export type DataFormat =
   | "text"
@@ -62,7 +63,8 @@ export type DataSource =
   | "opensearch"        // opportunities, sessions (Railway scheduler sync)
   | "elevate_k12"       // subscriptions (Elevate import pipeline)
   | "scraper"           // vacancies, vacancy_scans
-  | "query_tool";       // query_log, saved_reports
+  | "query_tool"        // query_log, saved_reports
+  | "news_ingest";      // news_articles + junctions (RSS/Google News + Haiku classifier)
 
 export interface ColumnMetadata {
   /** Prisma camelCase field name */
@@ -2583,6 +2585,31 @@ export const VACANCY_COLUMNS: ColumnMetadata[] = [
   { field: "updatedAt", column: "updated_at", label: "Updated At", description: "Last update timestamp.", domain: "vacancy", format: "date", source: "scraper", queryable: true },
 ];
 
+/**
+ * news_articles — RSS + Google News ingestion of K-12 news, matched to
+ * districts/schools/contacts via junction tables and classified by a Haiku
+ * pass for sentiment, topic categories, and Fullmind sales relevance.
+ */
+export const NEWS_ARTICLE_COLUMNS: ColumnMetadata[] = [
+  { field: "id", column: "id", label: "Article ID", description: "cuid PK.", domain: "news", format: "text", source: "news_ingest", queryable: true },
+  { field: "url", column: "url", label: "URL", description: "Canonical article URL. Rep questions linking out to the original story should expose this column.", domain: "news", format: "text", source: "news_ingest", queryable: true },
+  { field: "urlHash", column: "url_hash", label: "URL Hash", description: "Internal dedup key (sha256 of url). Not user-relevant — never SELECT for reps.", domain: "news", format: "text", source: "news_ingest", queryable: false },
+  { field: "title", column: "title", label: "Title", description: "Headline. Use ILIKE for keyword search ('news mentioning Algebra', 'articles about ESSER').", domain: "news", format: "text", source: "news_ingest", queryable: true },
+  { field: "description", column: "description", label: "Description", description: "1-sentence summary from the feed (often null for Google News results).", domain: "news", format: "text", source: "news_ingest", queryable: true },
+  { field: "content", column: "content", label: "Full Content", description: "Full article body when available. Large text — only include in SELECT when the rep asks for the article body or wants a deep keyword scan.", domain: "news", format: "text", source: "news_ingest", queryable: true },
+  { field: "imageUrl", column: "image_url", label: "Image URL", description: "Lead image URL when present in the feed.", domain: "news", format: "text", source: "news_ingest", queryable: true },
+  { field: "author", column: "author", label: "Author", description: "Article byline (often null).", domain: "news", format: "text", source: "news_ingest", queryable: true },
+  { field: "source", column: "source", label: "Source", description: "Publication name as parsed from the feed (e.g., 'Chalkbeat', 'EdSurge', a local paper). For 'news from Chalkbeat' style filters use this column. For the originating ingest pipeline use feed_source.", domain: "news", format: "text", source: "news_ingest", queryable: true },
+  { field: "feedSource", column: "feed_source", label: "Feed Source", description: "Which ingest pipeline produced this row. Full enum: 'chalkbeat', 'k12dive', 'the74', 'edsurge', 'google_news_query' (industry-wide topic searches), 'google_news_district' (per-district name searches), 'manual_refresh' (admin-triggered). Industry-trends questions favor the first 4 + google_news_query; per-district coverage favors google_news_district plus the junction.", domain: "news", format: "text", source: "news_ingest", queryable: true },
+  { field: "publishedAt", column: "published_at", label: "Published At", description: "When the article was published per the source feed. Default sort/filter column for 'recent news' / 'this week' / 'last 30 days' rep questions. Indexed.", domain: "news", format: "date", source: "news_ingest", queryable: true },
+  { field: "fetchedAt", column: "fetched_at", label: "Fetched At", description: "When our ingestor first saw the article. Use published_at for rep-facing recency questions; fetched_at is mainly for ops/freshness debugging.", domain: "news", format: "date", source: "news_ingest", queryable: true },
+  { field: "stateAbbrevs", column: "state_abbrevs", label: "State Abbreviations", description: "Array of 2-letter state codes the article was geo-tagged to (e.g., {'TX','OK'}). Sourced from feed metadata + district junction backfill. Use the postgres array operator: state_abbrevs && ARRAY['TX'] for 'news in TX', or 'TX' = ANY(state_abbrevs). For multi-state queries use the && (overlap) operator. May be empty when geo couldn't be inferred.", domain: "news", format: "text", source: "news_ingest", queryable: true },
+  { field: "sentiment", column: "sentiment", label: "Sentiment", description: "Haiku classifier output. Full enum: 'positive', 'neutral', 'negative'. NULL until the article is classified — filtering on sentiment IS NOT NULL excludes the unclassified backlog. For 'negative news' / 'bad news at <district>' rep questions, filter sentiment = 'negative'.", domain: "news", format: "text", source: "news_ingest", queryable: true },
+  { field: "categories", column: "categories", label: "Categories", description: "Haiku-assigned topic tags (text[]). Full enum: 'budget_funding', 'leadership_change', 'academic_performance', 'enrollment_trends', 'labor_contract', 'curriculum_adoption', 'technology_edtech', 'policy_regulation', 'facility_operations', 'student_services', 'scandal_incident'. Use postgres array ops: categories && ARRAY['budget_funding','leadership_change'] for any-match, or 'student_services' = ANY(categories). Empty array means classifier ran but nothing applied; NULL means not yet classified.", domain: "news", format: "text", source: "news_ingest", queryable: true },
+  { field: "fullmindRelevance", column: "fullmind_relevance", label: "Fullmind Relevance", description: "Sales-actionability tier from the Haiku classifier. Full enum: 'high' (direct sales signal — RFPs, Title I, intervention budget, ESSER), 'medium' (priorities affected but not a direct selling moment — general budget, curriculum, enrollment, SEL), 'low' (K-12 news but not sales-actionable — facilities, scheduling, sports), 'none' (off-topic). NULL until classified. For 'high-priority news' / 'sales-relevant news' default to fullmind_relevance IN ('high','medium'). Indexed alongside published_at.", domain: "news", format: "text", source: "news_ingest", queryable: true },
+  { field: "classifiedAt", column: "classified_at", label: "Classified At", description: "When the Haiku classifier ran. NULL = not yet classified (sentiment / categories / fullmind_relevance will all be null on those rows).", domain: "news", format: "date", source: "news_ingest", queryable: true },
+];
+
 /** query_log — audit log of every natural-language query and agentic action */
 export const QUERY_LOG_COLUMNS: ColumnMetadata[] = [
   { field: "id", column: "id", label: "ID", description: "Auto-increment primary key.", domain: "audit", format: "integer", source: "query_tool", queryable: true },
@@ -2785,6 +2812,12 @@ export const TABLE_REGISTRY: Record<string, TableMetadata> = {
         joinSql: "district_tags.district_leaid = districts.leaid",
         description: "Junction to tags",
       },
+      {
+        toTable: "news_article_districts",
+        type: "one-to-many",
+        joinSql: "news_article_districts.leaid = districts.leaid",
+        description: "Junction to news articles (join news_articles via article_id; default confidence IN ('high','llm'))",
+      },
     ],
   },
 
@@ -2867,7 +2900,7 @@ export const TABLE_REGISTRY: Record<string, TableMetadata> = {
   contacts: {
     table: "contacts",
     description:
-      "District-level people records — superintendents, admins, principals, curriculum directors, etc. One district can have many contacts. Rep questions: 'who do we know at <district>', 'all superintendents in CA', 'HR directors we've reached', 'primary contact at <district>', 'stale contacts', 'contacts at <specific school>' (via the school_contacts junction), 'contacts who attended <event>' (via the activity_contacts junction), 'contacts assigned to <task>' (via task_contacts). Use persona / seniority_level for role-based filtering (both columns' value sets live in the data — call get_column_values to confirm). For contacts-at-a-school questions, the school_contacts junction is the right hop (still excluded from TABLE_REGISTRY; use raw Prisma join).",
+      "District-level people records — superintendents, admins, principals, curriculum directors, etc. One district can have many contacts. Rep questions: 'who do we know at <district>', 'all superintendents in CA', 'HR directors we've reached', 'primary contact at <district>', 'stale contacts', 'contacts at <specific school>' (via the school_contacts junction), 'contacts who attended <event>' (via the activity_contacts junction), 'contacts assigned to <task>' (via task_contacts), 'contacts mentioned in recent news' (via the news_article_contacts junction). Use persona / seniority_level for role-based filtering (both columns' value sets live in the data — call get_column_values to confirm). For contacts-at-a-school questions, the school_contacts junction is the right hop (still excluded from TABLE_REGISTRY; use raw Prisma join).",
     primaryKey: "id",
     columns: CONTACT_COLUMNS,
     relationships: [
@@ -2876,6 +2909,12 @@ export const TABLE_REGISTRY: Record<string, TableMetadata> = {
         type: "many-to-one",
         joinSql: "contacts.leaid = districts.leaid",
         description: "Parent district",
+      },
+      {
+        toTable: "news_article_contacts",
+        type: "one-to-many",
+        joinSql: "news_article_contacts.contact_id = contacts.id",
+        description: "Junction to news articles mentioning this contact (default confidence IN ('high','llm'))",
       },
     ],
   },
@@ -3044,6 +3083,12 @@ export const TABLE_REGISTRY: Record<string, TableMetadata> = {
         joinSql: "school_enrollment_history.ncessch = schools.ncessch",
         description: "Historical enrollment snapshots per year (trend / growth / shrinkage)",
       },
+      {
+        toTable: "news_article_schools",
+        type: "one-to-many",
+        joinSql: "news_article_schools.ncessch = schools.ncessch",
+        description: "Junction to news articles mentioning this school (default confidence IN ('high','llm'))",
+      },
     ],
   },
   district_data_history: {
@@ -3135,6 +3180,67 @@ export const TABLE_REGISTRY: Record<string, TableMetadata> = {
       },
     ],
   },
+  news_articles: {
+    table: "news_articles",
+    description:
+      "K-12 news articles ingested from RSS (Chalkbeat, K12 Dive, The 74, EdSurge), Google News (industry-topic + per-district queries), and admin manual refreshes. Classified by a Haiku pass for sentiment, topic categories, and Fullmind sales relevance — those columns are NULL until the classifier runs. Article-to-entity matching is many-to-many via three junctions: news_article_districts, news_article_schools, news_article_contacts. Rep questions split three ways: (1) per-entity coverage ('news at <district>', 'recent news at my schools', 'articles mentioning <superintendent>') — go through the junction, (2) per-state recency ('news in TX this week', 'recent CA coverage') — use state_abbrevs (postgres text[]) WITHOUT the junction, (3) industry trends ('what's been hot in K-12 news this month', 'most-covered topics') — group by categories or feed_source on news_articles directly. For 'sales-relevant news' default to fullmind_relevance IN ('high','medium'). Articles can outlive their classification window — when filtering by sentiment / categories / fullmind_relevance, surface a brief caveat that unclassified articles are excluded. Always order by published_at DESC for recency questions.",
+    primaryKey: "id",
+    columns: NEWS_ARTICLE_COLUMNS,
+    relationships: [
+      {
+        toTable: "news_article_districts",
+        type: "one-to-many",
+        joinSql: "news_article_districts.article_id = news_articles.id",
+        description: "Junction to districts (each row carries a confidence tier)",
+      },
+      {
+        toTable: "news_article_schools",
+        type: "one-to-many",
+        joinSql: "news_article_schools.article_id = news_articles.id",
+        description: "Junction to schools",
+      },
+      {
+        toTable: "news_article_contacts",
+        type: "one-to-many",
+        joinSql: "news_article_contacts.article_id = news_articles.id",
+        description: "Junction to contacts (named people mentioned in the article)",
+      },
+    ],
+  },
+  news_article_districts: {
+    table: "news_article_districts",
+    description:
+      "Junction between news articles and districts. confidence column is critical: full enum 'high' (exact-name match against district directory, ~5% false-positive rate), 'llm' (LLM-confirmed match against ambiguous candidates, the medium-quality tier), 'low' (uncertain — usually filtered out). DEFAULT filter for rep-facing news: confidence IN ('high','llm'). Use 'high' alone for the strictest accuracy.",
+    primaryKey: ["articleId", "leaid"],
+    columns: [],
+    relationships: [
+      { toTable: "news_articles", type: "many-to-one", joinSql: "news_article_districts.article_id = news_articles.id", description: "Parent article" },
+      { toTable: "districts", type: "many-to-one", joinSql: "news_article_districts.leaid = districts.leaid", description: "Matched district" },
+    ],
+  },
+  news_article_schools: {
+    table: "news_article_schools",
+    description:
+      "Junction between news articles and schools. Same confidence semantics as news_article_districts: full enum 'high' / 'llm' / 'low'. DEFAULT filter for rep-facing news: confidence IN ('high','llm'). School matches are a subset of high-confidence district matches (we only scan school names within an article's matched districts).",
+    primaryKey: ["articleId", "ncessch"],
+    columns: [],
+    relationships: [
+      { toTable: "news_articles", type: "many-to-one", joinSql: "news_article_schools.article_id = news_articles.id", description: "Parent article" },
+      { toTable: "schools", type: "many-to-one", joinSql: "news_article_schools.ncessch = schools.ncessch", description: "Matched school" },
+    ],
+  },
+  news_article_contacts: {
+    table: "news_article_contacts",
+    description:
+      "Junction between news articles and contacts (named people: superintendents, CFOs, board members, principals, etc.). Same confidence semantics as the other news junctions: full enum 'high' / 'llm' / 'low'. DEFAULT filter for rep-facing news: confidence IN ('high','llm'). Contact matches require both name co-occurrence AND a title-keyword co-occurrence in the article — so this surface is good for 'news mentioning <superintendent>' or 'recent coverage of leadership at <district>'.",
+    primaryKey: ["articleId", "contactId"],
+    columns: [],
+    relationships: [
+      { toTable: "news_articles", type: "many-to-one", joinSql: "news_article_contacts.article_id = news_articles.id", description: "Parent article" },
+      { toTable: "contacts", type: "many-to-one", joinSql: "news_article_contacts.contact_id = contacts.id", description: "Matched contact" },
+    ],
+  },
+
   query_log: {
     table: "query_log",
     description:
@@ -3506,6 +3612,17 @@ export const SEMANTIC_CONTEXT: SemanticContext = {
         "EK12 MASTER/ADD-ON DATA GAP: Elevate K12 deals follow a master-renewal-contract + add-ons structure that the data model does NOT yet capture. A master contract opportunity has minimum_purchase_amount and maximum_budget; add-on opportunities are separate rows in the same table and consume budget against the master's max — but there is NO parent_opportunity_id linking them. Implications: SUM(maximum_budget) across opportunities will roughly DOUBLE-COUNT the EK12 ceiling because both the master max and the add-on maxes are summed independently. SUM(minimum_purchase_amount) has the same trap but there IS a safe alternative: district_opportunity_actuals.min_purchase_bookings chain-deduplicates the add-on cumulative values correctly — prefer it for any closed-won contracted-floor aggregate. SUM(opportunities.net_booking_amount) is safe because add-ons add real incremental signed dollars. MAX(maximum_budget) per district is still misleading. When the user asks about 'upside', 'ceiling', 'potential', 'max FY26 pipeline', or any aggregation of maximum_budget, you MUST either refuse or surface a heavy caveat that the answer overcounts because we cannot distinguish master contracts from add-ons. Per-deal questions (single opportunity's min/max/budget) are fine. Tracked in Docs/superpowers/followups/2026-04-12-ek12-master-addon-data-gap.md.",
     },
     {
+      triggerTables: [
+        "news_articles",
+        "news_article_districts",
+        "news_article_schools",
+        "news_article_contacts",
+      ],
+      severity: "mandatory",
+      message:
+        "NEWS QUERY DEFAULTS: (1) When joining any of the three news junctions (news_article_districts / news_article_schools / news_article_contacts), DEFAULT to confidence IN ('high','llm'). The third value 'low' is uncertain matches and pollutes rep-facing results — only include it when the rep explicitly asks for everything. There is no 'medium' value; 'llm' IS the medium tier. (2) Classification columns (sentiment, categories, fullmind_relevance, classified_at) are NULL on the unclassified backlog. Filtering on any of them silently drops those rows — when a rep asks 'all news at <district>' or 'this week's coverage' WITHOUT a sentiment/category/relevance filter, do NOT add one (you'll under-count). When a rep DOES filter on classification ('negative news', 'sales-relevant news'), add a brief caveat that unclassified articles are excluded. (3) Always order by published_at DESC for recency questions; the (published_at) and (fullmind_relevance, published_at) indexes make this fast. (4) For per-state recency ('news in TX'), use news_articles.state_abbrevs (postgres text[]) directly with the && or = ANY operators — going through the district junction is slower and unnecessary unless the rep wants per-district drill-in. (5) For 'sales-relevant news' default fullmind_relevance IN ('high','medium').",
+    },
+    {
       triggerTables: ["opportunities"],
       severity: "mandatory",
       message:
@@ -3528,10 +3645,6 @@ export const SEMANTIC_CONTEXT: SemanticContext = {
     "initiatives",
     "map_views",
     "metric_registry",
-    "news_article_contacts",
-    "news_article_districts",
-    "news_article_schools",
-    "news_articles",
     "news_ingest_runs",
     "news_match_queue",
     "opportunity_snapshots",

--- a/src/lib/district-column-metadata.ts
+++ b/src/lib/district-column-metadata.ts
@@ -3397,10 +3397,17 @@ export const SEMANTIC_CONTEXT: SemanticContext = {
         "district_opportunity_actuals.sales_rep_email — filter or GROUP BY this column for any rep-scoped question.",
       note: "DOA and raw opportunities are the only sources with a rep column. Raw opportunities is unsafe for aggregates (no text-stage closed-won, no EK12 fold-in, no add-on chain dedup) — always prefer DOA for rep rollups. DF has no rep column and CANNOT answer rep-scoped questions.",
     },
+    default_revenue: {
+      dealLevel:
+        "When a rep asks about 'revenue' for a single deal or for per-deal results, the default is session+subscription folded together: COALESCE(o.total_revenue, 0) + COALESCE((SELECT SUM(s.net_total) FROM subscriptions s WHERE s.opportunity_id = o.id), 0) AS revenue. Apply this fold-in by default — do NOT use raw o.total_revenue (session-only) unless the rep explicitly says 'session revenue', 'session-only', or asks for a delivered/scheduled split.",
+      aggregated:
+        "For revenue aggregates across many deals (rep totals, district totals, state totals, FY totals), use district_opportunity_actuals.total_revenue (rep/category-scoped) or district_financials.total_revenue WHERE vendor='fullmind' (rep-agnostic). Both already fold EK12 subscription revenue in via refresh_fullmind_financials() / opp_subscriptions CTE — do NOT re-add subscriptions on top.",
+      note: "The single most common revenue mistake on this agent is reaching for opportunities.total_revenue as the default and silently producing session-only numbers. Reps don't think in modalities — when they say 'revenue' they mean 'all the dollars on this deal'. This mapping makes the right default explicit. If the user asks for the SPLIT (session vs subscription), see session_vs_subscription_revenue.",
+    },
     session_vs_subscription_revenue: {
       dealLevel:
         "session_revenue: SUM(opportunities.total_revenue) across opportunities in scope. subscription_revenue: SUM(subscriptions.net_total) where subscriptions.opportunity_id IN (<scope>). subscriptions.net_total is SIGNED — credits/cancellations reduce the sum.",
-      note: "Neither DOA nor DF exposes session and subscription revenue separately — both fold them together in total_revenue. When a user explicitly asks for the split, compute deal-level: query opportunities and subscriptions separately and report both. If this breakdown becomes a frequent request, add session_revenue / subscription_revenue columns to DOA as a follow-up.",
+      note: "Neither DOA nor DF exposes session and subscription revenue separately — both fold them together in total_revenue. When a user explicitly asks for the split, compute deal-level: query opportunities and subscriptions separately and report both. If this breakdown becomes a frequent request, add session_revenue / subscription_revenue columns to DOA as a follow-up. For the combined default when a rep just says 'revenue', see default_revenue.",
     },
     delivered_vs_scheduled_revenue: {
       dealLevel:


### PR DESCRIPTION
## Summary

Three orthogonal fixes for the Reports chat agent observed in conversation `5fd14854...` (May 2 2026, sierra.arcega):

- **Default revenue includes EK12 subscriptions.** Per-deal "revenue" questions now fold subscriptions in by default; raw session-only `total_revenue` is the explicit override. The user had to ask twice in the source conversation to get this behavior.
- **Ghost-report fix.** Conversation turn 143: agent text-narrated a SQL change without ever calling `run_sql`, so the user's table didn't update but the reply looked successful. Two-layer fix: prompt rule ("never describe a query you intend to run") + runtime auto-retry that injects a corrective message when text contains a SQL fence with no `tool_use`. Falls through to `surrender` (not `clarifying`) on retry exhaustion so error dashboards see real surrenders.
- **Currency formatting on aliased columns.** `net_booking_amount AS deal_size` rendered as plain decimals because `deal_size` didn't match the currency-name regex. Two-layer fix: widened the regex with bounded matchers (`_commit\b`, `deal_size`, `\brev\b`, `_charge\b`, `\bgross\b`, etc.) + system-prompt rule that aliases must keep a currency token.

5 commits, each independently green:

1. `fix(reports): widen currency formatter to catch aliased columns`
2. `feat(reports): make subscription-folded revenue the default for deal-level questions`
3. `feat(reports): add default_revenue concept mapping`
4. `feat(reports): system-prompt rules for revenue default, narration, anti-ghost-report, alias hygiene`
5. `feat(reports): auto-retry once when agent emits SQL in text without invoking run_sql`

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/features/reports` — 112/112 passing
- [x] `npx vitest run` — 1828/1846 passing; 18 DB-dependent integration test failures match the baseline on `main` (require `DATABASE_URL`)
- [ ] Manual: ask "largest deal by revenue" — preamble should mention subscription fold-in or stage filter
- [ ] Manual: refine to "now by revenue" — should produce updated table, not text-only response
- [ ] Manual: `min_commit` / `max_commit` / `deal_size` render as `$X,XXX.XX`
- [ ] Manual: "show session revenue only" — agent uses raw `total_revenue` and calls out the override
- [ ] Manual: trigger a ghost report (rare; the system-prompt rule should suppress most) — verify the auto-retry fires once and the `ghost_report_retry` event lands in `query_log.params.events`

🤖 Generated with [Claude Code](https://claude.com/claude-code)