### PR TITLE
feat(admin): rep filter for unmatched opportunities + dropdown typeahead

### DIFF
--- a/Docs/superpowers/plans/2026-05-04-unmatched-opps-rep-filter.md
+++ b/Docs/superpowers/plans/2026-05-04-unmatched-opps-rep-filter.md
@@ -1,0 +1,717 @@
+# Unmatched Opportunities Rep Filter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the leaderboard's `?rep=<UserProfile.id>` deep-link to actually filter `/admin/unmatched-opportunities`, and surface a Rep filter in the existing filter bar so admins can scope by rep on this page directly.
+
+**Architecture:** Three-layer in-place fix. (1) API route translates `rep` UUID → email via `UserProfile.findUnique`, sub-selects opportunity ids matching that `sales_rep_email`, then constrains the existing Prisma `where` with `id: { in: ids }`. (2) `ColumnDef` gains `isFilterOnly?: boolean` and `enumValues` is widened to accept `{value, label}` objects so the chip can show "Monica Sherwood" instead of a UUID. (3) Page reads `?rep=` via `useSearchParams()`, seeds filter state, hydrates a virtual Rep column from `useUsers()`, and `router.replace()`'s the URL when the chip is cleared.
+
+**Tech Stack:** Next.js 16 App Router, React 19, TypeScript, Prisma, TanStack Query, Vitest + Testing Library + jsdom, Tailwind 4.
+
+**Spec:** `Docs/superpowers/specs/2026-05-04-unmatched-opps-rep-filter-design.md`
+
+---
+
+## File Map
+
+| Path | Action | Purpose |
+|------|--------|---------|
+| `src/features/shared/components/DataGrid/types.ts` | Modify | Widen `enumValues` to support `{value,label}` form; add `isFilterOnly?: boolean` to `ColumnDef`. |
+| `src/app/admin/unmatched-opportunities/AdminFilterBar.tsx` | Modify | Normalize `enumValues` consumption; render label (not raw value) in chips when label exists. |
+| `src/app/admin/unmatched-opportunities/AdminColumnPicker.tsx` | Modify | Skip `isFilterOnly` columns in the toggle list. |
+| `src/features/shared/components/DataGrid/DataGrid.tsx` | Modify | Skip `isFilterOnly` columns when building TanStack Table column defs. |
+| `src/app/admin/unmatched-opportunities/columns.ts` | Modify | Add virtual "rep" column entry (`isFilterOnly: true`, `filterType: "enum"`). |
+| `src/app/api/admin/unmatched-opportunities/route.ts` | Modify | Accept `rep` query param; translate UUID → email → ids → `where.id`. |
+| `src/app/api/admin/unmatched-opportunities/__tests__/route.test.ts` | Create | TDD coverage of rep filter API behavior. |
+| `src/app/admin/unmatched-opportunities/page.tsx` | Modify | `useSearchParams` + `useRouter`; seed filters with rep on mount; hydrate rep column from `useUsers()`; forward `rep` to API; clear URL on chip removal. |
+
+---
+
+## Task 1: Extend `ColumnDef` type
+
+**Files:**
+- Modify: `src/features/shared/components/DataGrid/types.ts:4-15`
+
+- [ ] **Step 1: Modify the `ColumnDef` interface**
+
+Replace the interface body:
+
+```ts
+export interface ColumnDef {
+  key: string;
+  label: string;
+  group: string;
+  isDefault: boolean;
+  filterType: "text" | "enum" | "number" | "boolean" | "date" | "tags" | "relation";
+  enumValues?: Array<string | { value: string; label: string }>;
+  relationSource?: string; // intentionally wide per spec (existing districtColumns uses "tags" | "plans")
+  width?: number;    // explicit column width in px (applied as min-width + max-width)
+  editable?: boolean;
+  sortable?: boolean; // defaults to true; set false to disable sorting
+  isFilterOnly?: boolean; // virtual column — appears in filter picker but never rendered as a row cell
+}
+```
+
+The only changes vs. current: `enumValues` widened to `Array<string | { value: string; label: string }>`, and a new `isFilterOnly?: boolean` line.
+
+- [ ] **Step 2: Verify typecheck passes for the changed file only**
+
+Run: `npx tsc --noEmit -p tsconfig.json 2>&1 | grep -E "DataGrid/types\.ts|columns\.ts|AdminFilterBar\.tsx|AdminColumnPicker\.tsx|DataGrid\.tsx" | head -20`
+
+Expected: no errors mentioning these files. (If unrelated repo errors exist, ignore them — we're only verifying our change is type-clean.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/features/shared/components/DataGrid/types.ts
+git commit -m "feat(datagrid): widen ColumnDef enumValues + add isFilterOnly"
+```
+
+---
+
+## Task 2: Make `AdminFilterBar` use object-form `enumValues`
+
+The bar today builds dropdown options at line 353 with `colDef.enumValues.map((v) => ({ value: v, label: v }))` — assumes `v` is a string. The chip label at lines 59-69 also displays `filter.value` raw. Both need to handle the `{value,label}` form.
+
+**Files:**
+- Modify: `src/app/admin/unmatched-opportunities/AdminFilterBar.tsx`
+
+- [ ] **Step 1: Add a normalization helper**
+
+After the imports (top of the file, after line 6), add:
+
+```ts
+function normalizeEnumValues(
+  values: Array<string | { value: string; label: string }> | undefined
+): { value: string; label: string }[] {
+  if (!values) return [];
+  return values.map((v) => (typeof v === "string" ? { value: v, label: v } : v));
+}
+```
+
+- [ ] **Step 2: Update `formatFilterLabel` to look up the label**
+
+Replace the `formatFilterLabel` function (currently lines 59-69) with:
+
+```ts
+function formatFilterLabel(columnDefs: ColumnDef[], filter: FilterRule): string {
+  const col = getColumnDef(columnDefs, filter.column);
+  const label = col?.label ?? filter.column;
+  const operators = getOperators(col?.filterType ?? "text");
+  const opDef = operators.find((o) => o.op === filter.operator);
+  const opLabel = opDef?.label ?? filter.operator;
+  if (opDef && !opDef.needsValue) {
+    return `${label} ${opLabel}`;
+  }
+  // For enum columns with object-form values, render the human label, not the raw id.
+  let displayValue: string = String(filter.value);
+  if (col?.filterType === "enum" && col.enumValues) {
+    const match = normalizeEnumValues(col.enumValues).find(
+      (v) => v.value === String(filter.value)
+    );
+    if (match) displayValue = match.label;
+  }
+  return `${label} ${opLabel} "${displayValue}"`;
+}
+```
+
+- [ ] **Step 3: Update the value Dropdown to use normalized options**
+
+Find the `Dropdown` invocation for enum value inputs (currently around line 348-355):
+
+```tsx
+{colDef?.filterType === "enum" && colDef.enumValues ? (
+  <div className="relative mt-1">
+    <Dropdown
+      value={filterValue}
+      placeholder="Select value..."
+      options={colDef.enumValues.map((v) => ({ value: v, label: v }))}
+      onChange={setFilterValue}
+    />
+  </div>
+) : ...
+```
+
+Replace with:
+
+```tsx
+{colDef?.filterType === "enum" && colDef.enumValues ? (
+  <div className="relative mt-1">
+    <Dropdown
+      value={filterValue}
+      placeholder="Select value..."
+      options={normalizeEnumValues(colDef.enumValues)}
+      onChange={setFilterValue}
+    />
+  </div>
+) : ...
+```
+
+- [ ] **Step 4: Run the existing filter bar / page tests**
+
+Run: `npx vitest run src/app/admin/unmatched-opportunities --reporter=basic`
+
+Expected: any pre-existing tests still pass. (If none exist, vitest reports "no test files found" and exits 0 — also acceptable.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/admin/unmatched-opportunities/AdminFilterBar.tsx
+git commit -m "feat(admin-filter-bar): support {value,label} enumValues in chips and dropdown"
+```
+
+---
+
+## Task 3: Skip `isFilterOnly` columns in the column picker
+
+**Files:**
+- Modify: `src/app/admin/unmatched-opportunities/AdminColumnPicker.tsx:47-55`
+
+- [ ] **Step 1: Filter out `isFilterOnly` columns when building groups**
+
+Replace the `groups` `useMemo` (lines 47-55):
+
+```ts
+const groups = useMemo(() => {
+  const map = new Map<string, ColumnDef[]>();
+  for (const col of columnDefs) {
+    if (col.isFilterOnly) continue; // virtual filter-only columns never appear in the picker
+    const group = col.group || "Other";
+    if (!map.has(group)) map.set(group, []);
+    map.get(group)!.push(col);
+  }
+  return Array.from(map.entries());
+}, [columnDefs]);
+```
+
+Also update `defaultColumns` (lines 57-60) to skip filterOnly so "Reset to defaults" doesn't try to surface them:
+
+```ts
+const defaultColumns = useMemo(
+  () => columnDefs.filter((c) => c.isDefault && !c.isFilterOnly).map((c) => c.key),
+  [columnDefs]
+);
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/app/admin/unmatched-opportunities/AdminColumnPicker.tsx
+git commit -m "feat(admin-column-picker): hide isFilterOnly virtual columns"
+```
+
+---
+
+## Task 4: Skip `isFilterOnly` columns in DataGrid rendering
+
+Belt-and-suspenders: even if a filter-only column key sneaks into `visibleColumns`, the DataGrid should not try to render it as a table column.
+
+**Files:**
+- Modify: `src/features/shared/components/DataGrid/DataGrid.tsx:134-182` (the `cols` `useMemo` that builds TanStack Table column defs)
+
+- [ ] **Step 1: Locate and modify the visible-column resolution**
+
+Find the block starting at line 134:
+
+```ts
+const cols: TanStackColumnDef<Record<string, unknown>>[] = visibleColumns.map((key) => {
+  const colDef = columnDefs.find((c) => c.key === key);
+  return {
+    id: key,
+    accessorFn: (row: Record<string, unknown>) => row[key],
+    header: () => resolveLabel(key),
+    cell: (info) => {
+      const value = info.getValue();
+      const row = info.row.original;
+      if (cellRenderers?.[key] && colDef) {
+        return cellRenderers[key]({ value, row, columnDef: colDef });
+      }
+      return renderCell(value, key, colDef);
+    },
+  };
+});
+```
+
+Replace it with this `.flatMap` version that drops `isFilterOnly` entries:
+
+```ts
+const cols: TanStackColumnDef<Record<string, unknown>>[] = visibleColumns.flatMap((key) => {
+  const colDef = columnDefs.find((c) => c.key === key);
+  if (colDef?.isFilterOnly) return []; // never render filter-only columns
+  return [{
+    id: key,
+    accessorFn: (row: Record<string, unknown>) => row[key],
+    header: () => resolveLabel(key),
+    cell: (info) => {
+      const value = info.getValue();
+      const row = info.row.original;
+      if (cellRenderers?.[key] && colDef) {
+        return cellRenderers[key]({ value, row, columnDef: colDef });
+      }
+      return renderCell(value, key, colDef);
+    },
+  }];
+});
+```
+
+Note: in practice, `isFilterOnly` columns never reach `visibleColumns` because the page seeds it from `isDefault: true` columns and the picker (Task 3) hides them. This guard is belt-and-suspenders.
+
+- [ ] **Step 2: Verify typecheck on the changed file**
+
+Run: `npx tsc --noEmit 2>&1 | grep "DataGrid\.tsx"`
+
+Expected: no output (no new errors in DataGrid.tsx).
+
+- [ ] **Step 3: Run DataGrid tests**
+
+Run: `npx vitest run src/features/shared/components/DataGrid --reporter=basic`
+
+Expected: all existing tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/features/shared/components/DataGrid/DataGrid.tsx
+git commit -m "feat(datagrid): skip isFilterOnly columns when rendering"
+```
+
+---
+
+## Task 5: Add the virtual "rep" column
+
+**Files:**
+- Modify: `src/app/admin/unmatched-opportunities/columns.ts` (append a new entry)
+
+- [ ] **Step 1: Append the rep column**
+
+Add a new entry inside `unmatchedOpportunityColumns` array after the last existing entry (after the `netBookingAmount` block ending at line 102, before the closing `];`):
+
+```ts
+  // ---- Filters only (virtual — not a row field) ----
+  {
+    key: "rep",
+    label: "Rep",
+    group: "Filters",
+    isDefault: false,
+    isFilterOnly: true,
+    filterType: "enum",
+    enumValues: [], // populated at runtime from useUsers() data
+  },
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/app/admin/unmatched-opportunities/columns.ts
+git commit -m "feat(unmatched-opps): add virtual rep column for filter bar"
+```
+
+---
+
+## Task 6: API — accept `rep` filter (TDD)
+
+**Files:**
+- Create: `src/app/api/admin/unmatched-opportunities/__tests__/route.test.ts`
+- Modify: `src/app/api/admin/unmatched-opportunities/route.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create the test file:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/supabase/server", () => ({
+  getUser: vi.fn().mockResolvedValue({ id: "admin-1" }),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    userProfile: {
+      findUnique: vi.fn(),
+    },
+    opportunity: {
+      findMany: vi.fn(),
+    },
+    unmatchedOpportunity: {
+      findMany: vi.fn(),
+      count: vi.fn(),
+    },
+  },
+}));
+
+import { GET } from "../route";
+import prisma from "@/lib/prisma";
+
+function makeRequest(qs: string) {
+  return new NextRequest(`http://localhost/api/admin/unmatched-opportunities?${qs}`);
+}
+
+describe("GET /api/admin/unmatched-opportunities — rep filter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(prisma.unmatchedOpportunity.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.unmatchedOpportunity.count).mockResolvedValue(0 as never);
+    vi.mocked(prisma.opportunity.findMany).mockResolvedValue([] as never);
+  });
+
+  it("filters by rep: looks up email, fetches opp ids, constrains where.id", async () => {
+    vi.mocked(prisma.userProfile.findUnique).mockResolvedValue({
+      email: "monica@fullmindlearning.com",
+    } as never);
+    vi.mocked(prisma.opportunity.findMany).mockResolvedValue([
+      { id: "175922" },
+      { id: "175923" },
+    ] as never);
+
+    await GET(makeRequest("rep=619f3009-0966-47ec-a09a-5f406d1da596"));
+
+    expect(prisma.userProfile.findUnique).toHaveBeenCalledWith({
+      where: { id: "619f3009-0966-47ec-a09a-5f406d1da596" },
+      select: { email: true },
+    });
+    expect(prisma.opportunity.findMany).toHaveBeenCalledWith({
+      where: { salesRepEmail: "monica@fullmindlearning.com" },
+      select: { id: true },
+    });
+    const findManyCall = vi.mocked(prisma.unmatchedOpportunity.findMany).mock.calls[0][0];
+    expect(findManyCall.where).toMatchObject({ id: { in: ["175922", "175923"] } });
+  });
+
+  it("returns empty page when rep UUID has no matching profile", async () => {
+    vi.mocked(prisma.userProfile.findUnique).mockResolvedValue(null);
+
+    const res = await GET(makeRequest("rep=00000000-0000-0000-0000-000000000000"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.items).toEqual([]);
+    expect(body.pagination.total).toBe(0);
+    expect(prisma.opportunity.findMany).not.toHaveBeenCalled();
+    expect(prisma.unmatchedOpportunity.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns empty page when profile email is null", async () => {
+    vi.mocked(prisma.userProfile.findUnique).mockResolvedValue({ email: null } as never);
+
+    const res = await GET(makeRequest("rep=619f3009-0966-47ec-a09a-5f406d1da596"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.items).toEqual([]);
+    expect(body.pagination.total).toBe(0);
+  });
+
+  it("composes rep filter with resolved=false", async () => {
+    vi.mocked(prisma.userProfile.findUnique).mockResolvedValue({
+      email: "monica@fullmindlearning.com",
+    } as never);
+    vi.mocked(prisma.opportunity.findMany).mockResolvedValue([{ id: "175922" }] as never);
+
+    await GET(makeRequest("rep=619f3009&resolved=false"));
+
+    const findManyCall = vi.mocked(prisma.unmatchedOpportunity.findMany).mock.calls[0][0];
+    expect(findManyCall.where).toMatchObject({
+      resolved: false,
+      id: { in: ["175922"] },
+    });
+  });
+
+  it("ignores rep param when not provided (regression guard)", async () => {
+    await GET(makeRequest("resolved=false"));
+
+    expect(prisma.userProfile.findUnique).not.toHaveBeenCalled();
+    expect(prisma.opportunity.findMany).not.toHaveBeenCalled();
+    const findManyCall = vi.mocked(prisma.unmatchedOpportunity.findMany).mock.calls[0][0];
+    expect(findManyCall.where).not.toHaveProperty("id");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test — verify it fails**
+
+Run: `npx vitest run src/app/api/admin/unmatched-opportunities/__tests__/route.test.ts --reporter=basic`
+
+Expected: 5 tests fail. The first failure should be on `prisma.userProfile.findUnique` not being called (because the route doesn't read `rep` yet).
+
+- [ ] **Step 3: Implement the rep filter in the route**
+
+Modify `src/app/api/admin/unmatched-opportunities/route.ts`. After the line that reads `const stageGroup = searchParams.get("stage_group");` (around line 29), add:
+
+```ts
+    const rep = searchParams.get("rep");
+```
+
+Then, after the existing block that parses other params and before the line `const where: Record<string, unknown> = {};` (around line 36), insert the rep resolution. Actually, do the resolution *after* `where` is built but before the Prisma calls. Insert this block immediately before `const orderByColumn = ...` (currently around line 84):
+
+```ts
+    if (rep) {
+      const profile = await prisma.userProfile.findUnique({
+        where: { id: rep },
+        select: { email: true },
+      });
+      if (!profile?.email) {
+        return NextResponse.json({
+          items: [],
+          pagination: { page, pageSize, total: 0 },
+        });
+      }
+      const oppRows = await prisma.opportunity.findMany({
+        where: { salesRepEmail: profile.email },
+        select: { id: true },
+      });
+      where.id = { in: oppRows.map((o) => o.id) };
+    }
+```
+
+- [ ] **Step 4: Run the tests — verify they pass**
+
+Run: `npx vitest run src/app/api/admin/unmatched-opportunities/__tests__/route.test.ts --reporter=basic`
+
+Expected: all 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/api/admin/unmatched-opportunities/__tests__/route.test.ts src/app/api/admin/unmatched-opportunities/route.ts
+git commit -m "feat(api): filter unmatched opps by rep via UserProfile.email lookup"
+```
+
+---
+
+## Task 7: Page — read URL, seed filters, hydrate rep column, sync URL on clear
+
+**Files:**
+- Modify: `src/app/admin/unmatched-opportunities/page.tsx`
+
+- [ ] **Step 1: Add imports for `useSearchParams`, `useRouter`, and `useUsers`**
+
+Add to the top of the file (alongside existing imports):
+
+```ts
+import { useSearchParams, useRouter } from "next/navigation";
+import { useUsers } from "@/features/shared/lib/queries";
+```
+
+- [ ] **Step 2: Extend `fetchOpportunities` param shape and URLSearchParams build**
+
+In the `fetchOpportunities` function (currently lines 59-89), add `rep?: string` to the params type and forward it. Replace the function with:
+
+```ts
+async function fetchOpportunities(params: {
+  resolved?: string;
+  school_yr?: string;
+  state?: string;
+  stage?: string;
+  reason?: string;
+  search?: string;
+  has_district_id?: string;
+  stage_group?: string;
+  rep?: string;
+  sort_by?: string;
+  sort_dir?: string;
+  page: number;
+  page_size: number;
+}): Promise<{ items: UnmatchedOpportunity[]; pagination: PaginationInfo }> {
+  const qs = new URLSearchParams();
+  if (params.resolved) qs.set("resolved", params.resolved);
+  if (params.school_yr) qs.set("school_yr", params.school_yr);
+  if (params.state) qs.set("state", params.state);
+  if (params.stage) qs.set("stage", params.stage);
+  if (params.reason) qs.set("reason", params.reason);
+  if (params.search) qs.set("search", params.search);
+  if (params.has_district_id) qs.set("has_district_id", params.has_district_id);
+  if (params.stage_group) qs.set("stage_group", params.stage_group);
+  if (params.rep) qs.set("rep", params.rep);
+  if (params.sort_by) qs.set("sort_by", params.sort_by);
+  if (params.sort_dir) qs.set("sort_dir", params.sort_dir);
+  qs.set("page", String(params.page));
+  qs.set("page_size", String(params.page_size));
+  const res = await fetch(`/api/admin/unmatched-opportunities?${qs}`);
+  if (!res.ok) throw new Error("Failed to fetch");
+  return res.json();
+}
+```
+
+- [ ] **Step 3: Inside `UnmatchedOpportunitiesPage`, add hooks and seed filter state**
+
+The component starts around line 1181 with `export default function UnmatchedOpportunitiesPage() { const queryClient = useQueryClient();`. Immediately after that line, add:
+
+```ts
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const initialRepId = searchParams?.get("rep") ?? null;
+
+  const { data: users } = useUsers();
+```
+
+Then replace the `filters` state initializer (currently lines 1217-1219):
+
+```ts
+  const [filters, setFilters] = useState<FilterRule[]>([
+    { column: "resolved", operator: "is_false", value: false },
+  ]);
+```
+
+With:
+
+```ts
+  const [filters, setFilters] = useState<FilterRule[]>(() => {
+    const base: FilterRule[] = [
+      { column: "resolved", operator: "is_false", value: false },
+    ];
+    if (initialRepId) {
+      base.push({ column: "rep", operator: "eq", value: initialRepId });
+    }
+    return base;
+  });
+```
+
+- [ ] **Step 4: Hydrate the rep column with users**
+
+Find the `hydratedColumns` `useMemo` (currently lines 1199-1206):
+
+```ts
+const hydratedColumns = useMemo(() => {
+  if (!facets) return unmatchedOpportunityColumns;
+  return unmatchedOpportunityColumns.map((col) => {
+    if (col.key === "stage") return { ...col, enumValues: facets.stages };
+    if (col.key === "reason") return { ...col, enumValues: facets.reasons };
+    return col;
+  });
+}, [facets]);
+```
+
+Replace with:
+
+```ts
+const hydratedColumns = useMemo(() => {
+  return unmatchedOpportunityColumns.map((col) => {
+    if (col.key === "stage" && facets) return { ...col, enumValues: facets.stages };
+    if (col.key === "reason" && facets) return { ...col, enumValues: facets.reasons };
+    if (col.key === "rep") {
+      const repOptions = (users ?? [])
+        .filter((u) => u.fullName)
+        .map((u) => ({ value: u.id, label: u.fullName as string }));
+      return { ...col, enumValues: repOptions };
+    }
+    return col;
+  });
+}, [facets, users]);
+```
+
+- [ ] **Step 5: Forward `rep` to the API and add it to the query key**
+
+Find the `useQuery` call for unmatched opportunities (currently lines 1269-1285) and the filter-derivation block above it (lines 1250-1267).
+
+After the line `const searchFilter = filters.find((f) => f.column === "name" && f.operator === "contains");` (around line 1258), add:
+
+```ts
+  const repFilter = filters.find((f) => f.column === "rep" && f.operator === "eq");
+  const repFilterId = repFilter ? String(repFilter.value) : undefined;
+```
+
+Then update the `useQuery` to include `rep` in both the queryKey and the `fetchOpportunities` call:
+
+```ts
+const { data, isLoading, isError, refetch } = useQuery({
+  queryKey: ["unmatched-opportunities", filters, sorts, page, activeCard, repFilterId],
+  queryFn: () =>
+    fetchOpportunities({
+      resolved: resolvedParam,
+      school_yr: schoolYrFilter ? String(schoolYrFilter.value) : undefined,
+      state: stateFilterRule ? String(stateFilterRule.value) : undefined,
+      stage: stageFilter ? String(stageFilter.value) : undefined,
+      reason: reasonFilter ? String(reasonFilter.value) : undefined,
+      search: searchFilter ? String(searchFilter.value) : undefined,
+      rep: repFilterId,
+      ...cardParams,
+      sort_by: sortRule?.column,
+      sort_dir: sortRule?.direction,
+      page,
+      page_size: 50,
+    }),
+});
+```
+
+(Note: `repFilterId` is added as a serialized primitive in the queryKey per CLAUDE.md stable-key rule; `filters` and `sorts` were already in there.)
+
+- [ ] **Step 6: On rep chip removal, also strip `?rep=` from the URL**
+
+Find the `onRemoveFilter` prop on `AdminFilterBar` (currently line 1476):
+
+```tsx
+onRemoveFilter={(i) => { setFilters((prev) => prev.filter((_, idx) => idx !== i)); setPage(1); }}
+```
+
+Replace with:
+
+```tsx
+onRemoveFilter={(i) => {
+  setFilters((prev) => {
+    const removed = prev[i];
+    if (removed?.column === "rep") {
+      const url = new URL(window.location.href);
+      url.searchParams.delete("rep");
+      router.replace(url.pathname + (url.search ? url.search : ""));
+    }
+    return prev.filter((_, idx) => idx !== i);
+  });
+  setPage(1);
+}}
+```
+
+- [ ] **Step 7: Verify typecheck on the changed files**
+
+Run: `npx tsc --noEmit 2>&1 | grep -E "page\.tsx|columns\.ts|AdminFilterBar\.tsx|AdminColumnPicker\.tsx|DataGrid\.tsx|route\.ts" | grep "admin/unmatched-opportunities\|DataGrid"`
+
+Expected: no errors from our changed files.
+
+- [ ] **Step 8: Run all tests touching this feature**
+
+Run: `npx vitest run src/app/api/admin/unmatched-opportunities src/app/admin/unmatched-opportunities src/features/shared/components/DataGrid --reporter=basic`
+
+Expected: all tests pass (existing + the 5 new API tests from Task 6).
+
+- [ ] **Step 9: Manual smoke test**
+
+Start the dev server: `npm run dev` (port 3005, per CLAUDE.md).
+
+Verify in a browser:
+
+1. Navigate to `/?tab=leaderboard`. Confirm a rep with an unmatched-opp badge is visible.
+2. Click the badge — URL becomes `/admin/unmatched-opportunities?rep=<uuid>`.
+3. The page loads with **two chips visible**: `Status is false` and `Rep is "<rep name>"`.
+4. The table shows only that rep's unmatched opportunities (count matches the badge).
+5. Click `×` on the Rep chip. URL becomes `/admin/unmatched-opportunities` (no `?rep=`). Table re-fetches and shows all unmatched opportunities.
+6. Click "+ Filter" → choose "Rep" → choose another rep from the dropdown → click "Apply Filter". Confirm a new chip appears with that rep's name and the table refetches scoped to them. (The URL does not auto-update in this direction — only the URL→state direction is wired. That is intentional per spec.)
+7. Refresh the browser while the Rep chip is active (added via filter bar, not URL). The chip disappears (because it wasn't in the URL). Refreshing while on the deep-link URL keeps the chip.
+
+If any of these fails, stop and investigate before committing.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/app/admin/unmatched-opportunities/page.tsx
+git commit -m "feat(unmatched-opps): filter by rep via URL deep-link and filter bar
+
+- Reads ?rep= on mount and seeds the filters chip
+- Hydrates the virtual Rep column from useUsers() so the picker is populated
+- Forwards the rep id to the API as a stable serialized query key
+- router.replace()'s the URL when the rep chip is cleared so refresh stays clean"
+```
+
+---
+
+## Self-Review Checklist (run after the plan is complete)
+
+- [ ] All chips in the design (Rep, Status, etc.) actually render (smoke test step 3-6).
+- [ ] `?rep=` deep-link → table filters down (smoke step 4).
+- [ ] Removing chip strips `?rep=` from URL (smoke step 5).
+- [ ] Filter bar's "+ Filter" → Rep → name dropdown → apply works (smoke step 6).
+- [ ] Refresh respects URL state (smoke step 7).
+- [ ] No regressions in the other 4 admin filters (state, stage, reason, school year — exercise one to confirm).
+- [ ] API test file passes (5 cases).
+
+If any of these fail, return to the relevant task and fix before opening the PR.

--- a/Docs/superpowers/specs/2026-05-04-unmatched-opps-rep-filter-design.md
+++ b/Docs/superpowers/specs/2026-05-04-unmatched-opps-rep-filter-design.md
@@ -1,0 +1,200 @@
+# Unmatched Opportunities — Rep Filter
+
+## Problem
+
+The leaderboard shows a per-rep "X unmatched · $Y" badge linking to
+`/admin/unmatched-opportunities?rep=<UserProfile.id>`. The link does not
+filter the destination page — `?rep=` is silently dropped. Admins clicking
+Monica's badge see all 22 unresolved opportunities instead of the 2 attributed
+to her.
+
+The page also has no other way to scope by rep, so even after the deep-link is
+fixed it is not possible to look up a specific rep's queue without going through
+the leaderboard.
+
+## Goal
+
+Make `/admin/unmatched-opportunities` a first-class rep-scoped queue:
+
+1. The leaderboard's deep-link arrives correctly filtered.
+2. Admins can also filter by rep on the page directly via the existing filter
+   bar, without having to navigate through the leaderboard.
+3. The active rep filter is visible and removable like any other filter chip.
+
+## Non-Goals
+
+- Changing how rep attribution is computed (kept identical to
+  `getUnmatchedCountsByRep` in `src/lib/unmatched-counts.ts`).
+- Adding rep filtering to the public/non-admin views.
+- Persisting the rep filter choice across sessions.
+- Building a generic "saved view" mechanism.
+
+## Background
+
+`unmatched_opportunities` has no rep column. Rep attribution lives in the
+sibling `opportunities` table and is reached by joining on `id`:
+
+```sql
+SELECT o.sales_rep_email
+FROM unmatched_opportunities u
+JOIN opportunities o ON o.id = u.id
+```
+
+This is the same join `getUnmatchedCountsByRep` uses to compute the leaderboard
+badge counts.
+
+The leaderboard URL passes `UserProfile.id` (UUID), not the email, because
+`userId` is the primary identity used elsewhere in the app and emails in URLs
+are uglier and slightly leakier.
+
+## Architecture
+
+Three layers, all in-place edits — no new endpoints, no new components.
+
+### 1. API — `src/app/api/admin/unmatched-opportunities/route.ts`
+
+Add support for a new optional `rep` query param (UUID).
+
+When `rep` is present:
+
+1. `prisma.userProfile.findUnique({ where: { id: rep }, select: { email: true } })`.
+2. If no profile is found, or the profile's `email` is null/empty: return an
+   empty page (`items: []`, `pagination.total: 0`). The chip should remain
+   visible so the user can clear it; do not 4xx.
+3. Otherwise: `SELECT id FROM opportunities WHERE sales_rep_email = $1` →
+   array of opportunity ids.
+4. Add `id: { in: ids }` to the existing Prisma `where` object. The empty-array
+   case is fine — Prisma's `in: []` matches nothing, which is the desired
+   "no rows for this rep" behavior.
+
+This composes with all existing filters (`resolved`, `state`, `stage`, etc.)
+because we are intersecting on `id`, not replacing `where`.
+
+### 2. Page — `src/app/admin/unmatched-opportunities/page.tsx`
+
+- Read `?rep=` via `useSearchParams()` once on mount.
+- If present, seed the `filters` state with `{ column: "rep", operator: "eq", value: <id> }`
+  alongside the existing default `resolved=false` filter.
+- Use existing `useUsers()` hook (`src/features/shared/lib/queries.ts:160`) to
+  populate the rep dropdown — no new data fetch.
+- Forward the rep filter to the API by extending `fetchOpportunities`'s param
+  shape with `rep?: string` and the URLSearchParams build.
+- Add `rep` (serialized) to the TanStack Query key so changing the rep
+  retriggers the fetch. **Stable-keys rule**: pass the rep id as a string,
+  never an object.
+- When the user clicks `×` on the Rep chip, also `router.replace()` to drop
+  `?rep=` from the URL. This keeps refresh state consistent (refreshing after
+  clearing should stay cleared).
+
+### 3. Filter bar — `src/app/admin/unmatched-opportunities/AdminFilterBar.tsx` + `columns.ts`
+
+- Add a virtual "rep" column to `unmatchedOpportunityColumns` with
+  `filterType: "enum"` and a `label: "Rep"`.
+- Hydrate the column's `enumValues` from `useUsers()` data, the same way
+  `stage` and `reason` are hydrated from the facets endpoint
+  (`page.tsx:1199-1206`).
+- Extend `enumValues` typing from `string[]` to `Array<string | { value: string; label: string }>`
+  in `src/features/shared/components/DataGrid/types.ts`. Normalize at the
+  consumption sites (today only `AdminFilterBar.tsx:353`):
+  ```ts
+  const opts = colDef.enumValues.map((v) =>
+    typeof v === "string" ? { value: v, label: v } : v
+  );
+  ```
+- Update `formatFilterLabel` (`AdminFilterBar.tsx:59-69`) so when the column
+  has object-form `enumValues`, the chip looks up the matching label rather
+  than rendering the raw UUID. Result: chip reads `Rep is "Monica Sherwood"`.
+
+The "rep" virtual column is filterable but is not a row field, so it must be
+excluded from the table and from the column picker's toggle list. Add a new
+`isFilterOnly?: boolean` flag to `ColumnDef` and gate two places:
+
+- `AdminColumnPicker` skips columns where `isFilterOnly === true` so users
+  cannot toggle the column on.
+- `DataGrid` (or its column-resolution path) skips them as well so the column
+  cannot accidentally render even if `visibleColumns` somehow contains the key.
+
+The `AdminFilterBar` already iterates all columns with a `filterType`, so the
+rep column appears in the "+ Filter" picker without special-casing.
+
+## Data Flow
+
+```
+Leaderboard badge click
+  └─> /admin/unmatched-opportunities?rep=619f3009-...
+      └─> page.tsx mounts
+          ├─ useSearchParams() reads "rep"
+          ├─ filters seeded with [{rep, eq, "619f..."}, {resolved, is_false, …}]
+          ├─ useUsers() — cached or fetched once for the picker + chip label
+          └─ fetchOpportunities({ rep: "619f...", resolved: "false", … })
+              └─> GET /api/admin/unmatched-opportunities?rep=619f...&resolved=false
+                  ├─ UserProfile.findUnique → email
+                  ├─ SELECT id FROM opportunities WHERE sales_rep_email = email
+                  └─ prisma.unmatchedOpportunity.findMany({
+                       where: { resolved: false, id: { in: ids } }, …
+                     })
+```
+
+User clicks `×` on the chip:
+
+```
+filters state ← filters.filter(f => f.column !== "rep")
+router.replace("/admin/unmatched-opportunities")  // strip ?rep=
+TanStack Query refetches with new key
+```
+
+## Edge Cases
+
+| Case | Handling |
+|------|----------|
+| `?rep=<unknown-uuid>` | API returns 0 rows. Chip stays visible so user can clear. |
+| Rep has 0 unmatched opps | Empty table, "no rows" message, chip remains. |
+| User opens picker before `useUsers()` resolves | Show disabled placeholder per CLAUDE.md "Show loading state, don't hide UI". |
+| User removes Rep chip then reloads | URL was cleared by `router.replace`, so reload stays unfiltered. |
+| User combines Rep + State + Stage filters | All three intersect via Prisma `where`. The rep filter narrows `id`, the others narrow other columns. |
+| `?rep=<valid-uuid>` but profile has no email | Treated same as unknown UUID — 0 rows. |
+| Two browser tabs, one filtered, one not | Each tab owns its own `filters` state and URL. No cross-tab effect. |
+
+## Performance
+
+- Two extra DB queries when `rep` is set (profile lookup + opportunity-id
+  fan-out). Both are indexed: `user_profiles.id` is PK, `opportunities.sales_rep_email`
+  is filterable in existing leaderboard code without complaint.
+- The opportunity-id list is bounded by a single rep's lifetime opportunity
+  count — typically hundreds, not tens of thousands. `id: { in: [...] }` with
+  this size is fine.
+- `useUsers()` is already 10-minute-cached and reused elsewhere; no additional
+  network cost in the common case.
+- TanStack Query key uses the rep id string, satisfying the project's stable-key
+  rule (CLAUDE.md § Performance).
+
+## Testing
+
+### API route (`route.test.ts` co-located)
+
+- `rep=<valid-uuid>` filters to that rep's unmatched opportunities.
+- `rep=<unknown-uuid>` returns `items: []`, `total: 0`, status 200.
+- `rep=<uuid>` combines correctly with `resolved=false` (existing behavior preserved).
+- `rep=<uuid>` combines correctly with `state=NY`.
+- Without `rep`, results are unchanged from current behavior (regression guard).
+
+### Page (`page.test.tsx` if patterns exist; otherwise integration via existing
+fetch mocks)
+
+- Mounting with `?rep=<id>` seeds the filter state and renders the Rep chip.
+- Removing the Rep chip clears `filters` AND updates the URL via `router.replace`.
+- Picking a rep from the filter bar also adds the chip and triggers a refetch.
+
+### Filter bar
+
+- `enumValues` accepting `{value, label}` form renders the label in the chip
+  (regression test for the existing `string[]` form remains green).
+
+## Out of Scope (Explicitly)
+
+- Migrating other admin pages to use the same rep filter pattern (could be a
+  follow-up if it works well here).
+- Adding a `rep` field directly to `unmatched_opportunities` (would denormalize
+  and require a backfill; the join is fast enough).
+- Multi-select rep filter ("show me Monica AND Mike"). Current scope is
+  single rep at a time.

--- a/src/app/admin/unmatched-opportunities/AdminColumnPicker.tsx
+++ b/src/app/admin/unmatched-opportunities/AdminColumnPicker.tsx
@@ -47,6 +47,7 @@ export default function AdminColumnPicker({
   const groups = useMemo(() => {
     const map = new Map<string, ColumnDef[]>();
     for (const col of columnDefs) {
+      if (col.isFilterOnly) continue; // virtual filter-only columns never appear in the picker
       const group = col.group || "Other";
       if (!map.has(group)) map.set(group, []);
       map.get(group)!.push(col);
@@ -55,7 +56,7 @@ export default function AdminColumnPicker({
   }, [columnDefs]);
 
   const defaultColumns = useMemo(
-    () => columnDefs.filter((c) => c.isDefault).map((c) => c.key),
+    () => columnDefs.filter((c) => c.isDefault && !c.isFilterOnly).map((c) => c.key),
     [columnDefs]
   );
 

--- a/src/app/admin/unmatched-opportunities/AdminFilterBar.tsx
+++ b/src/app/admin/unmatched-opportunities/AdminFilterBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { createPortal } from "react-dom";
 import type { ColumnDef } from "@/features/shared/components/DataGrid/types";
 import type { FilterRule } from "@/features/shared/components/DataGrid/types";
@@ -103,13 +103,25 @@ function Dropdown({
   onChange: (value: string) => void;
 }) {
   const [isOpen, setIsOpen] = useState(false);
+  const [search, setSearch] = useState("");
   const triggerRef = useRef<HTMLButtonElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
   const [pos, setPos] = useState({ top: -9999, left: -9999, width: 0 });
 
   const selectedLabel = options.find((o) => o.value === value)?.label;
 
+  // Show typeahead only when there are enough options to make scrolling painful.
+  const showSearch = options.length > 7;
+
+  const filteredOptions = useMemo(() => {
+    if (!search) return options;
+    const q = search.toLowerCase();
+    return options.filter((o) => o.label.toLowerCase().includes(q));
+  }, [options, search]);
+
   const openDropdown = () => {
+    setSearch("");
     if (triggerRef.current) {
       const rect = triggerRef.current.getBoundingClientRect();
       setPos({ top: rect.bottom + 4, left: rect.left, width: rect.width });
@@ -137,6 +149,12 @@ function Dropdown({
       document.removeEventListener("keydown", handleKey);
     };
   }, [isOpen]);
+
+  useEffect(() => {
+    if (isOpen && showSearch) {
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  }, [isOpen, showSearch]);
 
   return (
     <>
@@ -168,24 +186,40 @@ function Dropdown({
           className="fixed z-[9999] bg-white rounded-xl shadow-xl border border-[#D4CFE2] max-h-60 overflow-y-auto py-1"
           style={{ top: pos.top, left: pos.left, width: Math.max(pos.width, 180) }}
         >
-          {options.map((opt) => {
-            const isSelected = value === opt.value;
-            return (
-              <li
-                key={opt.value}
-                role="option"
-                aria-selected={isSelected}
-                onClick={() => { onChange(opt.value); setIsOpen(false); }}
-                className={`px-3 py-1.5 text-sm cursor-pointer transition-colors ${
-                  isSelected
-                    ? "bg-[#F7F5FA] font-medium text-[#403770]"
-                    : "text-[#403770] hover:bg-[#EFEDF5]"
-                }`}
-              >
-                {opt.label}
-              </li>
-            );
-          })}
+          {showSearch && (
+            <li className="sticky top-0 bg-white px-2 pt-1 pb-1.5 border-b border-[#E2DEEC]">
+              <input
+                ref={inputRef}
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search..."
+                className="w-full text-sm text-[#403770] border border-[#C2BBD4] rounded-md px-2 py-1 focus:outline-none focus:ring-2 focus:ring-[#403770]/30 focus:border-[#403770] placeholder:text-[#A69DC0]"
+              />
+            </li>
+          )}
+          {filteredOptions.length === 0 ? (
+            <li className="px-3 py-2 text-xs text-[#A69DC0]">No matches</li>
+          ) : (
+            filteredOptions.map((opt) => {
+              const isSelected = value === opt.value;
+              return (
+                <li
+                  key={opt.value}
+                  role="option"
+                  aria-selected={isSelected}
+                  onClick={() => { onChange(opt.value); setIsOpen(false); }}
+                  className={`px-3 py-1.5 text-sm cursor-pointer transition-colors ${
+                    isSelected
+                      ? "bg-[#F7F5FA] font-medium text-[#403770]"
+                      : "text-[#403770] hover:bg-[#EFEDF5]"
+                  }`}
+                >
+                  {opt.label}
+                </li>
+              );
+            })
+          )}
         </ul>,
         document.body
       )}

--- a/src/app/admin/unmatched-opportunities/AdminFilterBar.tsx
+++ b/src/app/admin/unmatched-opportunities/AdminFilterBar.tsx
@@ -117,7 +117,9 @@ function Dropdown({
   const filteredOptions = useMemo(() => {
     if (!search) return options;
     const q = search.toLowerCase();
-    return options.filter((o) => o.label.toLowerCase().includes(q));
+    return options.filter(
+      (o) => o.label.toLowerCase().includes(q) || o.value.toLowerCase().includes(q)
+    );
   }, [options, search]);
 
   const openDropdown = () => {

--- a/src/app/admin/unmatched-opportunities/AdminFilterBar.tsx
+++ b/src/app/admin/unmatched-opportunities/AdminFilterBar.tsx
@@ -6,6 +6,17 @@ import type { ColumnDef } from "@/features/shared/components/DataGrid/types";
 import type { FilterRule } from "@/features/shared/components/DataGrid/types";
 
 // ---------------------------------------------------------------------------
+// Normalization helper
+// ---------------------------------------------------------------------------
+
+function normalizeEnumValues(
+  values: Array<string | { value: string; label: string }> | undefined
+): { value: string; label: string }[] {
+  if (!values) return [];
+  return values.map((v) => (typeof v === "string" ? { value: v, label: v } : v));
+}
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -65,7 +76,15 @@ function formatFilterLabel(columnDefs: ColumnDef[], filter: FilterRule): string 
   if (opDef && !opDef.needsValue) {
     return `${label} ${opLabel}`;
   }
-  return `${label} ${opLabel} "${filter.value}"`;
+  // For enum columns with object-form values, render the human label, not the raw id.
+  let displayValue: string = String(filter.value);
+  if (col?.filterType === "enum" && col.enumValues) {
+    const match = normalizeEnumValues(col.enumValues).find(
+      (v) => v.value === String(filter.value)
+    );
+    if (match) displayValue = match.label;
+  }
+  return `${label} ${opLabel} "${displayValue}"`;
 }
 
 // ---------------------------------------------------------------------------
@@ -350,7 +369,7 @@ export default function AdminFilterBar({
                     <Dropdown
                       value={filterValue}
                       placeholder="Select value..."
-                      options={colDef.enumValues.map((v) => (typeof v === "string" ? { value: v, label: v } : v))}
+                      options={normalizeEnumValues(colDef.enumValues)}
                       onChange={setFilterValue}
                     />
                   </div>

--- a/src/app/admin/unmatched-opportunities/AdminFilterBar.tsx
+++ b/src/app/admin/unmatched-opportunities/AdminFilterBar.tsx
@@ -350,7 +350,7 @@ export default function AdminFilterBar({
                     <Dropdown
                       value={filterValue}
                       placeholder="Select value..."
-                      options={colDef.enumValues.map((v) => ({ value: v, label: v }))}
+                      options={colDef.enumValues.map((v) => (typeof v === "string" ? { value: v, label: v } : v))}
                       onChange={setFilterValue}
                     />
                   </div>

--- a/src/app/admin/unmatched-opportunities/columns.ts
+++ b/src/app/admin/unmatched-opportunities/columns.ts
@@ -2,7 +2,7 @@
 // Keys match the field names returned by the unmatched opportunities API.
 
 import type { ColumnDef } from "@/features/shared/components/DataGrid/types";
-import { US_STATES } from "@/lib/states";
+import { US_STATES, stateDisplayName } from "@/lib/states";
 
 export const unmatchedOpportunityColumns: ColumnDef[] = [
   // ---- Core ----
@@ -44,7 +44,10 @@ export const unmatchedOpportunityColumns: ColumnDef[] = [
     group: "Core",
     isDefault: true,
     filterType: "enum",
-    enumValues: US_STATES,
+    enumValues: US_STATES.map((abbrev) => ({
+      value: abbrev,
+      label: `${stateDisplayName(abbrev)} (${abbrev})`,
+    })),
     width: 60,
   },
   {

--- a/src/app/admin/unmatched-opportunities/columns.ts
+++ b/src/app/admin/unmatched-opportunities/columns.ts
@@ -100,4 +100,15 @@ export const unmatchedOpportunityColumns: ColumnDef[] = [
     filterType: "number",
     width: 120,
   },
+
+  // ---- Filters only (virtual — not a row field) ----
+  {
+    key: "rep",
+    label: "Rep",
+    group: "Filters",
+    isDefault: false,
+    isFilterOnly: true,
+    filterType: "enum",
+    enumValues: [], // populated at runtime from useUsers() data
+  },
 ];

--- a/src/app/admin/unmatched-opportunities/page.tsx
+++ b/src/app/admin/unmatched-opportunities/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useMemo, useRef, useEffect } from "react";
+import { useState, useCallback, useMemo, useRef, useEffect, Suspense } from "react";
 import { createPortal } from "react-dom";
 import { useSearchParams, useRouter } from "next/navigation";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
@@ -1182,10 +1182,13 @@ function DistrictSearchModal({
 // Main page
 // ---------------------------------------------------------------------------
 
-export default function UnmatchedOpportunitiesPage() {
+function UnmatchedOpportunitiesContent() {
   const queryClient = useQueryClient();
   const searchParams = useSearchParams();
   const router = useRouter();
+  // Mount-only seed: reading ?rep= here is intentional. We do NOT sync
+  // searchParams -> filters via useEffect because that would clobber chips
+  // the user adds via the filter bar after arriving on the page.
   const initialRepId = searchParams?.get("rep") ?? null;
 
   const { data: users } = useUsers();
@@ -1502,7 +1505,7 @@ export default function UnmatchedOpportunitiesPage() {
               if (removed?.column === "rep") {
                 const url = new URL(window.location.href);
                 url.searchParams.delete("rep");
-                router.replace(url.pathname + (url.search ? url.search : ""));
+                router.replace(url.pathname + url.search);
               }
               return prev.filter((_, idx) => idx !== i);
             });
@@ -1602,5 +1605,13 @@ export default function UnmatchedOpportunitiesPage() {
         </div>
       )}
     </div>
+  );
+}
+
+export default function UnmatchedOpportunitiesPage() {
+  return (
+    <Suspense fallback={null}>
+      <UnmatchedOpportunitiesContent />
+    </Suspense>
   );
 }

--- a/src/app/admin/unmatched-opportunities/page.tsx
+++ b/src/app/admin/unmatched-opportunities/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useMemo, useRef, useEffect } from "react";
 import { createPortal } from "react-dom";
+import { useSearchParams, useRouter } from "next/navigation";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { unmatchedOpportunityColumns } from "./columns";
 import { DataGrid } from "@/features/shared/components/DataGrid/DataGrid";
@@ -11,6 +12,7 @@ import AdminColumnPicker from "./AdminColumnPicker";
 import { US_STATES } from "@/lib/states";
 import { ACCOUNT_TYPES } from "@/features/shared/types/account-types";
 import type { AccountTypeValue } from "@/features/shared/types/account-types";
+import { useUsers } from "@/features/shared/lib/queries";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -65,6 +67,7 @@ async function fetchOpportunities(params: {
   search?: string;
   has_district_id?: string;
   stage_group?: string;
+  rep?: string;
   sort_by?: string;
   sort_dir?: string;
   page: number;
@@ -79,6 +82,7 @@ async function fetchOpportunities(params: {
   if (params.search) qs.set("search", params.search);
   if (params.has_district_id) qs.set("has_district_id", params.has_district_id);
   if (params.stage_group) qs.set("stage_group", params.stage_group);
+  if (params.rep) qs.set("rep", params.rep);
   if (params.sort_by) qs.set("sort_by", params.sort_by);
   if (params.sort_dir) qs.set("sort_dir", params.sort_dir);
   qs.set("page", String(params.page));
@@ -1180,6 +1184,11 @@ function DistrictSearchModal({
 
 export default function UnmatchedOpportunitiesPage() {
   const queryClient = useQueryClient();
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const initialRepId = searchParams?.get("rep") ?? null;
+
+  const { data: users } = useUsers();
 
   // Summary stats for KPI cards
   const { data: summary } = useQuery({
@@ -1197,13 +1206,18 @@ export default function UnmatchedOpportunitiesPage() {
 
   // Hydrate column defs with facet values
   const hydratedColumns = useMemo(() => {
-    if (!facets) return unmatchedOpportunityColumns;
     return unmatchedOpportunityColumns.map((col) => {
-      if (col.key === "stage") return { ...col, enumValues: facets.stages };
-      if (col.key === "reason") return { ...col, enumValues: facets.reasons };
+      if (col.key === "stage" && facets) return { ...col, enumValues: facets.stages };
+      if (col.key === "reason" && facets) return { ...col, enumValues: facets.reasons };
+      if (col.key === "rep") {
+        const repOptions = (users ?? [])
+          .filter((u) => u.fullName)
+          .map((u) => ({ value: u.id, label: u.fullName as string }));
+        return { ...col, enumValues: repOptions };
+      }
       return col;
     });
-  }, [facets]);
+  }, [facets, users]);
 
   // DataGrid state
   const [visibleColumns, setVisibleColumns] = useState<string[]>(
@@ -1214,9 +1228,15 @@ export default function UnmatchedOpportunitiesPage() {
   ]);
   const [page, setPage] = useState(1);
   // Start with "unresolved" filter active (same default as current page)
-  const [filters, setFilters] = useState<FilterRule[]>([
-    { column: "resolved", operator: "is_false", value: false },
-  ]);
+  const [filters, setFilters] = useState<FilterRule[]>(() => {
+    const base: FilterRule[] = [
+      { column: "resolved", operator: "is_false", value: false },
+    ];
+    if (initialRepId) {
+      base.push({ column: "rep", operator: "eq", value: initialRepId });
+    }
+    return base;
+  });
 
   const [activeCard, setActiveCard] = useState<CardKey | null>(null);
   const [resolvingOpp, setResolvingOpp] = useState<UnmatchedOpportunity | null>(null);
@@ -1256,6 +1276,8 @@ export default function UnmatchedOpportunitiesPage() {
   const stageFilter = filters.find((f) => f.column === "stage" && f.operator === "eq");
   const reasonFilter = filters.find((f) => f.column === "reason" && f.operator === "eq");
   const searchFilter = filters.find((f) => f.column === "name" && f.operator === "contains");
+  const repFilter = filters.find((f) => f.column === "rep" && f.operator === "eq");
+  const repFilterId = repFilter ? String(repFilter.value) : undefined;
 
   // Derive card-based API params
   const cardParams: { has_district_id?: string; stage_group?: string } = {};
@@ -1267,7 +1289,7 @@ export default function UnmatchedOpportunitiesPage() {
   const sortRule = sorts[0];
 
   const { data, isLoading, isError, refetch } = useQuery({
-    queryKey: ["unmatched-opportunities", filters, sorts, page, activeCard],
+    queryKey: ["unmatched-opportunities", filters, sorts, page, activeCard, repFilterId],
     queryFn: () =>
       fetchOpportunities({
         resolved: resolvedParam,
@@ -1276,6 +1298,7 @@ export default function UnmatchedOpportunitiesPage() {
         stage: stageFilter ? String(stageFilter.value) : undefined,
         reason: reasonFilter ? String(reasonFilter.value) : undefined,
         search: searchFilter ? String(searchFilter.value) : undefined,
+        rep: repFilterId,
         ...cardParams,
         sort_by: sortRule?.column,
         sort_dir: sortRule?.direction,
@@ -1473,7 +1496,18 @@ export default function UnmatchedOpportunitiesPage() {
           columnDefs={hydratedColumns}
           filters={filters}
           onAddFilter={(f) => { setFilters((prev) => [...prev, f]); setPage(1); }}
-          onRemoveFilter={(i) => { setFilters((prev) => prev.filter((_, idx) => idx !== i)); setPage(1); }}
+          onRemoveFilter={(i) => {
+            setFilters((prev) => {
+              const removed = prev[i];
+              if (removed?.column === "rep") {
+                const url = new URL(window.location.href);
+                url.searchParams.delete("rep");
+                router.replace(url.pathname + (url.search ? url.search : ""));
+              }
+              return prev.filter((_, idx) => idx !== i);
+            });
+            setPage(1);
+          }}
           onUpdateFilter={(i, f) => { setFilters((prev) => prev.map((existing, idx) => idx === i ? f : existing)); setPage(1); }}
         />
         <div className="ml-auto">

--- a/src/app/api/admin/unmatched-opportunities/__tests__/route.test.ts
+++ b/src/app/api/admin/unmatched-opportunities/__tests__/route.test.ts
@@ -55,8 +55,8 @@ describe("GET /api/admin/unmatched-opportunities — rep filter", () => {
       select: { id: true },
       take: 5000,
     });
-    const findManyCall = vi.mocked(prisma.unmatchedOpportunity.findMany).mock.calls[0][0];
-    expect(findManyCall.where).toMatchObject({ id: { in: ["175922", "175923"] } });
+    const findManyCall = vi.mocked(prisma.unmatchedOpportunity.findMany).mock.calls[0]![0];
+    expect(findManyCall!.where).toMatchObject({ id: { in: ["175922", "175923"] } });
   });
 
   it("returns empty page when rep UUID has no matching profile", async () => {
@@ -91,8 +91,8 @@ describe("GET /api/admin/unmatched-opportunities — rep filter", () => {
 
     await GET(makeRequest("rep=619f3009&resolved=false"));
 
-    const findManyCall = vi.mocked(prisma.unmatchedOpportunity.findMany).mock.calls[0][0];
-    expect(findManyCall.where).toMatchObject({
+    const findManyCall = vi.mocked(prisma.unmatchedOpportunity.findMany).mock.calls[0]![0];
+    expect(findManyCall!.where).toMatchObject({
       resolved: false,
       id: { in: ["175922"] },
     });
@@ -106,8 +106,8 @@ describe("GET /api/admin/unmatched-opportunities — rep filter", () => {
 
     await GET(makeRequest("rep=619f3009-0966-47ec-a09a-5f406d1da596"));
 
-    const findManyCall = vi.mocked(prisma.unmatchedOpportunity.findMany).mock.calls[0][0];
-    expect(findManyCall.where).toMatchObject({ id: { in: [] } });
+    const findManyCall = vi.mocked(prisma.unmatchedOpportunity.findMany).mock.calls[0]![0];
+    expect(findManyCall!.where).toMatchObject({ id: { in: [] } });
   });
 
   it("ignores rep param when not provided (regression guard)", async () => {
@@ -115,7 +115,7 @@ describe("GET /api/admin/unmatched-opportunities — rep filter", () => {
 
     expect(prisma.userProfile.findUnique).not.toHaveBeenCalled();
     expect(prisma.opportunity.findMany).not.toHaveBeenCalled();
-    const findManyCall = vi.mocked(prisma.unmatchedOpportunity.findMany).mock.calls[0][0];
-    expect(findManyCall.where).not.toHaveProperty("id");
+    const findManyCall = vi.mocked(prisma.unmatchedOpportunity.findMany).mock.calls[0]![0];
+    expect(findManyCall!.where).not.toHaveProperty("id");
   });
 });

--- a/src/app/api/admin/unmatched-opportunities/__tests__/route.test.ts
+++ b/src/app/api/admin/unmatched-opportunities/__tests__/route.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/supabase/server", () => ({
+  getUser: vi.fn().mockResolvedValue({ id: "admin-1" }),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    userProfile: {
+      findUnique: vi.fn(),
+    },
+    opportunity: {
+      findMany: vi.fn(),
+    },
+    unmatchedOpportunity: {
+      findMany: vi.fn(),
+      count: vi.fn(),
+    },
+  },
+}));
+
+import { GET } from "../route";
+import prisma from "@/lib/prisma";
+
+function makeRequest(qs: string) {
+  return new NextRequest(`http://localhost/api/admin/unmatched-opportunities?${qs}`);
+}
+
+describe("GET /api/admin/unmatched-opportunities — rep filter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(prisma.unmatchedOpportunity.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.unmatchedOpportunity.count).mockResolvedValue(0 as never);
+    vi.mocked(prisma.opportunity.findMany).mockResolvedValue([] as never);
+  });
+
+  it("filters by rep: looks up email, fetches opp ids, constrains where.id", async () => {
+    vi.mocked(prisma.userProfile.findUnique).mockResolvedValue({
+      email: "monica@fullmindlearning.com",
+    } as never);
+    vi.mocked(prisma.opportunity.findMany).mockResolvedValue([
+      { id: "175922" },
+      { id: "175923" },
+    ] as never);
+
+    await GET(makeRequest("rep=619f3009-0966-47ec-a09a-5f406d1da596"));
+
+    expect(prisma.userProfile.findUnique).toHaveBeenCalledWith({
+      where: { id: "619f3009-0966-47ec-a09a-5f406d1da596" },
+      select: { email: true },
+    });
+    expect(prisma.opportunity.findMany).toHaveBeenCalledWith({
+      where: { salesRepEmail: "monica@fullmindlearning.com" },
+      select: { id: true },
+    });
+    const findManyCall = vi.mocked(prisma.unmatchedOpportunity.findMany).mock.calls[0][0];
+    expect(findManyCall.where).toMatchObject({ id: { in: ["175922", "175923"] } });
+  });
+
+  it("returns empty page when rep UUID has no matching profile", async () => {
+    vi.mocked(prisma.userProfile.findUnique).mockResolvedValue(null);
+
+    const res = await GET(makeRequest("rep=00000000-0000-0000-0000-000000000000"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.items).toEqual([]);
+    expect(body.pagination.total).toBe(0);
+    expect(prisma.opportunity.findMany).not.toHaveBeenCalled();
+    expect(prisma.unmatchedOpportunity.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns empty page when profile email is null", async () => {
+    vi.mocked(prisma.userProfile.findUnique).mockResolvedValue({ email: null } as never);
+
+    const res = await GET(makeRequest("rep=619f3009-0966-47ec-a09a-5f406d1da596"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.items).toEqual([]);
+    expect(body.pagination.total).toBe(0);
+  });
+
+  it("composes rep filter with resolved=false", async () => {
+    vi.mocked(prisma.userProfile.findUnique).mockResolvedValue({
+      email: "monica@fullmindlearning.com",
+    } as never);
+    vi.mocked(prisma.opportunity.findMany).mockResolvedValue([{ id: "175922" }] as never);
+
+    await GET(makeRequest("rep=619f3009&resolved=false"));
+
+    const findManyCall = vi.mocked(prisma.unmatchedOpportunity.findMany).mock.calls[0][0];
+    expect(findManyCall.where).toMatchObject({
+      resolved: false,
+      id: { in: ["175922"] },
+    });
+  });
+
+  it("ignores rep param when not provided (regression guard)", async () => {
+    await GET(makeRequest("resolved=false"));
+
+    expect(prisma.userProfile.findUnique).not.toHaveBeenCalled();
+    expect(prisma.opportunity.findMany).not.toHaveBeenCalled();
+    const findManyCall = vi.mocked(prisma.unmatchedOpportunity.findMany).mock.calls[0][0];
+    expect(findManyCall.where).not.toHaveProperty("id");
+  });
+});

--- a/src/app/api/admin/unmatched-opportunities/__tests__/route.test.ts
+++ b/src/app/api/admin/unmatched-opportunities/__tests__/route.test.ts
@@ -53,6 +53,7 @@ describe("GET /api/admin/unmatched-opportunities — rep filter", () => {
     expect(prisma.opportunity.findMany).toHaveBeenCalledWith({
       where: { salesRepEmail: "monica@fullmindlearning.com" },
       select: { id: true },
+      take: 5000,
     });
     const findManyCall = vi.mocked(prisma.unmatchedOpportunity.findMany).mock.calls[0][0];
     expect(findManyCall.where).toMatchObject({ id: { in: ["175922", "175923"] } });
@@ -95,6 +96,18 @@ describe("GET /api/admin/unmatched-opportunities — rep filter", () => {
       resolved: false,
       id: { in: ["175922"] },
     });
+  });
+
+  it("returns where.id = { in: [] } when rep has zero opportunities", async () => {
+    vi.mocked(prisma.userProfile.findUnique).mockResolvedValue({
+      email: "newhire@fullmindlearning.com",
+    } as never);
+    // opportunity.findMany defaults to [] via beforeEach
+
+    await GET(makeRequest("rep=619f3009-0966-47ec-a09a-5f406d1da596"));
+
+    const findManyCall = vi.mocked(prisma.unmatchedOpportunity.findMany).mock.calls[0][0];
+    expect(findManyCall.where).toMatchObject({ id: { in: [] } });
   });
 
   it("ignores rep param when not provided (regression guard)", async () => {

--- a/src/app/api/admin/unmatched-opportunities/route.ts
+++ b/src/app/api/admin/unmatched-opportunities/route.ts
@@ -27,6 +27,7 @@ export async function GET(request: NextRequest) {
     const reason = searchParams.get("reason");
     const hasDistrictId = searchParams.get("has_district_id");
     const stageGroup = searchParams.get("stage_group");
+    const rep = searchParams.get("rep");
     const sortBy = searchParams.get("sort_by") || "netBookingAmount";
     const sortDir = searchParams.get("sort_dir") === "asc" ? "asc" : "desc";
     const search = searchParams.get("search") || "";
@@ -79,6 +80,24 @@ export async function GET(request: NextRequest) {
         { name: { contains: search, mode: "insensitive" } },
         { accountName: { contains: search, mode: "insensitive" } },
       ];
+    }
+
+    if (rep) {
+      const profile = await prisma.userProfile.findUnique({
+        where: { id: rep },
+        select: { email: true },
+      });
+      if (!profile?.email) {
+        return NextResponse.json({
+          items: [],
+          pagination: { page, pageSize, total: 0 },
+        });
+      }
+      const oppRows = await prisma.opportunity.findMany({
+        where: { salesRepEmail: profile.email },
+        select: { id: true },
+      });
+      where.id = { in: oppRows.map((o) => o.id) };
     }
 
     const orderByColumn = SORTABLE_COLUMNS.has(sortBy) ? sortBy : "netBookingAmount";

--- a/src/app/api/admin/unmatched-opportunities/route.ts
+++ b/src/app/api/admin/unmatched-opportunities/route.ts
@@ -93,9 +93,13 @@ export async function GET(request: NextRequest) {
           pagination: { page, pageSize, total: 0 },
         });
       }
+      // Bounded by a single rep's lifetime opportunity count (~hundreds typical).
+      // The 5000 cap is a tripwire: if a rep ever exceeds it, the chip will under-count
+      // and we should add an index on opportunities.sales_rep_email + tighten this.
       const oppRows = await prisma.opportunity.findMany({
         where: { salesRepEmail: profile.email },
         select: { id: true },
+        take: 5000,
       });
       where.id = { in: oppRows.map((o) => o.id) };
     }

--- a/src/features/shared/components/DataGrid/DataGrid.tsx
+++ b/src/features/shared/components/DataGrid/DataGrid.tsx
@@ -131,9 +131,10 @@ export function DataGrid({
 
   // ---- Build TanStack columns ----
   const columns = useMemo<TanStackColumnDef<Record<string, unknown>>[]>(() => {
-    const cols: TanStackColumnDef<Record<string, unknown>>[] = visibleColumns.map((key) => {
+    const cols: TanStackColumnDef<Record<string, unknown>>[] = visibleColumns.flatMap((key) => {
       const colDef = columnDefs.find((c) => c.key === key);
-      return {
+      if (colDef?.isFilterOnly) return []; // never render filter-only columns
+      return [{
         id: key,
         accessorFn: (row: Record<string, unknown>) => row[key],
         header: () => resolveLabel(key),
@@ -145,7 +146,7 @@ export function DataGrid({
           }
           return renderCell(value, key, colDef);
         },
-      };
+      }];
     });
 
     // Prepend expand column

--- a/src/features/shared/components/DataGrid/types.ts
+++ b/src/features/shared/components/DataGrid/types.ts
@@ -7,11 +7,12 @@ export interface ColumnDef {
   group: string;
   isDefault: boolean;
   filterType: "text" | "enum" | "number" | "boolean" | "date" | "tags" | "relation";
-  enumValues?: string[];
+  enumValues?: Array<string | { value: string; label: string }>;
   relationSource?: string; // intentionally wide per spec (existing districtColumns uses "tags" | "plans")
   width?: number;    // explicit column width in px (applied as min-width + max-width)
   editable?: boolean;
   sortable?: boolean; // defaults to true; set false to disable sorting
+  isFilterOnly?: boolean; // virtual column — appears in filter picker but never rendered as a row cell
 }
 
 export type SortRule = {

--- a/src/lib/states.ts
+++ b/src/lib/states.ts
@@ -18,7 +18,7 @@ const STATE_NAME_TO_ABBREV: Record<string, string> = {
   WISCONSIN: "WI", WYOMING: "WY",
 };
 
-const STATE_ABBREV_TO_NAME: Record<string, string> = Object.fromEntries(
+export const STATE_ABBREV_TO_NAME: Record<string, string> = Object.fromEntries(
   Object.entries(STATE_NAME_TO_ABBREV).map(([name, abbrev]) => [
     abbrev,
     name.toLowerCase().replace(/\b\w/g, (c) => c.toUpperCase()).replace(/\bOf\b/g, "of"),


### PR DESCRIPTION
## Summary

- Wires the leaderboard's existing \`?rep=<UserProfile.id>\` deep-link so it actually filters \`/admin/unmatched-opportunities\`. Previously the param was silently dropped — clicking Monica's badge showed all 22 opps instead of her 2.
- Adds **Rep** as a first-class option in the admin filter bar, populated from \`useUsers()\` so admins can scope by rep on this page directly without the leaderboard detour.
- Improves dropdown UX: enum dropdowns with >7 options now have a typeahead search, and the **State** dropdown shows full names ("Alabama (AL)") matching the map's GeographyDropdown convention. Search matches on label OR value.

Specs and plan in this PR's diff:
- \`Docs/superpowers/specs/2026-05-04-unmatched-opps-rep-filter-design.md\`
- \`Docs/superpowers/plans/2026-05-04-unmatched-opps-rep-filter.md\`

## Architecture

Three layers, in-place:

1. **API** (\`src/app/api/admin/unmatched-opportunities/route.ts\`): accepts \`rep\` param, looks up \`UserProfile.email\`, sub-selects opportunity ids by \`salesRepEmail\`, constrains \`unmatchedOpportunity.findMany\` with \`id: { in: ids }\`. Returns empty page (200) when the UUID is unknown so the chip stays visible. \`take: 5000\` cap on the fan-out as a tripwire.
2. **Foundation types** (\`src/features/shared/components/DataGrid/types.ts\`): \`enumValues\` widened to \`Array<string | {value, label}>\`; new \`isFilterOnly?: boolean\` flag for virtual columns.
3. **Page + filter bar** (\`page.tsx\`, \`AdminFilterBar.tsx\`, \`AdminColumnPicker.tsx\`, \`columns.ts\`): page reads \`?rep=\` via \`useSearchParams()\` once on mount, seeds the filter chip, hydrates a virtual Rep column from \`useUsers()\`. Chip removal calls \`router.replace()\` to drop \`?rep=\` from the URL. \`useSearchParams\` is wrapped in \`<Suspense>\` per Next.js 16.

## Test plan

- [x] Vitest: 38 tests passing across 4 files (6 new API cases + 32 existing)
- [x] Typecheck clean for all 8 files touched
- [x] Manual smoke test in browser:
  - [x] Click leaderboard badge → URL becomes \`?rep=<uuid>\` → page filters to that rep
  - [x] Two chips visible: \`Status is false\` + \`Rep is "<full name>"\` (not UUID)
  - [x] Click × on Rep chip → URL strips \`?rep=\` → table shows all opps
  - [x] "+ Filter" → Rep → typeahead works → pick another rep → chip + refetch
  - [x] State dropdown: typing "Alaska" or "AK" both find the right entry
- [ ] Reviewer to confirm no regressions in existing State/Stage/Reason filter chips after the \`{value,label}\` change

## Known follow-ups

- \`opportunities.sales_rep_email\` is **not indexed**. The fan-out is a sequential scan (same as the existing leaderboard query). Worth a follow-up migration but out of scope for this PR.
- The 5000 fan-out cap is silent if exceeded. Could add a \`console.warn\` when \`oppRows.length === 5000\` so we notice before users do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)