### PR TITLE
feat(map-plans): add MVT tile endpoint + lightweight /list endpoint

### DIFF
--- a/src/app/api/map/plans/[z]/[x]/[y]/__tests__/route.test.ts
+++ b/src/app/api/map/plans/[z]/[x]/[y]/__tests__/route.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockQuery = vi.fn();
+const mockRelease = vi.fn();
+vi.mock("@/lib/db", () => ({
+  default: {
+    connect: vi.fn(() =>
+      Promise.resolve({ query: mockQuery, release: mockRelease })
+    ),
+  },
+}));
+
+import { GET } from "../route";
+import pool from "@/lib/db";
+
+function buildRequest(
+  z: string,
+  x: string,
+  y: string,
+  searchParams?: Record<string, string>
+) {
+  const url = new URL(`http://localhost/api/map/plans/${z}/${x}/${y}`);
+  if (searchParams) {
+    for (const [key, value] of Object.entries(searchParams)) {
+      url.searchParams.set(key, value);
+    }
+  }
+  return new NextRequest(url);
+}
+
+async function callGET(
+  z: string,
+  x: string,
+  y: string,
+  searchParams?: Record<string, string>
+) {
+  const request = buildRequest(z, x, y, searchParams);
+  return GET(request, { params: Promise.resolve({ z, x, y }) });
+}
+
+describe("GET /api/map/plans/[z]/[x]/[y]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("parameter validation", () => {
+    it("returns 400 for invalid z coordinate", async () => {
+      const res = await callGET("abc", "1", "2.mvt");
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("Invalid tile coordinates");
+    });
+
+    it("returns 400 for invalid x coordinate", async () => {
+      const res = await callGET("5", "xyz", "2.mvt");
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 400 for invalid y coordinate", async () => {
+      const res = await callGET("5", "1", "abc.mvt");
+      expect(res.status).toBe(400);
+    });
+
+    it("strips .mvt suffix from y parameter", async () => {
+      mockQuery.mockResolvedValue({ rows: [{ mvt: Buffer.from("tile") }] });
+      await callGET("7", "10", "20.mvt");
+      const [, queryParams] = mockQuery.mock.calls[0];
+      expect(queryParams[0]).toBe(7);
+      expect(queryParams[1]).toBe(10);
+      expect(queryParams[2]).toBe(20);
+    });
+  });
+});

--- a/src/app/api/map/plans/[z]/[x]/[y]/__tests__/route.test.ts
+++ b/src/app/api/map/plans/[z]/[x]/[y]/__tests__/route.test.ts
@@ -126,4 +126,86 @@ describe("GET /api/map/plans/[z]/[x]/[y]", () => {
       expect(queryParams.slice(0, 3)).toEqual([7, 10, 20]);
     });
   });
