### PR TITLE
feat(admin): AI Query Tool usage analytics + chat inspector

### DIFF
--- a/scripts/query-cost-analysis.ts
+++ b/scripts/query-cost-analysis.ts
@@ -1,0 +1,156 @@
+import { PrismaClient } from "@prisma/client";
+const prisma = new PrismaClient();
+
+// Anthropic pricing for Claude Opus 4.x ($/MTok)
+const PRICE = {
+  input: 15.0,
+  output: 75.0,
+  cacheWrite: 18.75, // 1.25x input
+  cacheRead: 1.5, // 0.10x input
+};
+
+function cost(t: {
+  inputTokens: number | null;
+  outputTokens: number | null;
+  cacheCreationInputTokens: number | null;
+  cacheReadInputTokens: number | null;
+}): number {
+  const i = t.inputTokens ?? 0;
+  const o = t.outputTokens ?? 0;
+  const cw = t.cacheCreationInputTokens ?? 0;
+  const cr = t.cacheReadInputTokens ?? 0;
+  return (
+    (i * PRICE.input) / 1_000_000 +
+    (o * PRICE.output) / 1_000_000 +
+    (cw * PRICE.cacheWrite) / 1_000_000 +
+    (cr * PRICE.cacheRead) / 1_000_000
+  );
+}
+
+async function main() {
+  const turns = await prisma.queryLog.findMany({
+    orderBy: { createdAt: "asc" },
+    select: {
+      id: true,
+      conversationId: true,
+      userId: true,
+      question: true,
+      sql: true,
+      params: true,
+      rowCount: true,
+      executionTimeMs: true,
+      inputTokens: true,
+      outputTokens: true,
+      cacheCreationInputTokens: true,
+      cacheReadInputTokens: true,
+      error: true,
+      createdAt: true,
+    },
+  });
+
+  const billed = turns.filter(
+    (t) => t.inputTokens != null || t.outputTokens != null,
+  );
+
+  console.log(`=== ALL-TIME (${turns.length} turns total, ${billed.length} with token data) ===\n`);
+
+  // Aggregate
+  const sum = billed.reduce(
+    (acc, t) => {
+      acc.input += t.inputTokens ?? 0;
+      acc.output += t.outputTokens ?? 0;
+      acc.cw += t.cacheCreationInputTokens ?? 0;
+      acc.cr += t.cacheReadInputTokens ?? 0;
+      acc.cost += cost(t);
+      return acc;
+    },
+    { input: 0, output: 0, cw: 0, cr: 0, cost: 0 },
+  );
+
+  console.log(`Total input  : ${(sum.input / 1000).toFixed(1)}k tokens`);
+  console.log(`Total output : ${(sum.output / 1000).toFixed(1)}k tokens`);
+  console.log(`Cache write  : ${(sum.cw / 1000).toFixed(1)}k tokens`);
+  console.log(`Cache read   : ${(sum.cr / 1000).toFixed(1)}k tokens`);
+  console.log(`TOTAL COST   : $${sum.cost.toFixed(2)}`);
+  console.log(`Avg / turn   : $${(sum.cost / billed.length).toFixed(4)}`);
+  console.log(
+    `Cache hit %  : ${((sum.cr / (sum.input + sum.cr)) * 100).toFixed(1)}% of input tokens served from cache\n`,
+  );
+
+  // By turn position in conversation
+  const byConvo = new Map<string, typeof billed>();
+  for (const t of billed) {
+    const k = t.conversationId ?? `solo-${t.id}`;
+    if (!byConvo.has(k)) byConvo.set(k, []);
+    byConvo.get(k)!.push(t);
+  }
+
+  console.log(`=== COST BY TURN POSITION (cold start vs follow-up) ===`);
+  const byPos = new Map<number, { count: number; cost: number; inp: number; out: number; cw: number; cr: number }>();
+  for (const ts of byConvo.values()) {
+    ts.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+    ts.forEach((t, i) => {
+      const pos = i + 1;
+      if (!byPos.has(pos)) byPos.set(pos, { count: 0, cost: 0, inp: 0, out: 0, cw: 0, cr: 0 });
+      const b = byPos.get(pos)!;
+      b.count++;
+      b.cost += cost(t);
+      b.inp += t.inputTokens ?? 0;
+      b.out += t.outputTokens ?? 0;
+      b.cw += t.cacheCreationInputTokens ?? 0;
+      b.cr += t.cacheReadInputTokens ?? 0;
+    });
+  }
+  console.log(
+    `pos | n   | avg cost | avg input | avg output | avg cache-write | avg cache-read`,
+  );
+  for (const [pos, b] of [...byPos.entries()].sort((a, b) => a[0] - b[0]).slice(0, 10)) {
+    console.log(
+      `${String(pos).padStart(3)} | ${String(b.count).padStart(3)} | $${(b.cost / b.count).toFixed(4).padStart(7)} | ${Math.round(b.inp / b.count).toString().padStart(9)} | ${Math.round(b.out / b.count).toString().padStart(10)} | ${Math.round(b.cw / b.count).toString().padStart(15)} | ${Math.round(b.cr / b.count).toString().padStart(14)}`,
+    );
+  }
+
+  // Most expensive single turns
+  console.log(`\n=== TOP 10 MOST EXPENSIVE TURNS ===`);
+  const ranked = [...billed]
+    .map((t) => ({ t, c: cost(t) }))
+    .sort((a, b) => b.c - a.c)
+    .slice(0, 10);
+  for (const { t, c } of ranked) {
+    const params = (t.params as { events?: unknown[] } | null) ?? null;
+    const evtCount = Array.isArray(params?.events) ? params.events.length : 0;
+    console.log(
+      `$${c.toFixed(4)} | i=${t.inputTokens} o=${t.outputTokens} cw=${t.cacheCreationInputTokens} cr=${t.cacheReadInputTokens} | events=${evtCount} rows=${t.rowCount}${t.error ? " ERR" : ""} | ${t.question.slice(0, 90)}`,
+    );
+  }
+
+  // Most expensive conversations
+  console.log(`\n=== TOP 10 MOST EXPENSIVE CONVERSATIONS ===`);
+  const convoCosts: Array<{ id: string; turns: number; cost: number; inp: number; out: number; firstQ: string }> = [];
+  for (const [id, ts] of byConvo.entries()) {
+    const c = ts.reduce((s, t) => s + cost(t), 0);
+    const inp = ts.reduce((s, t) => s + (t.inputTokens ?? 0), 0);
+    const out = ts.reduce((s, t) => s + (t.outputTokens ?? 0), 0);
+    convoCosts.push({ id, turns: ts.length, cost: c, inp, out, firstQ: ts[0].question.slice(0, 100) });
+  }
+  convoCosts.sort((a, b) => b.cost - a.cost);
+  for (const c of convoCosts.slice(0, 10)) {
+    console.log(
+      `$${c.cost.toFixed(4)} | ${c.turns}t | i=${c.inp} o=${c.out} | ${c.firstQ}`,
+    );
+  }
+
+  // Failed-turn cost (turns with error or no SQL produced)
+  const failed = billed.filter((t) => t.error || (!t.sql && t.rowCount == null));
+  const failedCost = failed.reduce((s, t) => s + cost(t), 0);
+  console.log(
+    `\n=== WASTED ON FAILED TURNS ===\n${failed.length} failed turns cost $${failedCost.toFixed(2)} (${((failedCost / sum.cost) * 100).toFixed(1)}% of total)`,
+  );
+
+  await prisma.$disconnect();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/query-recent-chats.ts
+++ b/scripts/query-recent-chats.ts
@@ -1,0 +1,59 @@
+import { PrismaClient } from "@prisma/client";
+const prisma = new PrismaClient();
+
+async function main() {
+  const turns = await prisma.queryLog.findMany({
+    orderBy: { createdAt: "desc" },
+    take: 80,
+    select: {
+      id: true,
+      conversationId: true,
+      userId: true,
+      question: true,
+      sql: true,
+      params: true,
+      rowCount: true,
+      executionTimeMs: true,
+      inputTokens: true,
+      outputTokens: true,
+      error: true,
+      action: true,
+      actionSuccess: true,
+      createdAt: true,
+    },
+  });
+
+  // Group by conversation
+  const convos = new Map<string, typeof turns>();
+  for (const t of turns) {
+    const k = t.conversationId ?? "(none)";
+    if (!convos.has(k)) convos.set(k, []);
+    convos.get(k)!.push(t);
+  }
+
+  console.log(`=== ${turns.length} recent turns across ${convos.size} conversations ===\n`);
+
+  let cIdx = 0;
+  for (const [convoId, ts] of convos) {
+    cIdx++;
+    if (cIdx > 25) break;
+    const ordered = [...ts].reverse(); // oldest first
+    console.log(`\n--- Convo ${cIdx} [${convoId.slice(0, 8)}] ${ordered.length} turns, ${ordered[0].createdAt.toISOString().slice(0, 16)} ---`);
+    for (const t of ordered) {
+      const params: any = t.params ?? {};
+      const summary = params?.summary?.source ?? params?.summary ?? "";
+      const assistantText = (params?.assistantText ?? "").slice(0, 200);
+      const events = Array.isArray(params?.events) ? params.events : [];
+      const toolCalls = events.filter((e: any) => e?.type === "tool_use" || e?.toolName).map((e: any) => e?.toolName ?? e?.name).filter(Boolean);
+      const eventTypes = events.map((e: any) => e?.type ?? e?.kind).filter(Boolean);
+      console.log(`  Q: ${(t.question ?? "").slice(0, 220)}`);
+      if (assistantText) console.log(`  A: ${assistantText.replace(/\n/g, " ")}`);
+      if (summary) console.log(`  src: ${typeof summary === "string" ? summary : JSON.stringify(summary).slice(0, 200)}`);
+      console.log(`  tools: [${toolCalls.slice(0, 12).join(", ")}] events:${eventTypes.length} rows:${t.rowCount} ms:${t.executionTimeMs} tok:${t.inputTokens}/${t.outputTokens}${t.error ? " ERR:" + t.error.slice(0, 120) : ""}${t.action ? " action:" + t.action + (t.actionSuccess === false ? "(fail)" : "") : ""}`);
+      if (t.sql) console.log(`  sql: ${t.sql.replace(/\s+/g, " ").slice(0, 240)}`);
+    }
+  }
+
+  await prisma.$disconnect();
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/src/app/api/admin/ai-query/conversations/[id]/route.ts
+++ b/src/app/api/admin/ai-query/conversations/[id]/route.ts
@@ -1,0 +1,123 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { getAdminUser } from "@/lib/supabase/server";
+import { turnCost } from "@/features/admin/lib/ai-query-cost";
+
+export const dynamic = "force-dynamic";
+
+interface ConversationTurn {
+  id: number;
+  createdAt: string;
+  question: string;
+  assistantText: string | null;
+  summarySource: string | null;
+  sql: string | null;
+  tools: string[];
+  eventCount: number;
+  rowCount: number | null;
+  executionTimeMs: number | null;
+  error: string | null;
+  tokens: {
+    input: number;
+    output: number;
+    cacheWrite: number;
+    cacheRead: number;
+  };
+  cost: number;
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const admin = await getAdminUser();
+  if (!admin) {
+    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+  }
+
+  const { id } = await params;
+  if (!id) {
+    return NextResponse.json({ error: "Missing conversation id" }, { status: 400 });
+  }
+
+  const rows = await prisma.queryLog.findMany({
+    where: { conversationId: id },
+    orderBy: { createdAt: "asc" },
+    select: {
+      id: true,
+      userId: true,
+      question: true,
+      sql: true,
+      params: true,
+      rowCount: true,
+      executionTimeMs: true,
+      inputTokens: true,
+      outputTokens: true,
+      cacheCreationInputTokens: true,
+      cacheReadInputTokens: true,
+      error: true,
+      createdAt: true,
+    },
+  });
+
+  if (rows.length === 0) {
+    return NextResponse.json({ error: "Conversation not found" }, { status: 404 });
+  }
+
+  const userId = rows[0].userId;
+  const profile = await prisma.userProfile.findUnique({
+    where: { id: userId },
+    select: { email: true, fullName: true },
+  });
+
+  const turns: ConversationTurn[] = rows.map((t) => {
+    const params = (t.params as Record<string, unknown> | null) ?? null;
+    const events = Array.isArray(params?.events) ? (params.events as unknown[]) : [];
+    const tools = events
+      .map((e) => {
+        if (!e || typeof e !== "object") return null;
+        const ev = e as { kind?: string; toolName?: string };
+        return ev.kind === "tool_result" ? ev.toolName ?? null : null;
+      })
+      .filter((s): s is string => typeof s === "string" && s.length > 0);
+    const summary =
+      params && typeof params.summary === "object" && params.summary !== null
+        ? ((params.summary as { source?: unknown }).source ?? null)
+        : null;
+    const assistantText =
+      params && typeof params.assistantText === "string"
+        ? (params.assistantText as string)
+        : null;
+
+    return {
+      id: t.id,
+      createdAt: t.createdAt.toISOString(),
+      question: t.question,
+      assistantText,
+      summarySource: typeof summary === "string" ? summary : null,
+      sql: t.sql,
+      tools,
+      eventCount: events.length,
+      rowCount: t.rowCount,
+      executionTimeMs: t.executionTimeMs,
+      error: t.error,
+      tokens: {
+        input: t.inputTokens ?? 0,
+        output: t.outputTokens ?? 0,
+        cacheWrite: t.cacheCreationInputTokens ?? 0,
+        cacheRead: t.cacheReadInputTokens ?? 0,
+      },
+      cost: turnCost(t),
+    };
+  });
+
+  return NextResponse.json({
+    conversationId: id,
+    userId,
+    userEmail: profile?.email ?? null,
+    userName: profile?.fullName ?? null,
+    turnCount: turns.length,
+    totalCost: turns.reduce((s, t) => s + t.cost, 0),
+    turns,
+  });
+}

--- a/src/app/api/admin/ai-query/conversations/route.ts
+++ b/src/app/api/admin/ai-query/conversations/route.ts
@@ -1,0 +1,124 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { getAdminUser } from "@/lib/supabase/server";
+import {
+  parseScope,
+  scopeToSinceDate,
+  turnCost,
+} from "@/features/admin/lib/ai-query-cost";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+  const admin = await getAdminUser();
+  if (!admin) {
+    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const scope = parseScope(searchParams.get("scope"));
+  const since = scopeToSinceDate(scope);
+  const search = (searchParams.get("search") ?? "").trim();
+  const page = Math.max(1, parseInt(searchParams.get("page") ?? "1", 10));
+  const pageSize = Math.min(
+    100,
+    Math.max(1, parseInt(searchParams.get("page_size") ?? "25", 10)),
+  );
+
+  // Pull turns in scope, group by conversation, then paginate by conversation cost.
+  const turns = await prisma.queryLog.findMany({
+    where: {
+      ...(since ? { createdAt: { gte: since } } : {}),
+      ...(search
+        ? { question: { contains: search, mode: "insensitive" as const } }
+        : {}),
+    },
+    orderBy: { createdAt: "asc" },
+    select: {
+      conversationId: true,
+      userId: true,
+      question: true,
+      sql: true,
+      rowCount: true,
+      inputTokens: true,
+      outputTokens: true,
+      cacheCreationInputTokens: true,
+      cacheReadInputTokens: true,
+      error: true,
+      createdAt: true,
+    },
+  });
+
+  // Group by conversation
+  type Convo = {
+    conversationId: string;
+    userId: string;
+    turnCount: number;
+    totalCost: number;
+    hasError: boolean;
+    firstQuestion: string;
+    lastActivity: Date;
+    firstActivity: Date;
+  };
+  const map = new Map<string, Convo>();
+  for (const t of turns) {
+    const id = t.conversationId;
+    const existing = map.get(id);
+    if (!existing) {
+      map.set(id, {
+        conversationId: id,
+        userId: t.userId,
+        turnCount: 1,
+        totalCost: turnCost(t),
+        hasError: !!t.error,
+        firstQuestion: t.question,
+        lastActivity: t.createdAt,
+        firstActivity: t.createdAt,
+      });
+    } else {
+      existing.turnCount++;
+      existing.totalCost += turnCost(t);
+      if (t.error) existing.hasError = true;
+      if (t.createdAt > existing.lastActivity) existing.lastActivity = t.createdAt;
+      if (t.createdAt < existing.firstActivity) {
+        existing.firstActivity = t.createdAt;
+        existing.firstQuestion = t.question;
+      }
+    }
+  }
+
+  const allConvos = [...map.values()].sort(
+    (a, b) => b.lastActivity.getTime() - a.lastActivity.getTime(),
+  );
+
+  // Resolve user emails / names in one query
+  const userIds = [...new Set(allConvos.map((c) => c.userId))];
+  const profiles = userIds.length
+    ? await prisma.userProfile.findMany({
+        where: { id: { in: userIds } },
+        select: { id: true, email: true, fullName: true },
+      })
+    : [];
+  const userMap = new Map(profiles.map((p) => [p.id, p]));
+
+  const total = allConvos.length;
+  const start = (page - 1) * pageSize;
+  const slice = allConvos.slice(start, start + pageSize);
+
+  const rows = slice.map((c) => {
+    const u = userMap.get(c.userId);
+    return {
+      conversationId: c.conversationId,
+      userId: c.userId,
+      userEmail: u?.email ?? null,
+      userName: u?.fullName ?? null,
+      turnCount: c.turnCount,
+      totalCost: c.totalCost,
+      hasError: c.hasError,
+      firstQuestion: c.firstQuestion.slice(0, 240),
+      lastActivity: c.lastActivity.toISOString(),
+    };
+  });
+
+  return NextResponse.json({ rows, page, pageSize, total, scope });
+}

--- a/src/app/api/admin/ai-query/cost-summary/route.ts
+++ b/src/app/api/admin/ai-query/cost-summary/route.ts
@@ -1,0 +1,174 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { getAdminUser } from "@/lib/supabase/server";
+import {
+  parseScope,
+  scopeToSinceDate,
+  turnCost,
+} from "@/features/admin/lib/ai-query-cost";
+
+export const dynamic = "force-dynamic";
+
+interface ByPositionAccum {
+  count: number;
+  cost: number;
+  inp: number;
+  out: number;
+  cw: number;
+  cr: number;
+}
+
+export async function GET(request: NextRequest) {
+  const admin = await getAdminUser();
+  if (!admin) {
+    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const scope = parseScope(searchParams.get("scope"));
+  const since = scopeToSinceDate(scope);
+
+  const turns = await prisma.queryLog.findMany({
+    where: {
+      OR: [{ inputTokens: { not: null } }, { outputTokens: { not: null } }],
+      ...(since ? { createdAt: { gte: since } } : {}),
+    },
+    orderBy: { createdAt: "asc" },
+    select: {
+      id: true,
+      conversationId: true,
+      userId: true,
+      question: true,
+      sql: true,
+      params: true,
+      rowCount: true,
+      inputTokens: true,
+      outputTokens: true,
+      cacheCreationInputTokens: true,
+      cacheReadInputTokens: true,
+      error: true,
+      createdAt: true,
+    },
+  });
+
+  const totalTurns = turns.length;
+  let totalInput = 0;
+  let totalOutput = 0;
+  let totalCacheWrite = 0;
+  let totalCacheRead = 0;
+  let totalCost = 0;
+  let wastedCost = 0;
+  let wastedTurns = 0;
+
+  for (const t of turns) {
+    totalInput += t.inputTokens ?? 0;
+    totalOutput += t.outputTokens ?? 0;
+    totalCacheWrite += t.cacheCreationInputTokens ?? 0;
+    totalCacheRead += t.cacheReadInputTokens ?? 0;
+    const c = turnCost(t);
+    totalCost += c;
+    const isFailed = !!t.error || (!t.sql && t.rowCount == null);
+    if (isFailed) {
+      wastedCost += c;
+      wastedTurns++;
+    }
+  }
+
+  const cacheHitDenom = totalInput + totalCacheRead;
+  const cacheHitPct = cacheHitDenom > 0 ? (totalCacheRead / cacheHitDenom) * 100 : 0;
+
+  // By turn position in conversation
+  const byConvo = new Map<string, typeof turns>();
+  for (const t of turns) {
+    const key = t.conversationId ?? `solo-${t.id}`;
+    if (!byConvo.has(key)) byConvo.set(key, []);
+    byConvo.get(key)!.push(t);
+  }
+  const byPosition = new Map<number, ByPositionAccum>();
+  for (const arr of byConvo.values()) {
+    arr.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+    arr.forEach((t, i) => {
+      const pos = i + 1;
+      if (pos > 10) return;
+      const b = byPosition.get(pos) ?? { count: 0, cost: 0, inp: 0, out: 0, cw: 0, cr: 0 };
+      b.count++;
+      b.cost += turnCost(t);
+      b.inp += t.inputTokens ?? 0;
+      b.out += t.outputTokens ?? 0;
+      b.cw += t.cacheCreationInputTokens ?? 0;
+      b.cr += t.cacheReadInputTokens ?? 0;
+      byPosition.set(pos, b);
+    });
+  }
+  const positionRows = [...byPosition.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([position, b]) => ({
+      position,
+      n: b.count,
+      avgCost: b.cost / b.count,
+      avgInput: Math.round(b.inp / b.count),
+      avgOutput: Math.round(b.out / b.count),
+      avgCacheWrite: Math.round(b.cw / b.count),
+      avgCacheRead: Math.round(b.cr / b.count),
+    }));
+
+  // Top 10 expensive turns
+  const topTurns = [...turns]
+    .map((t) => ({ t, c: turnCost(t) }))
+    .sort((a, b) => b.c - a.c)
+    .slice(0, 10)
+    .map(({ t, c }) => {
+      const params = (t.params as { events?: unknown[] } | null) ?? null;
+      const events = Array.isArray(params?.events) ? params.events : [];
+      return {
+        id: t.id,
+        conversationId: t.conversationId,
+        question: t.question.slice(0, 200),
+        cost: c,
+        events: events.length,
+        rowCount: t.rowCount,
+        hasError: !!t.error,
+        createdAt: t.createdAt.toISOString(),
+      };
+    });
+
+  // Top 10 expensive conversations
+  const convoRows: Array<{
+    conversationId: string;
+    turns: number;
+    cost: number;
+    firstQuestion: string;
+    lastActivity: string;
+  }> = [];
+  for (const [id, arr] of byConvo.entries()) {
+    const c = arr.reduce((s, t) => s + turnCost(t), 0);
+    arr.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+    convoRows.push({
+      conversationId: id,
+      turns: arr.length,
+      cost: c,
+      firstQuestion: arr[0].question.slice(0, 200),
+      lastActivity: arr[arr.length - 1].createdAt.toISOString(),
+    });
+  }
+  convoRows.sort((a, b) => b.cost - a.cost);
+  const topConversations = convoRows.slice(0, 10);
+
+  return NextResponse.json({
+    scope,
+    totalTurns,
+    totalCost,
+    avgCostPerTurn: totalTurns > 0 ? totalCost / totalTurns : 0,
+    totalInput,
+    totalOutput,
+    totalCacheWrite,
+    totalCacheRead,
+    cacheHitPct,
+    wastedCost,
+    wastedTurns,
+    wastedPct: totalCost > 0 ? (wastedCost / totalCost) * 100 : 0,
+    byPosition: positionRows,
+    topExpensiveTurns: topTurns,
+    topExpensiveConversations: topConversations,
+  });
+}

--- a/src/features/admin/components/AIQueryToolTab.tsx
+++ b/src/features/admin/components/AIQueryToolTab.tsx
@@ -1,0 +1,543 @@
+"use client";
+
+import { Fragment, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { AlertCircle, ChevronRight, RefreshCcw } from "lucide-react";
+import ConversationDetail from "./ai-query/ConversationDetail";
+
+type Scope = "7d" | "30d" | "90d" | "all";
+
+interface CostSummary {
+  scope: Scope;
+  totalTurns: number;
+  totalCost: number;
+  avgCostPerTurn: number;
+  totalInput: number;
+  totalOutput: number;
+  totalCacheWrite: number;
+  totalCacheRead: number;
+  cacheHitPct: number;
+  wastedCost: number;
+  wastedTurns: number;
+  wastedPct: number;
+  byPosition: Array<{
+    position: number;
+    n: number;
+    avgCost: number;
+    avgInput: number;
+    avgOutput: number;
+    avgCacheWrite: number;
+    avgCacheRead: number;
+  }>;
+  topExpensiveTurns: Array<{
+    id: number;
+    conversationId: string | null;
+    question: string;
+    cost: number;
+    events: number;
+    rowCount: number | null;
+    hasError: boolean;
+    createdAt: string;
+  }>;
+  topExpensiveConversations: Array<{
+    conversationId: string;
+    turns: number;
+    cost: number;
+    firstQuestion: string;
+    lastActivity: string;
+  }>;
+}
+
+interface ConversationRow {
+  conversationId: string;
+  userId: string;
+  userEmail: string | null;
+  userName: string | null;
+  turnCount: number;
+  totalCost: number;
+  hasError: boolean;
+  firstQuestion: string;
+  lastActivity: string;
+}
+
+interface ConversationListResponse {
+  rows: ConversationRow[];
+  page: number;
+  pageSize: number;
+  total: number;
+  scope: Scope;
+}
+
+const SCOPE_LABELS: Record<Scope, string> = {
+  "7d": "Last 7 days",
+  "30d": "Last 30 days",
+  "90d": "Last 90 days",
+  all: "All time",
+};
+
+const SCOPES: Scope[] = ["7d", "30d", "90d", "all"];
+
+function fmtUSD(n: number, fractionDigits = 2): string {
+  return `$${n.toLocaleString(undefined, {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  })}`;
+}
+
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return n.toLocaleString();
+}
+
+function relativeTime(date: string | null): string {
+  if (!date) return "—";
+  const diff = Date.now() - new Date(date).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function ScopePicker({ value, onChange }: { value: Scope; onChange: (s: Scope) => void }) {
+  return (
+    <div className="inline-flex items-center bg-[#F7F5FA] border border-[#D4CFE2] rounded-lg p-0.5">
+      {SCOPES.map((s) => (
+        <button
+          key={s}
+          onClick={() => onChange(s)}
+          className={`px-3 py-1.5 text-xs font-semibold rounded-md transition-colors duration-100 whitespace-nowrap ${
+            value === s
+              ? "bg-white text-[#403770] shadow-sm"
+              : "text-[#8A80A8] hover:text-[#403770]"
+          }`}
+        >
+          {SCOPE_LABELS[s]}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+interface KPICardProps {
+  accent: string;
+  label: string;
+  value: string;
+  subtitle: string;
+}
+
+function KPICard({ accent, label, value, subtitle }: KPICardProps) {
+  return (
+    <div className="bg-white rounded-lg border border-[#D4CFE2] shadow-sm p-4 relative overflow-hidden">
+      <div
+        className="absolute left-0 top-0 bottom-0 w-[3px]"
+        style={{ backgroundColor: accent }}
+      />
+      <div className="text-[11px] text-[#8A80A8] font-semibold uppercase tracking-wider whitespace-nowrap">
+        {label}
+      </div>
+      <div className="text-xl font-bold text-[#403770] mt-1 tabular-nums whitespace-nowrap">
+        {value}
+      </div>
+      <div className="text-[11px] text-[#A69DC0] mt-0.5 whitespace-nowrap">
+        {subtitle}
+      </div>
+    </div>
+  );
+}
+
+function KPICardSkeleton() {
+  return (
+    <div className="bg-white rounded-lg border border-[#D4CFE2] shadow-sm p-4 relative overflow-hidden">
+      <div className="absolute left-0 top-0 bottom-0 w-[3px] bg-[#E2DEEC]" />
+      <div className="h-3 w-20 bg-[#E2DEEC]/60 rounded animate-pulse mb-2" />
+      <div className="h-5 w-24 bg-[#E2DEEC]/60 rounded animate-pulse mb-1" />
+      <div className="h-3 w-32 bg-[#E2DEEC]/40 rounded animate-pulse" />
+    </div>
+  );
+}
+
+function CostByPositionTable({ rows }: { rows: CostSummary["byPosition"] }) {
+  if (rows.length === 0) {
+    return (
+      <div className="text-xs text-[#8A80A8] py-6 text-center">
+        No data in this window.
+      </div>
+    );
+  }
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="text-left text-xs font-semibold uppercase tracking-wider text-[#8A80A8] border-b border-[#E2DEEC]">
+            <th className="px-3 py-2 whitespace-nowrap">Turn</th>
+            <th className="px-3 py-2 text-right whitespace-nowrap">N</th>
+            <th className="px-3 py-2 text-right whitespace-nowrap">Avg cost</th>
+            <th className="px-3 py-2 text-right whitespace-nowrap">Input</th>
+            <th className="px-3 py-2 text-right whitespace-nowrap">Output</th>
+            <th className="px-3 py-2 text-right whitespace-nowrap">Cache write</th>
+            <th className="px-3 py-2 text-right whitespace-nowrap">Cache read</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => (
+            <tr key={r.position} className="border-b border-[#E2DEEC] last:border-0">
+              <td className="px-3 py-2 font-semibold text-[#403770] whitespace-nowrap">
+                #{r.position}
+              </td>
+              <td className="px-3 py-2 text-right tabular-nums text-[#6E6390]">
+                {r.n}
+              </td>
+              <td className="px-3 py-2 text-right tabular-nums font-medium text-[#403770]">
+                {fmtUSD(r.avgCost, 4)}
+              </td>
+              <td className="px-3 py-2 text-right tabular-nums text-[#6E6390]">
+                {fmtTokens(r.avgInput)}
+              </td>
+              <td className="px-3 py-2 text-right tabular-nums text-[#6E6390]">
+                {fmtTokens(r.avgOutput)}
+              </td>
+              <td className="px-3 py-2 text-right tabular-nums text-[#6E6390]">
+                {fmtTokens(r.avgCacheWrite)}
+              </td>
+              <td className="px-3 py-2 text-right tabular-nums text-[#6E6390]">
+                {fmtTokens(r.avgCacheRead)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function TopExpensiveTurnsList({ rows }: { rows: CostSummary["topExpensiveTurns"] }) {
+  if (rows.length === 0) {
+    return (
+      <div className="text-xs text-[#8A80A8] py-6 text-center">
+        No data in this window.
+      </div>
+    );
+  }
+  return (
+    <ul className="divide-y divide-[#E2DEEC]">
+      {rows.map((t) => (
+        <li key={t.id} className="py-2.5 flex items-start gap-3">
+          <div className="text-sm font-semibold text-[#403770] tabular-nums shrink-0 w-16">
+            {fmtUSD(t.cost, 4)}
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="text-sm text-[#544A78] truncate">{t.question}</div>
+            <div className="text-[11px] text-[#8A80A8] mt-0.5 flex items-center gap-2 whitespace-nowrap">
+              <span>{t.events} events</span>
+              <span className="text-[#D4CFE2]">·</span>
+              <span>{t.rowCount ?? 0} rows</span>
+              <span className="text-[#D4CFE2]">·</span>
+              <span>{relativeTime(t.createdAt)}</span>
+              {t.hasError && (
+                <>
+                  <span className="text-[#D4CFE2]">·</span>
+                  <span className="inline-flex items-center gap-1 text-[#c25a52] font-semibold">
+                    <AlertCircle className="w-3 h-3" /> error
+                  </span>
+                </>
+              )}
+            </div>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+interface ConversationsTableProps {
+  rows: ConversationRow[];
+  isLoading: boolean;
+  expandedId: string | null;
+  onToggleExpand: (id: string) => void;
+}
+
+function ConversationsTable({
+  rows,
+  isLoading,
+  expandedId,
+  onToggleExpand,
+}: ConversationsTableProps) {
+  if (isLoading && rows.length === 0) {
+    return (
+      <div className="space-y-2 p-4">
+        {[...Array(5)].map((_, i) => (
+          <div key={i} className="h-10 bg-[#E2DEEC]/40 rounded-lg animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div className="text-center text-sm text-[#8A80A8] py-12">
+        No conversations in this window.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="text-left text-xs font-semibold uppercase tracking-wider text-[#8A80A8] border-b border-[#E2DEEC] bg-[#F7F5FA]">
+            <th className="px-3 py-2.5 w-8" />
+            <th className="px-3 py-2.5">First question</th>
+            <th className="px-3 py-2.5 whitespace-nowrap">User</th>
+            <th className="px-3 py-2.5 text-right whitespace-nowrap">Turns</th>
+            <th className="px-3 py-2.5 text-right whitespace-nowrap">Cost</th>
+            <th className="px-3 py-2.5 whitespace-nowrap">Last activity</th>
+            <th className="px-3 py-2.5 whitespace-nowrap">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((c) => {
+            const isExpanded = expandedId === c.conversationId;
+            return (
+              <Fragment key={c.conversationId}>
+                <tr
+                  onClick={() => onToggleExpand(c.conversationId)}
+                  className={`border-b border-[#E2DEEC] cursor-pointer transition-colors duration-100 ${
+                    isExpanded ? "bg-[#EFEDF5]" : "hover:bg-[#F7F5FA]"
+                  }`}
+                >
+                  <td className="px-3 py-2.5">
+                    <ChevronRight
+                      className={`w-4 h-4 text-[#8A80A8] transition-transform duration-150 ${
+                        isExpanded ? "rotate-90" : ""
+                      }`}
+                    />
+                  </td>
+                  <td className="px-3 py-2.5 text-[#544A78] max-w-md truncate">
+                    {c.firstQuestion}
+                  </td>
+                  <td className="px-3 py-2.5 text-[#6E6390] whitespace-nowrap">
+                    {c.userName ?? c.userEmail ?? c.userId.slice(0, 8)}
+                  </td>
+                  <td className="px-3 py-2.5 text-right tabular-nums text-[#6E6390]">
+                    {c.turnCount}
+                  </td>
+                  <td className="px-3 py-2.5 text-right tabular-nums font-medium text-[#403770]">
+                    {fmtUSD(c.totalCost, 4)}
+                  </td>
+                  <td className="px-3 py-2.5 text-[#8A80A8] whitespace-nowrap">
+                    {relativeTime(c.lastActivity)}
+                  </td>
+                  <td className="px-3 py-2.5 whitespace-nowrap">
+                    {c.hasError ? (
+                      <span className="inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full bg-[#F37167]/15 text-[#c25a52]">
+                        <AlertCircle className="w-3 h-3" /> error
+                      </span>
+                    ) : (
+                      <span className="inline-flex px-2 py-0.5 text-xs font-medium rounded-full bg-[#EDFFE3] text-[#5f665b]">
+                        ok
+                      </span>
+                    )}
+                  </td>
+                </tr>
+                {isExpanded && (
+                  <tr className="bg-[#FFFCFA]">
+                    <td colSpan={7} className="px-4 py-4 border-b border-[#E2DEEC]">
+                      <ConversationDetail conversationId={c.conversationId} />
+                    </td>
+                  </tr>
+                )}
+              </Fragment>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default function AIQueryToolTab() {
+  const [scope, setScope] = useState<Scope>("30d");
+  const [search, setSearch] = useState("");
+  const [page, setPage] = useState(1);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  const summary = useQuery<CostSummary>({
+    queryKey: ["admin-ai-query-summary", scope],
+    queryFn: async () => {
+      const res = await fetch(`/api/admin/ai-query/cost-summary?scope=${scope}`);
+      if (!res.ok) throw new Error("Failed to load cost summary");
+      return res.json();
+    },
+    staleTime: 60_000,
+  });
+
+  const convos = useQuery<ConversationListResponse>({
+    queryKey: ["admin-ai-query-conversations", scope, search, page],
+    queryFn: async () => {
+      const url = new URL("/api/admin/ai-query/conversations", window.location.origin);
+      url.searchParams.set("scope", scope);
+      url.searchParams.set("page", String(page));
+      url.searchParams.set("page_size", "25");
+      if (search) url.searchParams.set("search", search);
+      const res = await fetch(url.toString());
+      if (!res.ok) throw new Error("Failed to load conversations");
+      return res.json();
+    },
+    staleTime: 60_000,
+  });
+
+  const totalPages = useMemo(
+    () => (convos.data ? Math.max(1, Math.ceil(convos.data.total / convos.data.pageSize)) : 1),
+    [convos.data],
+  );
+
+  return (
+    <div className="space-y-6">
+      {/* Header row: scope picker + refresh */}
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <div>
+          <h2 className="text-lg font-semibold text-[#403770]">AI Query Tool usage</h2>
+          <p className="text-sm text-[#8A80A8] mt-0.5">
+            Cost analysis and chat history for the Reports tool.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <ScopePicker value={scope} onChange={setScope} />
+          <button
+            onClick={() => {
+              summary.refetch();
+              convos.refetch();
+            }}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold rounded-lg border border-[#D4CFE2] text-[#544A78] bg-white hover:border-[#403770]/30 transition-colors duration-100"
+          >
+            <RefreshCcw className="w-3 h-3" /> Refresh
+          </button>
+        </div>
+      </div>
+
+      {/* KPI cards */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        {summary.isLoading || !summary.data ? (
+          <>
+            <KPICardSkeleton />
+            <KPICardSkeleton />
+            <KPICardSkeleton />
+            <KPICardSkeleton />
+          </>
+        ) : (
+          <>
+            <KPICard
+              accent="#403770"
+              label="Total spend"
+              value={fmtUSD(summary.data.totalCost)}
+              subtitle={`${summary.data.totalTurns} turns ${SCOPE_LABELS[scope].toLowerCase()}`}
+            />
+            <KPICard
+              accent="#6EA3BE"
+              label="Avg / turn"
+              value={fmtUSD(summary.data.avgCostPerTurn, 4)}
+              subtitle={`${fmtTokens(summary.data.totalInput + summary.data.totalCacheRead)} input incl. cache`}
+            />
+            <KPICard
+              accent="#8AC670"
+              label="Cache hit rate"
+              value={`${summary.data.cacheHitPct.toFixed(1)}%`}
+              subtitle={`${fmtTokens(summary.data.totalCacheRead)} served from cache`}
+            />
+            <KPICard
+              accent="#F37167"
+              label="Wasted on failures"
+              value={fmtUSD(summary.data.wastedCost)}
+              subtitle={`${summary.data.wastedTurns} failed turns (${summary.data.wastedPct.toFixed(1)}%)`}
+            />
+          </>
+        )}
+      </div>
+
+      {/* Two-column: cost-by-position + top expensive turns */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <div className="bg-white rounded-lg border border-[#D4CFE2] shadow-sm p-4">
+          <h3 className="text-sm font-semibold text-[#403770] mb-1">
+            Cost by turn position
+          </h3>
+          <p className="text-xs text-[#8A80A8] mb-3">
+            Cold start (turn 1) is typically twice as expensive as follow-ups.
+          </p>
+          {summary.isLoading || !summary.data ? (
+            <div className="h-48 bg-[#E2DEEC]/30 rounded animate-pulse" />
+          ) : (
+            <CostByPositionTable rows={summary.data.byPosition} />
+          )}
+        </div>
+        <div className="bg-white rounded-lg border border-[#D4CFE2] shadow-sm p-4">
+          <h3 className="text-sm font-semibold text-[#403770] mb-1">
+            Top 10 most expensive turns
+          </h3>
+          <p className="text-xs text-[#8A80A8] mb-3">
+            Single-turn cost outliers — usually deep exploration or failed retries.
+          </p>
+          {summary.isLoading || !summary.data ? (
+            <div className="h-48 bg-[#E2DEEC]/30 rounded animate-pulse" />
+          ) : (
+            <TopExpensiveTurnsList rows={summary.data.topExpensiveTurns} />
+          )}
+        </div>
+      </div>
+
+      {/* Conversations inspector */}
+      <div className="bg-white rounded-lg border border-[#D4CFE2] shadow-sm overflow-hidden">
+        <div className="p-4 border-b border-[#E2DEEC] flex items-center justify-between gap-4 flex-wrap">
+          <div>
+            <h3 className="text-sm font-semibold text-[#403770]">Conversations</h3>
+            <p className="text-xs text-[#8A80A8] mt-0.5">
+              Click a row to inspect every turn — questions, replies, SQL, tools, tokens, errors.
+            </p>
+          </div>
+          <input
+            type="search"
+            placeholder="Search questions..."
+            value={search}
+            onChange={(e) => {
+              setSearch(e.target.value);
+              setPage(1);
+            }}
+            className="px-3 py-1.5 text-sm rounded-lg border border-[#C2BBD4] bg-white focus:outline-none focus:border-[#403770] focus:ring-2 focus:ring-[#403770]/10 w-64"
+          />
+        </div>
+        <ConversationsTable
+          rows={convos.data?.rows ?? []}
+          isLoading={convos.isLoading}
+          expandedId={expandedId}
+          onToggleExpand={(id) => setExpandedId((cur) => (cur === id ? null : id))}
+        />
+        {convos.data && convos.data.total > convos.data.pageSize && (
+          <div className="p-3 flex items-center justify-between border-t border-[#E2DEEC] bg-[#F7F5FA]">
+            <div className="text-xs text-[#8A80A8] whitespace-nowrap">
+              Page {page} of {totalPages} ({convos.data.total} total)
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                disabled={page <= 1}
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                className="px-3 py-1.5 text-xs font-semibold rounded-lg border border-[#D4CFE2] text-[#544A78] bg-white disabled:opacity-50 disabled:cursor-not-allowed hover:border-[#403770]/30 transition-colors duration-100"
+              >
+                Previous
+              </button>
+              <button
+                disabled={page >= totalPages}
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                className="px-3 py-1.5 text-xs font-semibold rounded-lg border border-[#D4CFE2] text-[#544A78] bg-white disabled:opacity-50 disabled:cursor-not-allowed hover:border-[#403770]/30 transition-colors duration-100"
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/features/admin/components/ai-query/ConversationDetail.tsx
+++ b/src/features/admin/components/ai-query/ConversationDetail.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { AlertCircle, Code2, MessageSquare, Wrench } from "lucide-react";
+
+interface ConversationTurn {
+  id: number;
+  createdAt: string;
+  question: string;
+  assistantText: string | null;
+  summarySource: string | null;
+  sql: string | null;
+  tools: string[];
+  eventCount: number;
+  rowCount: number | null;
+  executionTimeMs: number | null;
+  error: string | null;
+  tokens: {
+    input: number;
+    output: number;
+    cacheWrite: number;
+    cacheRead: number;
+  };
+  cost: number;
+}
+
+interface ConversationDetailResponse {
+  conversationId: string;
+  userId: string;
+  userEmail: string | null;
+  userName: string | null;
+  turnCount: number;
+  totalCost: number;
+  turns: ConversationTurn[];
+}
+
+function fmtUSD(n: number): string {
+  return `$${n.toLocaleString(undefined, {
+    minimumFractionDigits: 4,
+    maximumFractionDigits: 4,
+  })}`;
+}
+
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return n.toLocaleString();
+}
+
+function ToolChip({ name }: { name: string }) {
+  // Color by category
+  const isRunSql = name === "run_sql";
+  const isExploration = ["describe_table", "search_metadata", "get_column_values", "sample_rows", "count_rows", "list_tables"].includes(name);
+  const cls = isRunSql
+    ? "bg-[#403770]/10 text-[#403770] border-[#403770]/20"
+    : isExploration
+      ? "bg-[#6EA3BE]/15 text-[#4d7285] border-[#6EA3BE]/30"
+      : "bg-[#EFEDF5] text-[#544A78] border-[#D4CFE2]";
+  return (
+    <span
+      className={`inline-flex items-center px-2 py-0.5 text-[11px] font-medium rounded-full border ${cls} whitespace-nowrap`}
+    >
+      {name}
+    </span>
+  );
+}
+
+function TurnCard({ turn, index }: { turn: ConversationTurn; index: number }) {
+  return (
+    <div className="bg-white rounded-lg border border-[#D4CFE2] shadow-sm p-4">
+      {/* Turn header */}
+      <div className="flex items-center justify-between gap-3 flex-wrap mb-3">
+        <div className="flex items-center gap-2 whitespace-nowrap">
+          <span className="text-[11px] font-semibold uppercase tracking-wider text-[#8A80A8]">
+            Turn {index + 1}
+          </span>
+          <span className="text-[#D4CFE2]">·</span>
+          <span className="text-xs text-[#8A80A8]">
+            {new Date(turn.createdAt).toLocaleString()}
+          </span>
+        </div>
+        <div className="flex items-center gap-3 text-xs whitespace-nowrap">
+          <span className="text-[#6E6390]">
+            <span className="font-semibold text-[#403770] tabular-nums">
+              {fmtUSD(turn.cost)}
+            </span>
+            <span className="text-[#A69DC0] ml-1">cost</span>
+          </span>
+          <span className="text-[#D4CFE2]">·</span>
+          <span className="text-[#6E6390] tabular-nums">
+            {fmtTokens(turn.tokens.input)} in / {fmtTokens(turn.tokens.output)} out
+          </span>
+          {(turn.tokens.cacheWrite > 0 || turn.tokens.cacheRead > 0) && (
+            <>
+              <span className="text-[#D4CFE2]">·</span>
+              <span className="text-[#6E6390] tabular-nums">
+                {fmtTokens(turn.tokens.cacheWrite)} cw / {fmtTokens(turn.tokens.cacheRead)} cr
+              </span>
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* User question */}
+      <div className="mb-3">
+        <div className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-[#8A80A8] mb-1">
+          <MessageSquare className="w-3 h-3" /> Question
+        </div>
+        <div className="text-sm text-[#403770] bg-[#F7F5FA] rounded-lg p-3 border border-[#E2DEEC]">
+          {turn.question}
+        </div>
+      </div>
+
+      {/* Assistant text */}
+      {turn.assistantText && (
+        <div className="mb-3">
+          <div className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-[#8A80A8] mb-1">
+            <MessageSquare className="w-3 h-3" /> Assistant reply
+          </div>
+          <div className="text-sm text-[#544A78] bg-white rounded-lg p-3 border border-[#E2DEEC] whitespace-pre-wrap">
+            {turn.assistantText}
+          </div>
+        </div>
+      )}
+
+      {/* Source / summary */}
+      {turn.summarySource && (
+        <div className="mb-3">
+          <div className="text-[11px] font-semibold uppercase tracking-wider text-[#8A80A8] mb-1">
+            Source label shown to user
+          </div>
+          <div className="text-sm text-[#544A78] italic">{turn.summarySource}</div>
+        </div>
+      )}
+
+      {/* Tools called */}
+      {turn.tools.length > 0 && (
+        <div className="mb-3">
+          <div className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-[#8A80A8] mb-1">
+            <Wrench className="w-3 h-3" /> Tools used ({turn.eventCount} events)
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            {turn.tools.map((tool, i) => (
+              <ToolChip key={`${tool}-${i}`} name={tool} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* SQL */}
+      {turn.sql && (
+        <div className="mb-3">
+          <div className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-[#8A80A8] mb-1">
+            <Code2 className="w-3 h-3" /> SQL executed
+            <span className="text-[#A69DC0] font-normal normal-case tracking-normal ml-1">
+              {turn.rowCount ?? 0} rows
+              {turn.executionTimeMs !== null && ` · ${turn.executionTimeMs}ms`}
+            </span>
+          </div>
+          <pre className="text-xs text-[#403770] bg-[#F7F5FA] rounded-lg p-3 border border-[#E2DEEC] overflow-x-auto whitespace-pre-wrap font-mono">
+            {turn.sql}
+          </pre>
+        </div>
+      )}
+
+      {/* Error */}
+      {turn.error && (
+        <div>
+          <div className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-[#c25a52] mb-1">
+            <AlertCircle className="w-3 h-3" /> Error
+          </div>
+          <pre className="text-xs text-[#c25a52] bg-[#fef1f0] rounded-lg p-3 border border-[#F37167]/30 whitespace-pre-wrap font-mono">
+            {turn.error}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function ConversationDetail({
+  conversationId,
+}: {
+  conversationId: string;
+}) {
+  const { data, isLoading, isError, error } = useQuery<ConversationDetailResponse>({
+    queryKey: ["admin-ai-query-convo-detail", conversationId],
+    queryFn: async () => {
+      const res = await fetch(
+        `/api/admin/ai-query/conversations/${encodeURIComponent(conversationId)}`,
+      );
+      if (!res.ok) throw new Error("Failed to load conversation");
+      return res.json();
+    },
+    staleTime: 60_000,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        {[...Array(2)].map((_, i) => (
+          <div key={i} className="h-32 bg-[#E2DEEC]/40 rounded-lg animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <div className="text-sm text-[#c25a52] bg-[#fef1f0] rounded-lg p-3 border border-[#F37167]/30">
+        Failed to load conversation: {error instanceof Error ? error.message : "unknown"}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="text-xs text-[#8A80A8] mb-3 flex items-center gap-2 flex-wrap whitespace-nowrap">
+        <span className="font-semibold text-[#544A78]">
+          {data.userName ?? data.userEmail ?? data.userId.slice(0, 8)}
+        </span>
+        <span className="text-[#D4CFE2]">·</span>
+        <span>{data.turnCount} turns</span>
+        <span className="text-[#D4CFE2]">·</span>
+        <span className="text-[#403770] font-semibold tabular-nums">
+          {fmtUSD(data.totalCost)} total
+        </span>
+        <span className="text-[#D4CFE2]">·</span>
+        <span className="font-mono">{data.conversationId.slice(0, 8)}</span>
+      </div>
+      <div className="space-y-3">
+        {data.turns.map((turn, i) => (
+          <TurnCard key={turn.id} turn={turn} index={i} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/features/admin/lib/ai-query-cost.ts
+++ b/src/features/admin/lib/ai-query-cost.ts
@@ -1,0 +1,41 @@
+// Anthropic Claude Opus 4.x pricing ($/MTok). Update if the report-tool model changes.
+export const PRICE = {
+  input: 15.0,
+  output: 75.0,
+  cacheWrite: 18.75, // 1.25× input
+  cacheRead: 1.5, // 0.10× input
+} as const;
+
+export interface TurnTokens {
+  inputTokens: number | null;
+  outputTokens: number | null;
+  cacheCreationInputTokens: number | null;
+  cacheReadInputTokens: number | null;
+}
+
+export function turnCost(t: TurnTokens): number {
+  const i = t.inputTokens ?? 0;
+  const o = t.outputTokens ?? 0;
+  const cw = t.cacheCreationInputTokens ?? 0;
+  const cr = t.cacheReadInputTokens ?? 0;
+  return (
+    (i * PRICE.input) / 1_000_000 +
+    (o * PRICE.output) / 1_000_000 +
+    (cw * PRICE.cacheWrite) / 1_000_000 +
+    (cr * PRICE.cacheRead) / 1_000_000
+  );
+}
+
+export type WindowScope = "7d" | "30d" | "90d" | "all";
+
+export function scopeToSinceDate(scope: WindowScope): Date | null {
+  if (scope === "all") return null;
+  const days = scope === "7d" ? 7 : scope === "30d" ? 30 : 90;
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - days);
+  return d;
+}
+
+export function parseScope(raw: string | null): WindowScope {
+  return raw === "7d" || raw === "90d" || raw === "all" ? raw : "30d";
+}


### PR DESCRIPTION
## Summary

New admin-only tab for monitoring the Reports tool's AI agent — cost analytics + a click-to-expand conversation inspector. Useful for spotting agent bugs visually and tracking cost-reduction progress over time.

- **KPI strip**: total spend, avg/turn, cache hit rate, wasted-on-failures
- **Cost by turn position**: see the cold-start premium (turn 1 ≈ 2× turn 3)
- **Top 10 most expensive turns**: cost outliers with question + event count
- **Conversation list**: searchable + paginated, click any row to inspect every turn — question, assistant reply, source label, tool chips (color-coded: \`run_sql\` plum, exploration tools steel blue), executed SQL with row count + duration, error block, full token breakdown + cost

API routes (admin-gated):
- \`GET /api/admin/ai-query/cost-summary?scope=7d|30d|90d|all\`
- \`GET /api/admin/ai-query/conversations?scope=...&search=...&page=...\`
- \`GET /api/admin/ai-query/conversations/[id]\`

Shared helper \`src/features/admin/lib/ai-query-cost.ts\` holds Opus 4.x pricing and \`turnCost()\` so future model changes update one place.

## Note: tab not yet wired into AdminDashboard

This PR ships the files but does not add the tab to the TABS array in \`AdminDashboard.tsx\`. The wiring is intentionally left for a follow-up so placement / feature gating can be decided separately. To enable for testing, add to TABS:

\`\`\`tsx
const AIQueryToolTab = lazy(() => import("./AIQueryToolTab"));
// ...
{ id: "ai-query-tool", label: "AI Query Tool" },
// ...
{activeTab === "ai-query-tool" && <AIQueryToolTab />}
\`\`\`

Then visit \`/admin?section=ai-query-tool\`.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] All routes return HTTP 307 (auth-gated, not 500)
- [x] Cost-summary numbers match offline analysis (\$34.46 / 77 turns / \$0.4476 avg)
- [ ] Manual: add the wiring (above) and click through every section
- [ ] Manual: search box filters conversations
- [ ] Manual: expand a real conversation, verify SQL/tools/tokens render

🤖 Generated with [Claude Code](https://claude.com/claude-code)