### PR TITLE
perf(reports): pre-bake schemas, tool-history replay, 1h cache, summary fallback

### DIFF
--- a/src/features/reports/lib/agent/__tests__/agent-loop.test.ts
+++ b/src/features/reports/lib/agent/__tests__/agent-loop.test.ts
@@ -7,6 +7,7 @@ vi.mock("@/features/reports/lib/tools/list-tables", () => ({
 }));
 vi.mock("@/features/reports/lib/tools/describe-table", () => ({
   handleDescribeTable: vi.fn(async () => "columns..."),
+  buildCompactSchema: vi.fn((table: string) => `## ${table} — mock compact schema`),
 }));
 vi.mock("@/features/reports/lib/tools/search-metadata", () => ({
   handleSearchMetadata: vi.fn(async () => "no matches"),

--- a/src/features/reports/lib/agent/__tests__/system-prompt.test.ts
+++ b/src/features/reports/lib/agent/__tests__/system-prompt.test.ts
@@ -30,12 +30,34 @@ describe("buildSystemPrompt", () => {
     expect(prompt.toLowerCase()).toMatch(/terminal|ends the turn|once per turn/);
   });
 
-  it("with no prior turns, omits the 'already explored' section header", async () => {
+  it("always includes the pre-loaded schemas section (covers districts, opportunities, etc.)", async () => {
     const prompt = await buildSystemPrompt();
-    expect(prompt).not.toContain("# Tables already explored in this conversation");
+    expect(prompt).toContain("# Pre-loaded table schemas");
+    expect(prompt).toContain("## districts");
+    expect(prompt).toContain("## opportunities");
   });
 
-  it("with a prior turn that queried districts, includes the 'already explored' section", async () => {
+  it("with no prior turns, omits the 'other tables explored' section header", async () => {
+    const prompt = await buildSystemPrompt();
+    expect(prompt).not.toContain("# Other tables already explored in this conversation");
+  });
+
+  it("with a prior turn that queried a non-pre-baked table, includes the explored section for that table", async () => {
+    const prior: PriorTurn[] = [
+      {
+        question: "Show me tasks for the rep",
+        sql: "SELECT id, title FROM tasks WHERE owner_id = '1' LIMIT 100",
+        summary: null,
+        assistantText: null,
+        createdAt: new Date(),
+      },
+    ];
+    const prompt = await buildSystemPrompt(prior);
+    expect(prompt).toContain("# Other tables already explored in this conversation");
+    expect(prompt).toContain("# tasks");
+  });
+
+  it("with a prior turn that queried only pre-baked tables, omits the explored section (no duplication)", async () => {
     const prior: PriorTurn[] = [
       {
         question: "Show me districts in Texas",
@@ -46,30 +68,31 @@ describe("buildSystemPrompt", () => {
       },
     ];
     const prompt = await buildSystemPrompt(prior);
-    expect(prompt).toContain("# Tables already explored in this conversation");
-    expect(prompt).toContain("# districts");
+    expect(prompt).not.toContain("# Other tables already explored in this conversation");
+    // districts compact schema still appears (in pre-baked section), exactly once
+    expect(prompt.match(/^## districts —/gm)?.length).toBe(1);
   });
 
   it("dedupes tables across prior turns and skips unknown ones", async () => {
     const prior: PriorTurn[] = [
       {
         question: "Q1",
-        sql: "SELECT * FROM districts d JOIN unknown_made_up_table u ON u.id = d.leaid",
+        sql: "SELECT * FROM tasks t JOIN unknown_made_up_table u ON u.id = t.id",
         summary: null,
         assistantText: null,
         createdAt: new Date(),
       },
       {
         question: "Q2",
-        sql: "SELECT * FROM districts WHERE state_abbrev = 'CA'",
+        sql: "SELECT * FROM tasks WHERE owner_id = 'abc'",
         summary: null,
         assistantText: null,
         createdAt: new Date(),
       },
     ];
     const prompt = await buildSystemPrompt(prior);
-    // districts schema appears exactly once
-    expect(prompt.match(/^# districts$/gm)?.length).toBe(1);
+    // tasks full schema (from describe_table) appears exactly once in the explored section
+    expect(prompt.match(/^# tasks$/gm)?.length).toBe(1);
     expect(prompt).not.toContain("unknown_made_up_table");
   });
 });

--- a/src/features/reports/lib/agent/agent-loop.ts
+++ b/src/features/reports/lib/agent/agent-loop.ts
@@ -87,15 +87,41 @@ function extractUsage(
 export async function runAgentLoop(args: RunAgentLoopArgs): Promise<AgentResult> {
   const { anthropic, userMessage, priorTurns, userId, conversationId } = args;
 
+  // Replay prior turns as tool_use/tool_result pairs (not Markdown SQL blocks)
+  // so the model sees structured execution it can't mimic in plain-text replies.
+  // The old "SQL used (server-side only, not shown to user)" template was being
+  // copied into user-facing chat text by the model.
   const history: Anthropic.MessageParam[] = [];
   for (const t of priorTurns) {
     history.push({ role: "user", content: t.question });
-    const blocks: string[] = [];
-    if (t.summary?.source) blocks.push(`Source: ${t.summary.source}`);
-    if (t.sql) blocks.push(`SQL used (server-side only, not shown to user):\n\`\`\`sql\n${t.sql}\n\`\`\``);
-    if (t.assistantText) blocks.push(t.assistantText);
-    if (blocks.length > 0) {
-      history.push({ role: "assistant", content: blocks.join("\n\n") });
+    if (t.sql) {
+      const priorToolUseId = `prior_${t.createdAt.getTime()}`;
+      const summaryForReplay: QuerySummary = t.summary ?? {
+        source: t.question.slice(0, 200),
+      };
+      const assistantBlocks: Anthropic.ContentBlockParam[] = [];
+      if (t.assistantText) {
+        assistantBlocks.push({ type: "text", text: t.assistantText });
+      }
+      assistantBlocks.push({
+        type: "tool_use",
+        id: priorToolUseId,
+        name: RUN_SQL_TOOL_NAME,
+        input: { sql: t.sql, summary: summaryForReplay },
+      });
+      history.push({ role: "assistant", content: assistantBlocks });
+      history.push({
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: priorToolUseId,
+            content: `run_sql ok — ${summaryForReplay.source}`,
+          },
+        ],
+      });
+    } else if (t.assistantText) {
+      history.push({ role: "assistant", content: t.assistantText });
     }
   }
   history.push({ role: "user", content: userMessage });
@@ -141,7 +167,7 @@ export async function runAgentLoop(args: RunAgentLoopArgs): Promise<AgentResult>
       model: "claude-opus-4-7",
       max_tokens: 16000,
       thinking: { type: "adaptive" },
-      system: [{ type: "text", text: systemPrompt, cache_control: { type: "ephemeral" } }],
+      system: [{ type: "text", text: systemPrompt, cache_control: { type: "ephemeral", ttl: "1h" } }],
       tools: AGENT_TOOLS,
       messages,
     });
@@ -201,7 +227,7 @@ export async function runAgentLoop(args: RunAgentLoopArgs): Promise<AgentResult>
     let runSqlResult: RunSqlResult | null = null;
     if (runSqlUse) {
       const input = runSqlUse.input as { sql: string; summary: QuerySummary };
-      runSqlResult = await handleRunSql(input.sql, input.summary);
+      runSqlResult = await handleRunSql(input.sql, input.summary, userMessage);
 
       if (runSqlResult.kind === "ok") {
         events.push({

--- a/src/features/reports/lib/agent/system-prompt.ts
+++ b/src/features/reports/lib/agent/system-prompt.ts
@@ -1,6 +1,25 @@
 import { TABLE_REGISTRY, SEMANTIC_CONTEXT } from "@/lib/district-column-metadata";
-import { handleDescribeTable } from "@/features/reports/lib/tools/describe-table";
+import {
+  buildCompactSchema,
+  handleDescribeTable,
+} from "@/features/reports/lib/tools/describe-table";
 import type { PriorTurn } from "./conversation";
+
+// Top tables by query frequency (from QueryLog usage analysis). Their compact
+// schemas are baked into the system prompt so the model can run_sql against
+// them without first calling describe_table — saves several thousand tokens
+// per cold-start turn and a couple of seconds of latency.
+const PREBAKED_TABLES = [
+  "opportunities",
+  "districts",
+  "district_opportunity_actuals",
+  "district_financials",
+  "user_profiles",
+  "activities",
+  "vacancies",
+  "subscriptions",
+  "sessions",
+] as const;
 
 export function extractTablesFromSql(sql: string): string[] {
   const matches = sql.matchAll(/(?:from|join)\s+["`]?([a-zA-Z_][\w]*)["`]?/gi);
@@ -19,16 +38,25 @@ export async function buildSystemPrompt(priorTurns: PriorTurn[] = []): Promise<s
     .map((w) => `- ${w.message}`)
     .join("\n");
 
+  const prebakedSet = new Set<string>(PREBAKED_TABLES);
+  const prebakedSection = `# Pre-loaded table schemas (use directly, no describe_table needed)\n\nThe schemas below cover ~90% of common questions. Call \`run_sql\` directly against any of these tables — no \`describe_table\` step required. If a column you need is not listed here for a pre-loaded table (rare), you may still call \`describe_table\` on it.\n\n${PREBAKED_TABLES.map(
+    (name) => buildCompactSchema(name),
+  )
+    .filter(Boolean)
+    .join("\n\n")}`;
+
   const exploredTables = new Set<string>();
   for (const t of priorTurns) {
     if (!t.sql) continue;
     for (const name of extractTablesFromSql(t.sql)) {
-      if (name in TABLE_REGISTRY) exploredTables.add(name);
+      if (name in TABLE_REGISTRY && !prebakedSet.has(name)) {
+        exploredTables.add(name);
+      }
     }
   }
 
   const exploredSection = exploredTables.size
-    ? `\n\n# Tables already explored in this conversation\n\nThe schemas below were examined in earlier turns. You may use these tables directly in \`run_sql\` without calling \`describe_table\` again. For any table NOT listed below, \`describe_table\` is still required before \`run_sql\`.\n\n${(
+    ? `\n\n# Other tables already explored in this conversation\n\nThe schemas below were examined in earlier turns. You may use these tables directly in \`run_sql\` without calling \`describe_table\` again. For any table NOT listed here AND NOT in the pre-loaded section above, \`describe_table\` is still required before \`run_sql\`.\n\n${(
         await Promise.all([...exploredTables].map((name) => handleDescribeTable(name)))
       ).join("\n\n")}`
     : "";
@@ -37,10 +65,10 @@ export async function buildSystemPrompt(priorTurns: PriorTurn[] = []): Promise<s
 
 # How you work
 
-You have tools to explore the database. **For tables you haven't seen yet, always explore before \`run_sql\`** — guessing column names burns retries. A typical first encounter with a table needs:
+You have tools to explore the database. **For pre-loaded tables (see the "Pre-loaded table schemas" section below), skip exploration and call \`run_sql\` directly** — those columns are already authoritative. For other tables, always explore before \`run_sql\` — guessing column names burns retries. A typical first encounter with an unlisted table needs:
 
 1. \`search_metadata\` when the user mentions a concept (bookings, renewal, pipeline, win rate) — returns the right columns and any gotchas.
-2. \`describe_table\` on every table you plan to reference in \`run_sql\` — UNLESS the table appears under "Tables already explored in this conversation," in which case you may skip this step and use the schema shown there.
+2. \`describe_table\` on every UNLISTED table you plan to reference. Pre-loaded tables don't need this step.
 3. \`get_column_values\` on any filter column whose value shape you're not sure about (e.g. stage strings, category strings).
 4. Optionally \`count_rows\` or \`sample_rows\` to sanity-check.
 5. \`run_sql\` with the final query. This ends the turn.
@@ -78,17 +106,19 @@ Bad (too verbose / over-explained):
 - "I'll now construct a SQL query against the opportunities table to filter for stages 0-5 with created_at greater than 7 days ago, ordered by created_at descending, with a limit of 200."
 - "Sure! Let me help you with that. I'll need to..."
 
-**Refinement happens in chat — and you have the prior SQL.** When the user is following up on a prior turn (e.g. "now only TX", "exclude closed-won", "sort by bookings desc", "yes", "good, also add the rep name"), the previous turn's SQL is included in the conversation history under "SQL used (server-side only, not shown to user)". Use it:
-- Modify it minimally — preserve CTEs, joins, and column shape unless the user's change requires altering them.
+**Refinement happens in chat — and you have the prior SQL.** When the user is following up on a prior turn (e.g. "now only TX", "exclude closed-won", "sort by bookings desc", "yes", "good, also add the rep name"), the previous turn's \`run_sql\` calls and their results are visible in the conversation history as tool_use/tool_result pairs. Use them:
+- Modify the prior SQL minimally — preserve CTEs, joins, and column shape unless the user's change requires altering them.
 - Don't re-explore tables that already appear under "Tables already explored in this conversation."
 - Don't repeat your prior assistant explanation verbatim — refer back to it briefly if needed.
-- Re-run \`run_sql\` with the modified query.
+- Call \`run_sql\` again with the modified query. **Pasting the SQL into your chat reply does not execute it. Only the \`run_sql\` tool actually runs anything.**
 
 Short ambiguous follow-ups ("yes", "do it", "ok") almost always mean "execute what you just proposed." Look at your prior assistant text to see what was proposed; don't ask the user to repeat themselves.
 
 **Handle SQL errors.** If \`run_sql\` returns an error, read it, fix your query, and try again. You get 2 retries. After that, apologize in plain language (not SQL jargon) and ask the user to clarify. Most errors come from guessing column names — use \`describe_table\` before retrying, not after.
 
-# Available tables
+${prebakedSection}
+
+# All available tables (full registry — call \`describe_table\` for any not pre-loaded above)
 
 ${tableList}
 

--- a/src/features/reports/lib/tools/__tests__/run-sql.test.ts
+++ b/src/features/reports/lib/tools/__tests__/run-sql.test.ts
@@ -63,7 +63,7 @@ describe("handleRunSql", () => {
     }
   });
 
-  it("rejects empty summary.source", async () => {
+  it("rejects empty summary.source when no fallback is provided", async () => {
     const res = await handleRunSql(
       "SELECT name FROM districts WHERE state = 'Texas' LIMIT 100",
       { source: "" },
@@ -71,6 +71,43 @@ describe("handleRunSql", () => {
     expect(res.kind).toBe("validation_error");
     if (res.kind === "validation_error") {
       expect(res.errors[0]).toMatch(/summary\.source/);
+    }
+  });
+
+  it("auto-fills empty summary.source from the fallback (user question)", async () => {
+    const res = await handleRunSql(
+      "SELECT name FROM districts WHERE state = 'Texas' LIMIT 100",
+      { source: "" },
+      "show me Texas districts",
+    );
+    expect(res.kind).toBe("ok");
+    if (res.kind === "ok") {
+      expect(res.summary.source).toBe("show me Texas districts");
+    }
+  });
+
+  it("auto-fills missing summary entirely from the fallback", async () => {
+    const res = await handleRunSql(
+      "SELECT name FROM districts WHERE state = 'Texas' LIMIT 100",
+      undefined as unknown as QuerySummary,
+      "show me Texas districts",
+    );
+    expect(res.kind).toBe("ok");
+    if (res.kind === "ok") {
+      expect(res.summary.source).toBe("show me Texas districts");
+    }
+  });
+
+  it("trims and truncates very long fallback sources to 200 chars", async () => {
+    const long = "a".repeat(500);
+    const res = await handleRunSql(
+      "SELECT name FROM districts WHERE state = 'Texas' LIMIT 100",
+      { source: "" },
+      `   ${long}   `,
+    );
+    expect(res.kind).toBe("ok");
+    if (res.kind === "ok") {
+      expect(res.summary.source.length).toBe(200);
     }
   });
 

--- a/src/features/reports/lib/tools/describe-table.ts
+++ b/src/features/reports/lib/tools/describe-table.ts
@@ -1,5 +1,37 @@
 import { TABLE_REGISTRY, SEMANTIC_CONTEXT } from "@/lib/district-column-metadata";
 
+/**
+ * Slim schema for inclusion in the system prompt. Includes column name + type +
+ * one-liner only — no relationship paragraphs, no value examples. Used to
+ * eliminate per-conversation `describe_table` calls on the most common tables.
+ */
+export function buildCompactSchema(table: string): string {
+  const meta = TABLE_REGISTRY[table];
+  if (!meta) return "";
+  const out: string[] = [];
+  out.push(
+    `## ${meta.table} — ${meta.description.split("\n")[0].slice(0, 200)}`,
+  );
+  const pk = Array.isArray(meta.primaryKey) ? meta.primaryKey.join(", ") : meta.primaryKey;
+  out.push(`PK: ${pk}`);
+  for (const col of meta.columns) {
+    if (!col.queryable) continue;
+    const desc = col.description.split("\n")[0].slice(0, 120);
+    out.push(`- ${col.column} (${col.format}): ${desc}`);
+  }
+  if (meta.relationships.length > 0) {
+    const joins = meta.relationships
+      .map((r) => r.toTable)
+      .slice(0, 8)
+      .join(", ");
+    out.push(`Joins: ${joins}`);
+  }
+  if (meta.warnings && meta.warnings.length > 0) {
+    out.push(`Warnings: ${meta.warnings.join(" | ")}`);
+  }
+  return out.join("\n");
+}
+
 export async function handleDescribeTable(table: string): Promise<string> {
   const meta = TABLE_REGISTRY[table];
   if (!meta) {

--- a/src/features/reports/lib/tools/run-sql.ts
+++ b/src/features/reports/lib/tools/run-sql.ts
@@ -25,6 +25,7 @@ function findLimit(sql: string): number | null {
 export async function handleRunSql(
   sql: string,
   summary: QuerySummary,
+  fallbackSource?: string,
 ): Promise<RunSqlResult> {
   if (!SELECT_ONLY.test(sql.trim())) {
     return {
@@ -48,11 +49,21 @@ export async function handleRunSql(
       errors: [`SQL LIMIT ${limit} exceeds MAX_LIMIT ${MAX_LIMIT}.`],
     };
   }
-  if (!summary?.source || typeof summary.source !== "string") {
-    return {
-      kind: "validation_error",
-      errors: ["summary.source must be a non-empty string describing the query."],
-    };
+  let effectiveSummary = summary;
+  const sourceIsValid =
+    summary?.source &&
+    typeof summary.source === "string" &&
+    summary.source.trim().length > 0;
+  if (!sourceIsValid) {
+    const cleanedFallback = fallbackSource?.trim().slice(0, 200);
+    if (cleanedFallback) {
+      effectiveSummary = { ...(summary ?? {}), source: cleanedFallback };
+    } else {
+      return {
+        kind: "validation_error",
+        errors: ["summary.source must be a non-empty string describing the query."],
+      };
+    }
   }
 
   const startedAt = Date.now();
@@ -71,7 +82,7 @@ export async function handleRunSql(
   return {
     kind: "ok",
     sql,
-    summary,
+    summary: effectiveSummary,
     columns,
     rows: res.rows ?? [],
     rowCount: res.rowCount ?? (res.rows ?? []).length,


### PR DESCRIPTION
## Summary

Four query-tool perf/quality fixes from a recent cost analysis ($34.46 across 77 turns; $7.09 wasted on failed turns). Estimated impact: ~30-50% cost reduction per turn + structural fix for the recurring SQL-leak bug.

- **Replay prior turns as tool_use/tool_result blocks** (`agent-loop.ts:91-122`). The previous shape replayed history as a Markdown assistant message containing the literal string `"SQL used (server-side only, not shown to user):"` followed by a fenced \`\`\`sql block. The model treated that as a valid response template and produced new replies in the same shape — pasting SQL straight into user-facing chat without ever calling \`run_sql\`. Reps then said "cool" / "sounds good" thinking the report ran. With history replayed as structured tool blocks, the model can't mimic the format in plain text.
- **Pre-bake top-9 table schemas in the system prompt** (`system-prompt.ts`, new `buildCompactSchema()` helper). The same 8-9 tables get \`describe_table\`'d in nearly every conversation, adding 2-5k tokens per call to the prefix and forcing a cache write. Now their slim schemas live in the cached system prompt — written once per hour, read for free thereafter.
- **Auto-fill \`summary.source\` from the user's question** (\`run-sql.ts:52-67\`) when the model omits it. Previously this validation error fired *after* expensive exploration (5-7 tool calls), wasting the entire run.
- **1-hour cache TTL** instead of 5-minute (\`agent-loop.ts:144\`). Users who step away for a few minutes don't repay the full cold-start cache write.

## Why this is separate from PR #164

PR #164 also fixes the SQL-leak bug, but with an auto-retry-once mechanism. This PR fixes it structurally (the model can't emit a leak in the first place). If both ship, the auto-retry path becomes dead code; either rebase #164 over this or drop the auto-retry commit.

## Test plan

- [x] \`npx vitest run src/features/reports\` — 103 passing
- [x] \`npx tsc --noEmit\` clean
- [ ] Manual smoke: ask a question, follow up with "now only TX", confirm both turns run \`run_sql\` and no SQL appears in chat text
- [ ] Manual smoke: cold-start turn with a question that hits one of the pre-baked tables (e.g. "show me TX districts") — verify no \`describe_table\` call is made

🤖 Generated with [Claude Code](https://claude.com/claude-code)