+
+  describe("filter handling", () => {
+    it("emits no extra WHERE clause when no filters are present", async () => {
+      mockQuery.mockResolvedValue({ rows: [{ mvt: null }] });
+      await callGET("7", "10", "20");
+      const [sql, queryParams] = mockQuery.mock.calls[0];
+      expect(queryParams).toEqual([7, 10, 20]);
+      expect(sql).not.toContain("AND tp.status");
+      expect(sql).not.toContain("AND tp.fiscal_year");
+      expect(sql).not.toContain("AND tp.owner_id");
+      expect(sql).not.toMatch(/AND tp\.id\s*(=|IN)/);
+    });
+
+    it("filters by single status", async () => {
+      mockQuery.mockResolvedValue({ rows: [{ mvt: null }] });
+      await callGET("7", "10", "20", { status: "working" });
+      const [sql, queryParams] = mockQuery.mock.calls[0];
+      expect(sql).toContain("AND tp.status = $4");
+      expect(queryParams).toEqual([7, 10, 20, "working"]);
+    });
+
+    it("filters by multiple statuses with IN clause", async () => {
+      mockQuery.mockResolvedValue({ rows: [{ mvt: null }] });
+      await callGET("7", "10", "20", { status: "working,planning" });
+      const [sql, queryParams] = mockQuery.mock.calls[0];
+      expect(sql).toMatch(/AND tp\.status IN \(\$4,\$5\)/);
+      expect(queryParams).toEqual([7, 10, 20, "working", "planning"]);
+    });
+
+    it("returns 400 for non-numeric fiscalYear", async () => {
+      const res = await callGET("7", "10", "20", { fiscalYear: "abc" });
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toBe("Invalid fiscalYear format");
+    });
+
+    it("filters by integer fiscalYear", async () => {
+      mockQuery.mockResolvedValue({ rows: [{ mvt: null }] });
+      await callGET("7", "10", "20", { fiscalYear: "2026" });
+      const [sql, queryParams] = mockQuery.mock.calls[0];
+      expect(sql).toContain("AND tp.fiscal_year = $4");
+      expect(queryParams).toEqual([7, 10, 20, 2026]);
+    });
+
+    it("filters by single planId param (legacy compat)", async () => {
+      mockQuery.mockResolvedValue({ rows: [{ mvt: null }] });
+      await callGET("7", "10", "20", { planId: "plan-uuid-1" });
+      const [sql, queryParams] = mockQuery.mock.calls[0];
+      expect(sql).toContain("AND tp.id = $4");
+      expect(queryParams).toEqual([7, 10, 20, "plan-uuid-1"]);
+    });
+
+    it("filters by planIds list with IN clause", async () => {
+      mockQuery.mockResolvedValue({ rows: [{ mvt: null }] });
+      await callGET("7", "10", "20", { planIds: "p1,p2,p3" });
+      const [sql, queryParams] = mockQuery.mock.calls[0];
+      expect(sql).toMatch(/AND tp\.id IN \(\$4,\$5,\$6\)/);
+      expect(queryParams).toEqual([7, 10, 20, "p1", "p2", "p3"]);
+    });
+
+    it("filters by ownerIds list with IN clause", async () => {
+      mockQuery.mockResolvedValue({ rows: [{ mvt: null }] });
+      await callGET("7", "10", "20", { ownerIds: "u1,u2" });
+      const [sql, queryParams] = mockQuery.mock.calls[0];
+      expect(sql).toMatch(/AND tp\.owner_id IN \(\$4,\$5\)/);
+      expect(queryParams).toEqual([7, 10, 20, "u1", "u2"]);
+    });
+
+    it("combines multiple filters with AND", async () => {
+      mockQuery.mockResolvedValue({ rows: [{ mvt: null }] });
+      await callGET("7", "10", "20", {
+        status: "working",
+        fiscalYear: "2026",
+        ownerIds: "u1",
+      });
+      const [sql, queryParams] = mockQuery.mock.calls[0];
+      expect(sql).toContain("AND tp.status = $4");
+      expect(sql).toContain("AND tp.fiscal_year = $5");
+      expect(sql).toContain("AND tp.owner_id IN ($6)");
+      expect(queryParams).toEqual([7, 10, 20, "working", 2026, "u1"]);
+    });
+  });
 });

--- a/src/app/api/map/plans/[z]/[x]/[y]/__tests__/route.test.ts
+++ b/src/app/api/map/plans/[z]/[x]/[y]/__tests__/route.test.ts
@@ -71,4 +71,59 @@ describe("GET /api/map/plans/[z]/[x]/[y]", () => {
       expect(queryParams[2]).toBe(20);
     });
   });
+
+  describe("geometry simplification", () => {
+    it("uses tolerance 0.01 for zoom < 7", async () => {
+      mockQuery.mockResolvedValue({ rows: [{ mvt: null }] });
+      await callGET("3", "1", "1");
+      const [sql] = mockQuery.mock.calls[0];
+      expect(sql).toContain("ST_Simplify(d.render_geometry, 0.01)");
+    });
+
+    it("uses tolerance 0.005 for zoom 7-10", async () => {
+      mockQuery.mockResolvedValue({ rows: [{ mvt: null }] });
+      await callGET("8", "10", "10");
+      const [sql] = mockQuery.mock.calls[0];
+      expect(sql).toContain("ST_Simplify(d.render_geometry, 0.005)");
+    });
+
+    it("uses tolerance 0.001 for zoom >= 11", async () => {
+      mockQuery.mockResolvedValue({ rows: [{ mvt: null }] });
+      await callGET("12", "10", "10");
+      const [sql] = mockQuery.mock.calls[0];
+      expect(sql).toContain("ST_Simplify(d.render_geometry, 0.001)");
+    });
+  });
+
+  describe("SQL shape", () => {
+    it("uses ST_AsMVT with the 'plans' layer name", async () => {
+      mockQuery.mockResolvedValue({ rows: [{ mvt: null }] });
+      await callGET("7", "10", "20");
+      const [sql] = mockQuery.mock.calls[0];
+      expect(sql).toContain("ST_AsMVT(tile_data, 'plans', 4096, 'geom')");
+    });
+
+    it("joins territory_plans → territory_plan_districts → district_map_features", async () => {
+      mockQuery.mockResolvedValue({ rows: [{ mvt: null }] });
+      await callGET("7", "10", "20");
+      const [sql] = mockQuery.mock.calls[0];
+      expect(sql).toContain("FROM territory_plans tp");
+      expect(sql).toContain("INNER JOIN territory_plan_districts tpd");
+      expect(sql).toContain("INNER JOIN district_map_features d");
+    });
+
+    it("filters by tile envelope using GIST-friendly &&", async () => {
+      mockQuery.mockResolvedValue({ rows: [{ mvt: null }] });
+      await callGET("7", "10", "20");
+      const [sql] = mockQuery.mock.calls[0];
+      expect(sql).toContain("d.render_geometry && (SELECT envelope_4326 FROM tile_bounds)");
+    });
+
+    it("passes z/x/y as the first three SQL parameters", async () => {
+      mockQuery.mockResolvedValue({ rows: [{ mvt: null }] });
+      await callGET("7", "10", "20");
+      const [, queryParams] = mockQuery.mock.calls[0];
+      expect(queryParams.slice(0, 3)).toEqual([7, 10, 20]);
+    });
+  });
 });

--- a/src/app/api/map/plans/[z]/[x]/[y]/__tests__/route.test.ts
+++ b/src/app/api/map/plans/[z]/[x]/[y]/__tests__/route.test.ts
@@ -208,4 +208,72 @@ describe("GET /api/map/plans/[z]/[x]/[y]", () => {
       expect(queryParams).toEqual([7, 10, 20, "working", 2026, "u1"]);
     });
   });
+
+  describe("response handling", () => {
+    it("returns 204 with vector-tile content type when MVT is null", async () => {
+      mockQuery.mockResolvedValue({ rows: [{ mvt: null }] });
+      const res = await callGET("7", "10", "20");
+      expect(res.status).toBe(204);
+      expect(res.headers.get("Content-Type")).toBe("application/vnd.mapbox-vector-tile");
+      expect(res.headers.get("Cache-Control")).toBe("public, max-age=300");
+    });
+
+    it("returns 204 when MVT buffer is empty", async () => {
+      mockQuery.mockResolvedValue({ rows: [{ mvt: Buffer.alloc(0) }] });
+      const res = await callGET("7", "10", "20");
+      expect(res.status).toBe(204);
+    });
+
+    it("returns 204 when rows are empty", async () => {
+      mockQuery.mockResolvedValue({ rows: [] });
+      const res = await callGET("7", "10", "20");
+      expect(res.status).toBe(204);
+    });
+
+    it("returns 200 with binary MVT and correct headers", async () => {
+      const tileData = Buffer.from("mock-tile-data");
+      mockQuery.mockResolvedValue({ rows: [{ mvt: tileData }] });
+      const res = await callGET("7", "10", "20");
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toBe("application/vnd.mapbox-vector-tile");
+      expect(res.headers.get("Content-Length")).toBe(String(tileData.length));
+      expect(res.headers.get("Cache-Control")).toBe("public, max-age=300");
+    });
+  });
+
+  describe("error handling", () => {
+    it("returns 500 on database query error", async () => {
+      mockQuery.mockRejectedValue(new Error("DB connection failed"));
+      const res = await callGET("7", "10", "20");
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe("Failed to generate tile");
+    });
+
+    it("returns 500 on pool.connect error", async () => {
+      vi.mocked(pool.connect).mockRejectedValueOnce(new Error("Pool exhausted"));
+      const res = await callGET("7", "10", "20");
+      expect(res.status).toBe(500);
+    });
+  });
+
+  describe("connection management", () => {
+    it("releases client after successful query", async () => {
+      mockQuery.mockResolvedValue({ rows: [{ mvt: Buffer.from("tile") }] });
+      await callGET("7", "10", "20");
+      expect(mockRelease).toHaveBeenCalledOnce();
+    });
+
+    it("releases client after empty result (204)", async () => {
+      mockQuery.mockResolvedValue({ rows: [{ mvt: null }] });
+      await callGET("7", "10", "20");
+      expect(mockRelease).toHaveBeenCalledOnce();
+    });
+
+    it("releases client even when query throws", async () => {
+      mockQuery.mockRejectedValue(new Error("query failed"));
+      await callGET("7", "10", "20");
+      expect(mockRelease).toHaveBeenCalledOnce();
+    });
+  });
 });

--- a/src/app/api/map/plans/[z]/[x]/[y]/route.ts
+++ b/src/app/api/map/plans/[z]/[x]/[y]/route.ts
@@ -20,10 +20,56 @@ export async function GET(
       );
     }
 
-    // TODO: filter parsing + SQL — added in subsequent tasks.
+    // Zoom-aware simplification (matches /api/tiles)
+    const simplifyTolerance = zoom < 7 ? 0.01 : zoom < 11 ? 0.005 : 0.001;
+
+    // Plan filter parsing — added in Task 4.
+    const planFilters = "";
+    const filterParams: (string | number)[] = [];
+
+    const query = `
+      WITH tile_bounds AS (
+        SELECT
+          ST_TileEnvelope($1, $2, $3) AS envelope,
+          ST_Transform(ST_TileEnvelope($1, $2, $3), 4326) AS envelope_4326
+      ),
+      tile_data AS (
+        SELECT
+          tp.id AS "planId",
+          tp.name AS "planName",
+          tp.color AS "planColor",
+          tp.status AS "planStatus",
+          d.name AS "districtName",
+          d.leaid,
+          tpd.renewal_target AS "renewalTarget",
+          tpd.expansion_target AS "expansionTarget",
+          ST_AsMVTGeom(
+            ST_Transform(
+              ST_Simplify(d.render_geometry, ${simplifyTolerance}),
+              3857
+            ),
+            (SELECT envelope FROM tile_bounds),
+            4096,
+            64,
+            true
+          ) AS geom
+        FROM territory_plans tp
+        INNER JOIN territory_plan_districts tpd ON tp.id = tpd.plan_id
+        INNER JOIN district_map_features d ON tpd.district_leaid = d.leaid
+        WHERE d.render_geometry IS NOT NULL
+          AND d.render_geometry && (SELECT envelope_4326 FROM tile_bounds)
+          ${planFilters}
+      )
+      SELECT ST_AsMVT(tile_data, 'plans', 4096, 'geom') AS mvt
+      FROM tile_data
+      WHERE geom IS NOT NULL
+    `;
+
+    const queryParams: (string | number)[] = [zoom, tileX, tileY, ...filterParams];
+
     const client = await pool.connect();
     try {
-      const result = await client.query("SELECT NULL::bytea AS mvt", [zoom, tileX, tileY]);
+      const result = await client.query(query, queryParams);
       const mvt = result.rows[0]?.mvt;
       if (!mvt || mvt.length === 0) {
         return new NextResponse(null, {

--- a/src/app/api/map/plans/[z]/[x]/[y]/route.ts
+++ b/src/app/api/map/plans/[z]/[x]/[y]/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import pool from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ z: string; x: string; y: string }> }
+) {
+  try {
+    const { z, x, y } = await params;
+    const zoom = parseInt(z);
+    const tileX = parseInt(x);
+    const tileY = parseInt(y.replace(".mvt", ""));
+
+    if (isNaN(zoom) || isNaN(tileX) || isNaN(tileY)) {
+      return NextResponse.json(
+        { error: "Invalid tile coordinates" },
+        { status: 400 }
+      );
+    }
+
+    // TODO: filter parsing + SQL — added in subsequent tasks.
+    const client = await pool.connect();
+    try {
+      const result = await client.query("SELECT NULL::bytea AS mvt", [zoom, tileX, tileY]);
+      const mvt = result.rows[0]?.mvt;
+      if (!mvt || mvt.length === 0) {
+        return new NextResponse(null, {
+          status: 204,
+          headers: {
+            "Content-Type": "application/vnd.mapbox-vector-tile",
+            "Cache-Control": "public, max-age=300",
+          },
+        });
+      }
+      return new NextResponse(mvt, {
+        status: 200,
+        headers: {
+          "Content-Type": "application/vnd.mapbox-vector-tile",
+          "Cache-Control": "public, max-age=300",
+          "Content-Length": mvt.length.toString(),
+        },
+      });
+    } finally {
+      client.release();
+    }
+  } catch (error) {
+    console.error("Error generating plans tile:", error);
+    return NextResponse.json(
+      { error: "Failed to generate tile" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/map/plans/[z]/[x]/[y]/route.ts
+++ b/src/app/api/map/plans/[z]/[x]/[y]/route.ts
@@ -23,9 +23,65 @@ export async function GET(
     // Zoom-aware simplification (matches /api/tiles)
     const simplifyTolerance = zoom < 7 ? 0.01 : zoom < 11 ? 0.005 : 0.001;
 
-    // Plan filter parsing — added in Task 4.
-    const planFilters = "";
+    const { searchParams } = new URL(request.url);
+    const status = searchParams.get("status");
+    const fiscalYearRaw = searchParams.get("fiscalYear");
+    const planId = searchParams.get("planId");
+    const planIdsParam = searchParams.get("planIds");
+    const ownerIdsParam = searchParams.get("ownerIds");
+
+    const conditions: string[] = [];
     const filterParams: (string | number)[] = [];
+    // z/x/y consume $1/$2/$3, so filter placeholders start at $4.
+    const placeholderFor = (val: string | number) => {
+      filterParams.push(val);
+      return `$${3 + filterParams.length}`;
+    };
+
+    if (status) {
+      const statuses = status.split(",").filter(Boolean);
+      if (statuses.length === 1) {
+        conditions.push(`tp.status = ${placeholderFor(statuses[0])}`);
+      } else if (statuses.length > 1) {
+        const ph = statuses.map((s) => placeholderFor(s)).join(",");
+        conditions.push(`tp.status IN (${ph})`);
+      }
+    }
+
+    if (fiscalYearRaw) {
+      const fy = parseInt(fiscalYearRaw, 10);
+      if (isNaN(fy)) {
+        return NextResponse.json(
+          { error: "Invalid fiscalYear format" },
+          { status: 400 }
+        );
+      }
+      conditions.push(`tp.fiscal_year = ${placeholderFor(fy)}`);
+    }
+
+    if (planId) {
+      conditions.push(`tp.id = ${placeholderFor(planId)}`);
+    }
+
+    if (planIdsParam) {
+      const ids = planIdsParam.split(",").filter(Boolean);
+      if (ids.length > 0) {
+        const ph = ids.map((id) => placeholderFor(id)).join(",");
+        conditions.push(`tp.id IN (${ph})`);
+      }
+    }
+
+    if (ownerIdsParam) {
+      const ids = ownerIdsParam.split(",").filter(Boolean);
+      if (ids.length > 0) {
+        const ph = ids.map((id) => placeholderFor(id)).join(",");
+        conditions.push(`tp.owner_id IN (${ph})`);
+      }
+    }
+
+    const planFilters = conditions.length > 0
+      ? "AND " + conditions.join(" AND ")
+      : "";
 
     const query = `
       WITH tile_bounds AS (

--- a/src/app/api/map/plans/list/__tests__/route.test.ts
+++ b/src/app/api/map/plans/list/__tests__/route.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockQuery = vi.fn();
+const mockRelease = vi.fn();
+vi.mock("@/lib/db", () => ({
+  default: {
+    connect: vi.fn(() =>
+      Promise.resolve({ query: mockQuery, release: mockRelease })
+    ),
+  },
+}));
+
+import { GET } from "../route";
+import pool from "@/lib/db";
+
+function buildRequest(searchParams?: Record<string, string>) {
+  const url = new URL("http://localhost/api/map/plans/list");
+  if (searchParams) {
+    for (const [key, value] of Object.entries(searchParams)) {
+      url.searchParams.set(key, value);
+    }
+  }
+  return new NextRequest(url);
+}
+
+const sampleRows = [
+  {
+    planId: "plan-1",
+    planName: "Working A",
+    planColor: "#7B6BA4",
+    planStatus: "working",
+    districtName: "Acme USD",
+    leaid: "0001234",
+    renewalTarget: "12.5",
+    expansionTarget: null,
+  },
+];
+
+describe("GET /api/map/plans/list", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns a flat array of rows (no FeatureCollection wrapper, no geometry)", async () => {
+    mockQuery.mockResolvedValue({ rows: sampleRows });
+    const res = await GET(buildRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body)).toBe(true);
+    expect(body[0]).toMatchObject({
+      planId: "plan-1",
+      planName: "Working A",
+      leaid: "0001234",
+    });
+    expect(body[0]).not.toHaveProperty("geometry");
+    expect(body[0]).not.toHaveProperty("type");
+  });
+
+  it("parses numeric targets to floats and preserves nulls", async () => {
+    mockQuery.mockResolvedValue({ rows: sampleRows });
+    const res = await GET(buildRequest());
+    const body = await res.json();
+    expect(body[0].renewalTarget).toBe(12.5);
+    expect(body[0].expansionTarget).toBeNull();
+  });
+
+  it("does NOT call ST_AsGeoJSON in the SQL", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+    await GET(buildRequest());
+    const [sql] = mockQuery.mock.calls[0];
+    expect(sql).not.toContain("ST_AsGeoJSON");
+    expect(sql).not.toContain("geometry");
+  });
+
+  it("filters by status with $1", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+    await GET(buildRequest({ status: "working" }));
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toContain("tp.status = $1");
+    expect(params).toEqual(["working"]);
+  });
+
+  it("filters by ownerIds list", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+    await GET(buildRequest({ ownerIds: "u1,u2" }));
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toMatch(/tp\.owner_id IN \(\$1,\$2\)/);
+    expect(params).toEqual(["u1", "u2"]);
+  });
+
+  it("returns 400 on invalid fiscalYear", async () => {
+    const res = await GET(buildRequest({ fiscalYear: "abc" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 500 on database error and releases the client", async () => {
+    mockQuery.mockRejectedValue(new Error("db down"));
+    const res = await GET(buildRequest());
+    expect(res.status).toBe(500);
+    expect(mockRelease).toHaveBeenCalledOnce();
+  });
+
+  it("sets a short browser cache header", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+    const res = await GET(buildRequest());
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=120");
+  });
+});

--- a/src/app/api/map/plans/list/__tests__/route.test.ts
+++ b/src/app/api/map/plans/list/__tests__/route.test.ts
@@ -89,6 +89,22 @@ describe("GET /api/map/plans/list", () => {
     expect(params).toEqual(["u1", "u2"]);
   });
 
+  it("filters by single planId param", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+    await GET(buildRequest({ planId: "plan-uuid-1" }));
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toContain("tp.id = $1");
+    expect(params).toEqual(["plan-uuid-1"]);
+  });
+
+  it("filters by planIds list with IN clause", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+    await GET(buildRequest({ planIds: "p1,p2,p3" }));
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toMatch(/tp\.id IN \(\$1,\$2,\$3\)/);
+    expect(params).toEqual(["p1", "p2", "p3"]);
+  });
+
   it("returns 400 on invalid fiscalYear", async () => {
     const res = await GET(buildRequest({ fiscalYear: "abc" }));
     expect(res.status).toBe(400);
@@ -105,5 +121,14 @@ describe("GET /api/map/plans/list", () => {
     mockQuery.mockResolvedValue({ rows: [] });
     const res = await GET(buildRequest());
     expect(res.headers.get("Cache-Control")).toBe("public, max-age=120");
+  });
+
+  it("returns 500 and does not release the client when pool.connect fails", async () => {
+    vi.mocked(pool.connect).mockRejectedValueOnce(new Error("Pool exhausted"));
+    const res = await GET(buildRequest());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Failed to fetch plan list");
+    expect(mockRelease).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/map/plans/list/route.ts
+++ b/src/app/api/map/plans/list/route.ts
@@ -95,7 +95,7 @@ export async function GET(request: NextRequest) {
           tpd.expansion_target AS "expansionTarget"
         FROM territory_plans tp
         INNER JOIN territory_plan_districts tpd ON tp.id = tpd.plan_id
-        INNER JOIN districts d ON tpd.district_leaid = d.leaid
+        INNER JOIN district_map_features d ON tpd.district_leaid = d.leaid
         ${whereClause}
         `,
         params

--- a/src/app/api/map/plans/list/route.ts
+++ b/src/app/api/map/plans/list/route.ts
@@ -1,0 +1,128 @@
+import { NextRequest, NextResponse } from "next/server";
+import pool from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/map/plans/list
+ *
+ * Lightweight companion to /api/map/plans/[z]/[x]/[y].
+ * Returns one row per (plan, district) pair with plan + target metadata,
+ * **without** geometry. Used by:
+ *   - `useCrossFilter` (extracts leaids to filter other overlays)
+ *   - `<PlansTab>` (groups by planId for the sidebar list)
+ *   - `SearchResults/index.tsx` tab counts
+ *
+ * Query params (mirror the legacy /api/map/plans endpoint):
+ *   - status: comma-separated plan statuses
+ *   - fiscalYear: integer FY
+ *   - planId: single-plan mode
+ *   - planIds: comma-separated plan UUIDs
+ *   - ownerIds: comma-separated owner UUIDs
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const status = searchParams.get("status");
+    const fiscalYearRaw = searchParams.get("fiscalYear");
+    const planId = searchParams.get("planId");
+    const planIdsParam = searchParams.get("planIds");
+    const ownerIdsParam = searchParams.get("ownerIds");
+
+    const conditions: string[] = [];
+    const params: (string | number)[] = [];
+    const placeholderFor = (val: string | number) => {
+      params.push(val);
+      return `$${params.length}`;
+    };
+
+    if (status) {
+      const statuses = status.split(",").filter(Boolean);
+      if (statuses.length === 1) {
+        conditions.push(`tp.status = ${placeholderFor(statuses[0])}`);
+      } else if (statuses.length > 1) {
+        const ph = statuses.map((s) => placeholderFor(s)).join(",");
+        conditions.push(`tp.status IN (${ph})`);
+      }
+    }
+
+    if (fiscalYearRaw) {
+      const fy = parseInt(fiscalYearRaw, 10);
+      if (isNaN(fy)) {
+        return NextResponse.json(
+          { error: "Invalid fiscalYear format" },
+          { status: 400 }
+        );
+      }
+      conditions.push(`tp.fiscal_year = ${placeholderFor(fy)}`);
+    }
+
+    if (planId) {
+      conditions.push(`tp.id = ${placeholderFor(planId)}`);
+    }
+
+    if (planIdsParam) {
+      const ids = planIdsParam.split(",").filter(Boolean);
+      if (ids.length > 0) {
+        const ph = ids.map((id) => placeholderFor(id)).join(",");
+        conditions.push(`tp.id IN (${ph})`);
+      }
+    }
+
+    if (ownerIdsParam) {
+      const ids = ownerIdsParam.split(",").filter(Boolean);
+      if (ids.length > 0) {
+        const ph = ids.map((id) => placeholderFor(id)).join(",");
+        conditions.push(`tp.owner_id IN (${ph})`);
+      }
+    }
+
+    const whereClause =
+      conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+
+    const client = await pool.connect();
+    try {
+      const result = await client.query(
+        `
+        SELECT
+          tp.id AS "planId",
+          tp.name AS "planName",
+          tp.color AS "planColor",
+          tp.status AS "planStatus",
+          d.name AS "districtName",
+          d.leaid,
+          tpd.renewal_target AS "renewalTarget",
+          tpd.expansion_target AS "expansionTarget"
+        FROM territory_plans tp
+        INNER JOIN territory_plan_districts tpd ON tp.id = tpd.plan_id
+        INNER JOIN districts d ON tpd.district_leaid = d.leaid
+        ${whereClause}
+        `,
+        params
+      );
+
+      const rows = result.rows.map((r) => ({
+        planId: r.planId,
+        planName: r.planName,
+        planColor: r.planColor,
+        planStatus: r.planStatus,
+        districtName: r.districtName,
+        leaid: r.leaid,
+        renewalTarget: r.renewalTarget != null ? parseFloat(r.renewalTarget) : null,
+        expansionTarget: r.expansionTarget != null ? parseFloat(r.expansionTarget) : null,
+      }));
+
+      return NextResponse.json(rows, {
+        headers: { "Cache-Control": "public, max-age=120" },
+      });
+    } finally {
+      client.release();
+    }
+  } catch (error) {
+    console.error("Error fetching plan list:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch plan list" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -80,7 +80,11 @@ export const config = {
      * - favicon.ico (favicon file)
      * - public files (images, etc.)
      * - API routes that should be public (tiles for map rendering)
+     *   `api/map/plans/\d+` allowlists the per-tile MVT endpoint
+     *   (`/api/map/plans/[z]/[x]/[y].mvt`) without exposing the legacy
+     *   `/api/map/plans` GeoJSON endpoint or the lightweight `/api/map/plans/list`
+     *   JSON endpoint, which stay session-gated for the React app.
      */
-    '/((?!_next|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$|api/tiles|api/cron|api/webhooks).*)',
+    '/((?!_next|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$|api/tiles|api/map/plans/\\d+|api/cron|api/webhooks).*)',
   ],
 }


### PR DESCRIPTION
## Summary
- Adds `/api/map/plans/[z]/[x]/[y]` returning binary MVT (per design spec) — replaces the 60s unfiltered `/api/map/plans` GeoJSON path with per-tile vector data scoped by tile envelope.
- Adds `/api/map/plans/list` returning a flat JSON array of plan-district rows without geometry — required for the cross-filter and PlansTab consumers identified during planning (these need `properties` only and can't read MVT).
- Allowlists `/api/map/plans/[z]/[x]/[y].mvt` in the Supabase auth middleware so MapLibre can fetch tiles without a session cookie. The legacy `/api/map/plans` GeoJSON endpoint and the new `/list` JSON endpoint stay session-gated.
- Old `/api/map/plans` GeoJSON endpoint left untouched — client cutover ships in PR 2, legacy delete in PR 3.

## Spec
- `Docs/superpowers/specs/2026-05-01-map-plans-vector-tiles-design.md`
- `docs/superpowers/plans/2026-05-04-map-plans-vector-tiles.md`

## Test plan
- [x] Backend unit tests pass (`npx vitest run src/app/api/map/plans` — 40/40)
- [x] Manual: `curl /api/map/plans/4/3/6.mvt` returns `application/vnd.mapbox-vector-tile`
- [x] Manual: `curl /api/map/plans/list | jq length` matches `/api/map/plans .features | length`
- [ ] No client code changed in this PR — production traffic still uses the old endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)