### PR TITLE
feat(vacancies): coverage-diagnostics taxonomy + admin card row 2

### DIFF
--- a/Docs/superpowers/plans/2026-05-03-vacancy-scanner-coverage-diagnostics.md
+++ b/Docs/superpowers/plans/2026-05-03-vacancy-scanner-coverage-diagnostics.md
@@ -1,0 +1,1894 @@
+# Vacancy Scanner Coverage Diagnostics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a categorized failure-reason column to `VacancyScan`, surface three new diagnostic stats on the admin card (tarpit, adjusted coverage, top failure reason), emit three structured Vercel log events, backfill historical scans — all without changing scan scheduling or fixing the underlying parser issues.
+
+**Architecture:** A single helper (`categorizeFailure`) is the only place that maps free-text errors to enum buckets. Every scan-runner failure site calls it with a known context; the outer catch falls back to regex. The same helper drives a one-time backfill script. The admin card and stats endpoint pick up three new fields without changing any existing field. One small behavior change: Claude-fallback returning `[]` is now `completed_partial` with `failureReason: claude_fallback_failed` (was silent `completed`), so the new bucket reflects reality.
+
+**Tech Stack:** TypeScript, Prisma, PostgreSQL, Next.js (App Router), Vitest, Tailwind, TanStack Query.
+
+**Spec:** `Docs/superpowers/specs/2026-05-03-vacancy-scanner-coverage-diagnostics-design.md`
+
+---
+
+## File Map
+
+| File | Action | Why |
+| --- | --- | --- |
+| `prisma/schema.prisma` | Modify | Add `VacancyFailureReason` enum + nullable `failureReason` column on `VacancyScan` |
+| `prisma/migrations/<ts>_add_vacancy_failure_reason/migration.sql` | Create (via `prisma migrate dev`) | DB migration |
+| `src/features/vacancies/lib/failure-reasons.ts` | Create | `categorizeFailure` helper — single source of truth for bucket mapping |
+| `src/features/vacancies/lib/__tests__/failure-reasons.test.ts` | Create | Exhaustive table-driven tests for the helper |
+| `src/features/vacancies/lib/scan-runner.ts` | Modify | Wire helper into all 5 failure sites, change Claude-empty behavior, return counters from helpers, emit per-scan log + tarpit-admission log |
+| `src/features/vacancies/lib/__tests__/scan-runner.test.ts` | Modify | Extend existing tests to assert `failureReason` written + tarpit log fires correctly |
+| `src/app/api/cron/scan-vacancies/route.ts` | Modify | Add `tarpitSize` query, emit `vacancy_cron_summary` log |
+| `src/app/api/admin/vacancy-scan-stats/route.ts` | Modify | Add three new fields (tarpit, adjustedCoveragePct, topFailureReason7d) |
+| `src/app/api/admin/vacancy-scan-stats/__tests__/route.test.ts` | Create | Tests for the new response fields |
+| `src/features/admin/components/VacancyScanCard.tsx` | Modify | Add row 2 stats; alert dot threshold |
+| `src/features/admin/components/__tests__/VacancyScanCard.test.tsx` | Create | Tests for the new row + alert behavior |
+| `scripts/backfill-vacancy-failure-reasons.ts` | Create | One-time backfill script with dry-run mode |
+
+---
+
+## Task 1: Schema migration — add `VacancyFailureReason` enum + nullable column
+
+**Files:**
+- Modify: `prisma/schema.prisma:862-868` (enum block; insert near other enums) and `prisma/schema.prisma:1475-1496` (`VacancyScan` model)
+- Create (via Prisma CLI): `prisma/migrations/<timestamp>_add_vacancy_failure_reason/migration.sql`
+
+- [ ] **Step 1: Add the enum to `prisma/schema.prisma`**
+
+Insert after the existing `UserRole` enum (around line 868), before the `// ===== User Profile & Goals =====` comment:
+
+```prisma
+enum VacancyFailureReason {
+  http_4xx
+  http_5xx
+  network_timeout
+  scan_timeout
+  parser_empty
+  claude_fallback_failed
+  statewide_unattributable
+  enrollment_ratio_skip
+  no_job_board_url
+  unknown_error
+
+  @@map("vacancy_failure_reason")
+}
+```
+
+- [ ] **Step 2: Add the column to `VacancyScan`**
+
+In `prisma/schema.prisma:1475-1496`, add one line after `errorMessage` (line 1485):
+
+```prisma
+  errorMessage          String?   @map("error_message") @db.Text
+  failureReason         VacancyFailureReason? @map("failure_reason")
+  triggeredBy           String    @map("triggered_by") @db.VarChar(100)
+```
+
+- [ ] **Step 3: Generate the migration**
+
+Run: `npx prisma migrate dev --name add_vacancy_failure_reason`
+Expected: creates `prisma/migrations/<YYYYMMDDHHMMSS>_add_vacancy_failure_reason/migration.sql` with the `CREATE TYPE` and `ALTER TABLE ADD COLUMN` statements, applies it locally, and regenerates the Prisma client.
+
+- [ ] **Step 4: Verify the migration ran cleanly**
+
+Run: `npx prisma migrate status`
+Expected: "Database schema is up to date!"
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add prisma/schema.prisma prisma/migrations
+git commit -m "feat(vacancies): add VacancyFailureReason enum + column"
+```
+
+---
+
+## Task 2: Create `categorizeFailure` helper (TDD)
+
+**Files:**
+- Create: `src/features/vacancies/lib/failure-reasons.ts`
+- Test: `src/features/vacancies/lib/__tests__/failure-reasons.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/features/vacancies/lib/__tests__/failure-reasons.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { categorizeFailure } from "../failure-reasons";
+
+describe("categorizeFailure — explicit context", () => {
+  it.each([
+    ["no_job_board_url", "no_job_board_url"],
+    ["scan_timeout", "scan_timeout"],
+    ["statewide_unattributable", "statewide_unattributable"],
+    ["enrollment_ratio_skip", "enrollment_ratio_skip"],
+    ["claude_fallback_empty", "claude_fallback_failed"],
+  ] as const)("context %s -> %s", (context, expected) => {
+    expect(categorizeFailure({ errorMessage: "anything", context })).toBe(expected);
+  });
+});
+
+describe("categorizeFailure — string match (thrown_error)", () => {
+  const cases: Array<[string, string]> = [
+    ["Scan timed out", "scan_timeout"],
+    ["Scan timed out (stale recovery)", "scan_timeout"],
+    ["AbortError: aborted", "scan_timeout"],
+    ["Anthropic API error: 529 overloaded", "claude_fallback_failed"],
+    ["Claude API rate limit exceeded", "claude_fallback_failed"],
+    ["Skipped: statewide board returned 412 vacancies", "statewide_unattributable"],
+    ["Skipped: 200 vacancies looks like a regional aggregator", "enrollment_ratio_skip"],
+    ["District has no job board URL", "no_job_board_url"],
+    ["Request failed with status 404", "http_4xx"],
+    ["403 Forbidden", "http_4xx"],
+    ["Page Not Found", "http_4xx"],
+    ["410 Gone", "http_4xx"],
+    ["Server returned 500", "http_5xx"],
+    ["502 Bad Gateway", "http_5xx"],
+    ["503 Service Unavailable", "http_5xx"],
+    ["fetch failed", "network_timeout"],
+    ["ECONNREFUSED", "network_timeout"],
+    ["getaddrinfo ENOTFOUND example.com", "network_timeout"],
+    ["Some weird error nobody saw before", "unknown_error"],
+    ["", "unknown_error"],
+  ];
+
+  it.each(cases)("%s -> %s", (errorMessage, expected) => {
+    expect(categorizeFailure({ errorMessage, context: "thrown_error" })).toBe(expected);
+  });
+
+  it("defaults to thrown_error when context is omitted", () => {
+    expect(categorizeFailure({ errorMessage: "Scan timed out" })).toBe("scan_timeout");
+  });
+});
+
+describe("categorizeFailure — first-match-wins ordering", () => {
+  it("scan_timeout beats http_4xx when both could match", () => {
+    expect(
+      categorizeFailure({ errorMessage: "Scan timed out: 404", context: "thrown_error" }),
+    ).toBe("scan_timeout");
+  });
+
+  it("claude_fallback_failed beats http_5xx when both could match", () => {
+    expect(
+      categorizeFailure({
+        errorMessage: "Anthropic API error: 503 service unavailable",
+        context: "thrown_error",
+      }),
+    ).toBe("claude_fallback_failed");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/features/vacancies/lib/__tests__/failure-reasons.test.ts`
+Expected: FAIL with "Cannot find module '../failure-reasons'".
+
+- [ ] **Step 3: Write the helper**
+
+Create `src/features/vacancies/lib/failure-reasons.ts`:
+
+```ts
+import type { VacancyFailureReason } from "@prisma/client";
+
+export type FailureContext =
+  | "no_job_board_url"
+  | "scan_timeout"
+  | "statewide_unattributable"
+  | "enrollment_ratio_skip"
+  | "claude_fallback_empty"
+  | "thrown_error";
+
+const CONTEXT_MAP: Partial<Record<FailureContext, VacancyFailureReason>> = {
+  no_job_board_url: "no_job_board_url",
+  scan_timeout: "scan_timeout",
+  statewide_unattributable: "statewide_unattributable",
+  enrollment_ratio_skip: "enrollment_ratio_skip",
+  claude_fallback_empty: "claude_fallback_failed",
+};
+
+// Order matters: first match wins. More-specific patterns precede more-generic ones.
+const PATTERNS: Array<{ regex: RegExp; reason: VacancyFailureReason }> = [
+  { regex: /timed out|aborted|abort/i, reason: "scan_timeout" },
+  { regex: /anthropic|claude api/i, reason: "claude_fallback_failed" },
+  { regex: /statewide board returned/i, reason: "statewide_unattributable" },
+  { regex: /regional aggregator/i, reason: "enrollment_ratio_skip" },
+  { regex: /no job board url/i, reason: "no_job_board_url" },
+  { regex: /4\d\d|not found|forbidden|gone/i, reason: "http_4xx" },
+  { regex: /5\d\d|server error|bad gateway|service unavailable/i, reason: "http_5xx" },
+  { regex: /econnrefused|enotfound|network|fetch failed|getaddrinfo/i, reason: "network_timeout" },
+];
+
+export function categorizeFailure(args: {
+  errorMessage: string;
+  context?: FailureContext;
+}): VacancyFailureReason {
+  const ctx = args.context ?? "thrown_error";
+  const direct = CONTEXT_MAP[ctx];
+  if (direct) return direct;
+
+  // Fall through to regex matching for thrown_error context
+  for (const { regex, reason } of PATTERNS) {
+    if (regex.test(args.errorMessage)) return reason;
+  }
+  return "unknown_error";
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/features/vacancies/lib/__tests__/failure-reasons.test.ts`
+Expected: PASS — all describe blocks green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/vacancies/lib/failure-reasons.ts src/features/vacancies/lib/__tests__/failure-reasons.test.ts
+git commit -m "feat(vacancies): categorizeFailure helper for failure-reason taxonomy"
+```
+
+---
+
+## Task 3: Wire helper into `scan-runner` thrown-error catch path
+
+**Files:**
+- Modify: `src/features/vacancies/lib/scan-runner.ts:286-309` (outer catch block)
+- Modify: `src/features/vacancies/lib/__tests__/scan-runner.test.ts` (extend the "on failed" test)
+
+- [ ] **Step 1: Extend the failing test in `scan-runner.test.ts`**
+
+Add this case inside `describe("runScan health-column updates", ...)` in `scan-runner.test.ts`:
+
+```ts
+it("on failed: writes failureReason via categorizeFailure", async () => {
+  getParserMock.mockImplementation(() => async () => {
+    throw new Error("Request failed with status 404");
+  });
+
+  await runScan("scan_abc");
+
+  const failedCall = vacancyScanUpdate.mock.calls.find(
+    (c) => (c[0] as any)?.data?.status === "failed",
+  );
+  expect((failedCall?.[0] as any)?.data?.failureReason).toBe("http_4xx");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/features/vacancies/lib/__tests__/scan-runner.test.ts`
+Expected: FAIL — `data.failureReason` is `undefined`.
+
+- [ ] **Step 3: Wire `categorizeFailure` into the catch block**
+
+In `src/features/vacancies/lib/scan-runner.ts`, add the import near the top (after the other imports from `./parsers`):
+
+```ts
+import { categorizeFailure } from "./failure-reasons";
+```
+
+Then replace the `prisma.vacancyScan.update` call inside the outer catch (currently lines 293-300) with one that also writes `failureReason`:
+
+```ts
+} catch (error) {
+  const errorMessage =
+    error instanceof Error ? error.message : "Unknown error";
+
+  console.error(`[scan-runner] Scan ${scanId} failed:`, errorMessage);
+
+  try {
+    const failureReason = categorizeFailure({
+      errorMessage,
+      context: "thrown_error",
+    });
+    await prisma.vacancyScan.update({
+      where: { id: scanId },
+      data: {
+        status: "failed",
+        errorMessage,
+        failureReason,
+        completedAt: new Date(),
+      },
+    });
+    if (scan?.district?.leaid) {
+      await markDistrictScanFailure(scan.district.leaid);
+    }
+  } catch (updateError) {
+    console.error(
+      `[scan-runner] Failed to update scan ${scanId} status:`,
+      updateError,
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/features/vacancies/lib/__tests__/scan-runner.test.ts`
+Expected: PASS — including the existing tests, which still match because they use `toMatchObject`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/vacancies/lib/scan-runner.ts src/features/vacancies/lib/__tests__/scan-runner.test.ts
+git commit -m "feat(vacancies): write failureReason on thrown-error scan failures"
+```
+
+---
+
+## Task 4: Wire helper into `no_job_board_url` and `scan_timeout` sites
+
+**Files:**
+- Modify: `src/features/vacancies/lib/scan-runner.ts:82-91` (no jobBoardUrl branch) and `:152-153` (timeout-controller flow)
+- Modify: `src/features/vacancies/lib/__tests__/scan-runner.test.ts` (extend existing no-URL test)
+
+- [ ] **Step 1: Extend the no-URL test**
+
+In `scan-runner.test.ts`, find the existing test `"on no-jobBoardUrl early-return: counts as a failure"` and add an assertion at the end:
+
+```ts
+const failedScanCall = vacancyScanUpdate.mock.calls.find(
+  (c) => (c[0] as any)?.data?.status === "failed",
+);
+expect((failedScanCall?.[0] as any)?.data?.failureReason).toBe("no_job_board_url");
+```
+
+Then add a new test for the scan-timeout path:
+
+```ts
+it("on scan_timeout: writes failureReason='scan_timeout'", async () => {
+  // Make the parser hang past the timeout. The runner aborts via the controller
+  // and throws "Scan timed out" — caught by the outer catch.
+  getParserMock.mockImplementation(() => async () => {
+    throw new Error("Scan timed out");
+  });
+
+  await runScan("scan_abc");
+
+  const failedCall = vacancyScanUpdate.mock.calls.find(
+    (c) => (c[0] as any)?.data?.status === "failed",
+  );
+  expect((failedCall?.[0] as any)?.data?.failureReason).toBe("scan_timeout");
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail (or partially pass)**
+
+Run: `npx vitest run src/features/vacancies/lib/__tests__/scan-runner.test.ts`
+Expected: the no-URL test FAILS (no `failureReason` written yet). The scan-timeout test already passes because Task 3's catch block handles it via regex matching.
+
+- [ ] **Step 3: Wire `categorizeFailure` into the no-URL branch**
+
+In `src/features/vacancies/lib/scan-runner.ts:82-91`, replace the early-return block with:
+
+```ts
+if (!scan.district.jobBoardUrl) {
+  await prisma.vacancyScan.update({
+    where: { id: scanId },
+    data: {
+      status: "failed",
+      errorMessage: "District has no job board URL",
+      failureReason: categorizeFailure({
+        errorMessage: "",
+        context: "no_job_board_url",
+      }),
+      completedAt: new Date(),
+    },
+  });
+  await markDistrictScanFailure(scan.district.leaid);
+  return;
+}
+```
+
+The scan-timeout site does not need a code change — it throws `"Scan timed out"` (line 153), which the outer catch routes through `categorizeFailure` with regex matching from Task 3.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/features/vacancies/lib/__tests__/scan-runner.test.ts`
+Expected: PASS — both new assertions green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/vacancies/lib/scan-runner.ts src/features/vacancies/lib/__tests__/scan-runner.test.ts
+git commit -m "feat(vacancies): write failureReason on no-URL and scan-timeout failures"
+```
+
+---
+
+## Task 5: Wire helper into `statewide_unattributable` and `enrollment_ratio_skip` sites
+
+**Files:**
+- Modify: `src/features/vacancies/lib/scan-runner.ts:168-178` (statewide unattributable) and `:247-258` (enrollment ratio safety net)
+- Modify: `src/features/vacancies/lib/__tests__/scan-runner.test.ts`
+
+- [ ] **Step 1: Add tests**
+
+In `scan-runner.test.ts`, after the existing tests, add a new describe block:
+
+```ts
+describe("runScan completed_partial paths write failureReason", () => {
+  it("statewide_unattributable: >50% missing employerName", async () => {
+    const { isStatewideBoardAsync } = await import(
+      "@/features/vacancies/lib/platform-detector"
+    );
+    // Override the mocked isStatewideBoardAsync for this test only
+    vi.mocked(isStatewideBoardAsync).mockResolvedValueOnce(true);
+
+    // Parser returns 25 jobs, 20 without employerName -> 80% missing -> trigger
+    const rawJobs = Array.from({ length: 25 }, (_, i) => ({
+      title: `Job ${i}`,
+      url: `https://example.com/${i}`,
+      ...(i < 5 ? { employerName: "Test District" } : {}),
+    }));
+    getParserMock.mockImplementation(() => async () => rawJobs);
+
+    await runScan("scan_abc");
+
+    const partialCall = vacancyScanUpdate.mock.calls.find(
+      (c) => (c[0] as any)?.data?.status === "completed_partial",
+    );
+    expect((partialCall?.[0] as any)?.data?.failureReason).toBe(
+      "statewide_unattributable",
+    );
+  });
+
+  it("enrollment_ratio_skip: too many vacancies for enrollment", async () => {
+    // 200 vacancies on a district with enrollment 1000 -> ratio 0.2 -> trigger
+    getParserMock.mockImplementation(() => async () =>
+      Array.from({ length: 200 }, (_, i) => ({
+        title: `Job ${i}`,
+        url: `https://example.com/${i}`,
+        employerName: "Test District",
+      })),
+    );
+
+    await runScan("scan_abc");
+
+    const partialCall = vacancyScanUpdate.mock.calls.find(
+      (c) => (c[0] as any)?.data?.status === "completed_partial",
+    );
+    expect((partialCall?.[0] as any)?.data?.failureReason).toBe(
+      "enrollment_ratio_skip",
+    );
+  });
+});
+```
+
+You will also need to update the `vi.mock` for `platform-detector` at the top of the file so `isStatewideBoardAsync` is a `vi.fn` instead of an inline arrow:
+
+```ts
+const isStatewideBoardAsyncMock = vi.fn(async () => false);
+
+vi.mock("@/features/vacancies/lib/platform-detector", () => ({
+  detectPlatform: () => "applitrack",
+  isStatewideBoardAsync: (...args: unknown[]) => isStatewideBoardAsyncMock(...args),
+  getAppliTrackInstance: () => null,
+}));
+```
+
+And reset the mock in `beforeEach`:
+
+```ts
+isStatewideBoardAsyncMock.mockReset().mockResolvedValue(false);
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/features/vacancies/lib/__tests__/scan-runner.test.ts`
+Expected: FAIL — both new tests, no `failureReason` field on the `completed_partial` updates.
+
+- [ ] **Step 3: Wire `categorizeFailure` into both sites**
+
+In `src/features/vacancies/lib/scan-runner.ts`, find the statewide-unattributable update (lines 168-176) and add `failureReason`:
+
+```ts
+await prisma.vacancyScan.update({
+  where: { id: scanId },
+  data: {
+    status: "completed_partial",
+    vacancyCount: 0,
+    errorMessage: `Skipped: statewide board returned ${rawVacancies.length} vacancies but ${withoutEmployer} lack employer info (cannot attribute to district)`,
+    failureReason: categorizeFailure({
+      errorMessage: "",
+      context: "statewide_unattributable",
+    }),
+    completedAt: new Date(),
+  },
+});
+```
+
+Then find the enrollment-ratio update (lines 247-256) and do the same:
+
+```ts
+await prisma.vacancyScan.update({
+  where: { id: scanId },
+  data: {
+    status: "completed_partial",
+    vacancyCount: 0,
+    errorMessage: `Skipped: ${rawVacancies.length} vacancies looks like a regional aggregator (enrollment: ${enrollment}, ratio: ${ratio.toFixed(2)})`,
+    failureReason: categorizeFailure({
+      errorMessage: "",
+      context: "enrollment_ratio_skip",
+    }),
+    completedAt: new Date(),
+  },
+});
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/features/vacancies/lib/__tests__/scan-runner.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/vacancies/lib/scan-runner.ts src/features/vacancies/lib/__tests__/scan-runner.test.ts
+git commit -m "feat(vacancies): write failureReason on completed_partial scans"
+```
+
+---
+
+## Task 6: B1 policy — Claude-fallback-empty becomes `completed_partial` with `claude_fallback_failed`
+
+**Files:**
+- Modify: `src/features/vacancies/lib/scan-runner.ts:118-149` (parser dispatch) — track which path ran, then handle empty result from Claude differently
+- Modify: `src/features/vacancies/lib/__tests__/scan-runner.test.ts`
+
+- [ ] **Step 1: Add the failing test**
+
+In `scan-runner.test.ts`, add a new test inside the `runScan completed_partial paths write failureReason` describe:
+
+```ts
+it("claude_fallback_failed: serverless Claude returns []", async () => {
+  // Force the dispatch into the Claude-fallback branch:
+  // 1) no parser for the platform, 2) running serverless, 3) Claude returns []
+  getParserMock.mockReturnValue(null);
+  process.env.VERCEL = "1";
+  process.env.ANTHROPIC_API_KEY = "test-key";
+  parseWithClaudeMock.mockResolvedValue([]);
+
+  try {
+    await runScan("scan_abc");
+
+    const partialCall = vacancyScanUpdate.mock.calls.find(
+      (c) => (c[0] as any)?.data?.status === "completed_partial",
+    );
+    expect((partialCall?.[0] as any)?.data?.failureReason).toBe(
+      "claude_fallback_failed",
+    );
+
+    // District counter must increment (B1 policy) — markDistrictScanFailure path
+    const districtFailureCall = districtUpdate.mock.calls.find(
+      (c) =>
+        (c[0] as any)?.where?.leaid === "0100001" &&
+        (c[0] as any)?.data?.vacancyConsecutiveFailures?.increment === 1,
+    );
+    expect(districtFailureCall).toBeDefined();
+  } finally {
+    delete process.env.VERCEL;
+    delete process.env.ANTHROPIC_API_KEY;
+  }
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/features/vacancies/lib/__tests__/scan-runner.test.ts`
+Expected: FAIL — Claude-empty currently writes `status: "completed"` with no `failureReason`.
+
+- [ ] **Step 3: Track the parser path and handle Claude-empty as failure**
+
+In `src/features/vacancies/lib/scan-runner.ts:118-149`, replace the parser-dispatch block with one that records which path ran:
+
+```ts
+// Step 4: Get parser and run it
+const parser = getParser(platform);
+let rawVacancies: RawVacancy[];
+let usedClaudeFallback = false;
+const isServerless = !!process.env.VERCEL;
+const needsPlaywright = !parser;
+
+if (parser && !(isServerless && needsPlaywright)) {
+  rawVacancies = await parser(scan.district.jobBoardUrl);
+} else if (isServerless) {
+  if (process.env.ANTHROPIC_API_KEY) {
+    console.log(`[scan-runner] Serverless env, using Claude fallback for "${platform}"...`);
+    rawVacancies = await parseWithClaude(scan.district.jobBoardUrl);
+    usedClaudeFallback = true;
+  } else {
+    console.log(`[scan-runner] Serverless env, no ANTHROPIC_API_KEY — cannot parse "${platform}"`);
+    rawVacancies = [];
+    usedClaudeFallback = true;
+  }
+} else {
+  console.log(`[scan-runner] No parser for platform "${platform}", trying Playwright...`);
+  rawVacancies = await parseWithPlaywright(scan.district.jobBoardUrl);
+
+  if (rawVacancies.length === 0 && process.env.ANTHROPIC_API_KEY) {
+    console.log(`[scan-runner] Playwright found nothing, trying Claude fallback...`);
+    rawVacancies = await parseWithClaude(scan.district.jobBoardUrl);
+    usedClaudeFallback = true;
+  }
+}
+
+// Check if aborted
+if (timeoutController.signal.aborted) {
+  throw new Error("Scan timed out");
+}
+
+// B1: Claude-fallback returning [] is the dominant silent-failure mode.
+// Mark as completed_partial + claude_fallback_failed AND increment the
+// district failure counter so these districts become eligible for the
+// future failure-reset job.
+if (usedClaudeFallback && rawVacancies.length === 0) {
+  await prisma.vacancyScan.update({
+    where: { id: scanId },
+    data: {
+      status: "completed_partial",
+      vacancyCount: 0,
+      errorMessage: "Claude fallback returned no vacancies",
+      failureReason: categorizeFailure({
+        errorMessage: "",
+        context: "claude_fallback_empty",
+      }),
+      completedAt: new Date(),
+    },
+  });
+  await markDistrictScanFailure(scan.district.leaid);
+  return;
+}
+```
+
+The B1 block is inserted *after* the timeout check and *before* the existing "Step 5: Post-process" block. Existing post-processing logic is untouched.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/features/vacancies/lib/__tests__/scan-runner.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/vacancies/lib/scan-runner.ts src/features/vacancies/lib/__tests__/scan-runner.test.ts
+git commit -m "feat(vacancies): treat Claude-fallback-empty as claude_fallback_failed"
+```
+
+---
+
+## Task 7: `markDistrictScan{Failure,Success}` return counter + tarpit-admission log
+
+**Files:**
+- Modify: `src/features/vacancies/lib/scan-runner.ts:13-28` (both helpers)
+- Modify: `src/features/vacancies/lib/__tests__/scan-runner.test.ts`
+
+- [ ] **Step 1: Add the failing test**
+
+In `scan-runner.test.ts`, add a new describe block:
+
+```ts
+describe("runScan tarpit-admission log", () => {
+  it("logs vacancy_tarpit_admission when consecutive_failures hits 5", async () => {
+    const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    // Simulate the fifth failure: districtUpdate returns counter = 5
+    districtUpdate.mockResolvedValue({
+      leaid: "0100001",
+      name: "Test District",
+      jobBoardPlatform: "applitrack",
+      jobBoardUrl: "https://example.applitrack.com/onlineapp",
+      vacancyConsecutiveFailures: 5,
+    });
+
+    getParserMock.mockImplementation(() => async () => {
+      throw new Error("Request failed with status 404");
+    });
+
+    await runScan("scan_abc");
+
+    const tarpitLog = consoleLogSpy.mock.calls.find((args) => {
+      const first = args[0];
+      if (typeof first !== "string") return false;
+      try {
+        const parsed = JSON.parse(first);
+        return parsed.event === "vacancy_tarpit_admission";
+      } catch {
+        return false;
+      }
+    });
+    expect(tarpitLog).toBeDefined();
+    const parsed = JSON.parse(tarpitLog![0] as string);
+    expect(parsed).toMatchObject({
+      event: "vacancy_tarpit_admission",
+      leaid: "0100001",
+      name: "Test District",
+      platform: "applitrack",
+      last_failure_reason: "http_4xx",
+    });
+
+    consoleLogSpy.mockRestore();
+  });
+
+  it("does NOT log vacancy_tarpit_admission when counter is 4 or 6", async () => {
+    const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    districtUpdate.mockResolvedValue({
+      leaid: "0100001",
+      name: "Test District",
+      jobBoardPlatform: "applitrack",
+      jobBoardUrl: "https://example.applitrack.com/onlineapp",
+      vacancyConsecutiveFailures: 4,
+    });
+
+    getParserMock.mockImplementation(() => async () => {
+      throw new Error("boom");
+    });
+
+    await runScan("scan_abc");
+
+    const tarpitLog = consoleLogSpy.mock.calls.find((args) => {
+      const first = args[0];
+      return typeof first === "string" && first.includes("vacancy_tarpit_admission");
+    });
+    expect(tarpitLog).toBeUndefined();
+
+    consoleLogSpy.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/features/vacancies/lib/__tests__/scan-runner.test.ts`
+Expected: FAIL — no tarpit log emitted yet.
+
+- [ ] **Step 3: Update both helpers to return the counter and emit the admission log**
+
+In `src/features/vacancies/lib/scan-runner.ts:13-28`, replace both helpers:
+
+```ts
+async function markDistrictScanSuccess(leaid: string): Promise<number> {
+  await prisma.district.update({
+    where: { leaid },
+    data: { vacancyConsecutiveFailures: 0, vacancyLastFailureAt: null },
+  });
+  return 0;
+}
+
+async function markDistrictScanFailure(
+  leaid: string,
+  failureReason: VacancyFailureReason | null = null,
+): Promise<number> {
+  const updated = await prisma.district.update({
+    where: { leaid },
+    data: {
+      vacancyConsecutiveFailures: { increment: 1 },
+      vacancyLastFailureAt: new Date(),
+    },
+    select: {
+      leaid: true,
+      name: true,
+      jobBoardPlatform: true,
+      jobBoardUrl: true,
+      vacancyConsecutiveFailures: true,
+    },
+  });
+
+  if (updated.vacancyConsecutiveFailures === 5) {
+    console.log(
+      JSON.stringify({
+        event: "vacancy_tarpit_admission",
+        leaid: updated.leaid,
+        name: updated.name,
+        platform: updated.jobBoardPlatform,
+        job_board_url: updated.jobBoardUrl,
+        last_failure_reason: failureReason,
+      }),
+    );
+  }
+
+  return updated.vacancyConsecutiveFailures;
+}
+```
+
+Add the import for `VacancyFailureReason` at the top (next to the existing Prisma import):
+
+```ts
+import { Prisma, type VacancyFailureReason } from "@prisma/client";
+```
+
+Now thread the `failureReason` through every existing `markDistrictScanFailure` call site so the log carries the right reason. There are three call sites — show explicit code for each:
+
+**Site 1 — No-URL branch (originally edited in Task 4).** Capture the reason into a local before the `prisma.update`, then pass it into the helper:
+
+```ts
+if (!scan.district.jobBoardUrl) {
+  const failureReason = categorizeFailure({
+    errorMessage: "",
+    context: "no_job_board_url",
+  });
+  await prisma.vacancyScan.update({
+    where: { id: scanId },
+    data: {
+      status: "failed",
+      errorMessage: "District has no job board URL",
+      failureReason,
+      completedAt: new Date(),
+    },
+  });
+  await markDistrictScanFailure(scan.district.leaid, failureReason);
+  return;
+}
+```
+
+**Site 2 — B1 Claude-empty (originally added in Task 6).** Same pattern:
+
+```ts
+if (usedClaudeFallback && rawVacancies.length === 0) {
+  const failureReason = categorizeFailure({
+    errorMessage: "",
+    context: "claude_fallback_empty",
+  });
+  await prisma.vacancyScan.update({
+    where: { id: scanId },
+    data: {
+      status: "completed_partial",
+      vacancyCount: 0,
+      errorMessage: "Claude fallback returned no vacancies",
+      failureReason,
+      completedAt: new Date(),
+    },
+  });
+  await markDistrictScanFailure(scan.district.leaid, failureReason);
+  return;
+}
+```
+
+**Site 3 — Outer catch (originally edited in Task 3).** Same pattern:
+
+```ts
+} catch (error) {
+  const errorMessage =
+    error instanceof Error ? error.message : "Unknown error";
+
+  console.error(`[scan-runner] Scan ${scanId} failed:`, errorMessage);
+
+  try {
+    const failureReason = categorizeFailure({
+      errorMessage,
+      context: "thrown_error",
+    });
+    await prisma.vacancyScan.update({
+      where: { id: scanId },
+      data: {
+        status: "failed",
+        errorMessage,
+        failureReason,
+        completedAt: new Date(),
+      },
+    });
+    if (scan?.district?.leaid) {
+      await markDistrictScanFailure(scan.district.leaid, failureReason);
+    }
+  } catch (updateError) {
+    console.error(
+      `[scan-runner] Failed to update scan ${scanId} status:`,
+      updateError,
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/features/vacancies/lib/__tests__/scan-runner.test.ts`
+Expected: PASS — both new tarpit tests green; all existing tests still green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/vacancies/lib/scan-runner.ts src/features/vacancies/lib/__tests__/scan-runner.test.ts
+git commit -m "feat(vacancies): emit vacancy_tarpit_admission log on 4->5 transition"
+```
+
+---
+
+## Task 8: Per-scan `vacancy_scan_outcome` log
+
+**Files:**
+- Modify: `src/features/vacancies/lib/scan-runner.ts` — hoist tracking variables, emit log in `finally`
+- Modify: `src/features/vacancies/lib/__tests__/scan-runner.test.ts`
+
+- [ ] **Step 1: Add the failing test**
+
+In `scan-runner.test.ts`, add a new describe block:
+
+```ts
+describe("runScan per-scan outcome log", () => {
+  it("emits vacancy_scan_outcome with all required fields", async () => {
+    const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    // Successful scan path
+    getParserMock.mockImplementation(() => async () => []);
+    districtUpdate.mockResolvedValue({
+      leaid: "0100001",
+      name: "Test District",
+      jobBoardPlatform: "applitrack",
+      jobBoardUrl: "https://example.applitrack.com/onlineapp",
+      vacancyConsecutiveFailures: 0,
+    });
+
+    await runScan("scan_abc");
+
+    const outcomeLog = consoleLogSpy.mock.calls
+      .map((args) => {
+        try {
+          return JSON.parse(args[0] as string);
+        } catch {
+          return null;
+        }
+      })
+      .find((p) => p?.event === "vacancy_scan_outcome");
+    expect(outcomeLog).toBeDefined();
+    expect(outcomeLog).toMatchObject({
+      event: "vacancy_scan_outcome",
+      leaid: "0100001",
+      platform: "applitrack",
+      status: "completed",
+      failure_reason: null,
+      vacancy_count: 0,
+      consecutive_failures_after: 0,
+    });
+    expect(typeof outcomeLog.duration_ms).toBe("number");
+    expect(typeof outcomeLog.was_first_attempt).toBe("boolean");
+
+    consoleLogSpy.mockRestore();
+  });
+});
+```
+
+You will also need to extend the `prisma` mock to include `vacancyScan.count`. Update the `vi.mock("@/lib/prisma", ...)` block at the top of `scan-runner.test.ts`:
+
+```ts
+const vacancyScanCount = vi.fn();
+// ...inside vi.mock("@/lib/prisma", () => ({...}))
+vacancyScan: {
+  findUnique: (...args: unknown[]) => vacancyScanFindUnique(...args),
+  update: (...args: unknown[]) => vacancyScanUpdate(...args),
+  count: (...args: unknown[]) => vacancyScanCount(...args),
+},
+```
+
+And reset it in `beforeEach`:
+
+```ts
+vacancyScanCount.mockReset().mockResolvedValue(0);  // default: first attempt
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/features/vacancies/lib/__tests__/scan-runner.test.ts`
+Expected: FAIL — no `vacancy_scan_outcome` log emitted.
+
+- [ ] **Step 3: Hoist tracking variables and emit the log**
+
+In `src/features/vacancies/lib/scan-runner.ts:40-58` (top of `runScan`), after the existing `let scan: ... = null;` line, add:
+
+```ts
+const scanStartMs = Date.now();
+let finalStatus: string = "unknown";
+let finalFailureReason: VacancyFailureReason | null = null;
+let finalVacancyCount = 0;
+let finalConsecutiveFailures = 0;
+let detectedPlatform: string | null = null;
+let hadPriorCompletedScan = false;
+```
+
+Then near the start of `try` (after fetching `scan`), capture `was_first_attempt`:
+
+```ts
+const priorCount = await prisma.vacancyScan.count({
+  where: {
+    leaid: scan.district.leaid,
+    status: { in: ["completed", "completed_partial"] },
+    NOT: { id: scanId },
+  },
+});
+hadPriorCompletedScan = priorCount > 0;
+```
+
+Now thread the hoisted variables through every status-setting site. Each `prisma.vacancyScan.update` call gets a small post-update block that copies the values into the hoisted vars. Each `markDistrictScan{Success,Failure}` call captures its return value into `finalConsecutiveFailures`. Enumerated:
+
+**Right after `detectPlatform`** (around line 101):
+
+```ts
+detectedPlatform = platform;
+```
+
+**Site A — no-URL branch** (the block from Task 7 Site 1). After the `prisma.vacancyScan.update`, before `markDistrictScanFailure`:
+
+```ts
+finalStatus = "failed";
+finalFailureReason = failureReason;
+```
+
+After the helper call:
+
+```ts
+finalConsecutiveFailures = await markDistrictScanFailure(scan.district.leaid, failureReason);
+```
+
+(Replace the existing `await markDistrictScanFailure(...)` line with this assignment form.)
+
+**Site B — Claude-empty branch** (the block from Task 7 Site 2). Same pattern:
+
+```ts
+finalStatus = "completed_partial";
+finalFailureReason = failureReason;
+finalConsecutiveFailures = await markDistrictScanFailure(scan.district.leaid, failureReason);
+```
+
+**Site C — statewide_unattributable** (around the existing line 168-178 block, after the `prisma.update`):
+
+```ts
+finalStatus = "completed_partial";
+finalFailureReason = "statewide_unattributable";
+finalConsecutiveFailures = await markDistrictScanSuccess(scan.district.leaid);
+```
+
+(Replace the existing `await markDistrictScanSuccess(...)` line.)
+
+**Site D — statewide success path** (after the `prisma.update` around line 209-219):
+
+```ts
+finalStatus = "completed";
+finalVacancyCount = result.vacancyCount;
+finalConsecutiveFailures = await markDistrictScanSuccess(scan.district.leaid);
+```
+
+**Site E — enrollment_ratio_skip** (after the `prisma.update` around line 247-258):
+
+```ts
+finalStatus = "completed_partial";
+finalFailureReason = "enrollment_ratio_skip";
+finalConsecutiveFailures = await markDistrictScanSuccess(scan.district.leaid);
+```
+
+**Site F — district-scoped success** (after the `prisma.update` around line 275-284):
+
+```ts
+finalStatus = "completed";
+finalVacancyCount = result.vacancyCount;
+finalConsecutiveFailures = await markDistrictScanSuccess(scan.district.leaid);
+```
+
+**Site G — outer catch** (the block from Task 7 Site 3). After the inner `prisma.update`, before `markDistrictScanFailure`:
+
+```ts
+finalStatus = "failed";
+finalFailureReason = failureReason;
+```
+
+After the helper call:
+
+```ts
+finalConsecutiveFailures = await markDistrictScanFailure(scan.district.leaid, failureReason);
+```
+
+Finally, replace the existing `finally` block (currently just `clearTimeout(timeoutId);`) with:
+
+```ts
+} finally {
+  clearTimeout(timeoutId);
+  console.log(
+    JSON.stringify({
+      event: "vacancy_scan_outcome",
+      leaid: scan?.district.leaid ?? null,
+      platform: detectedPlatform,
+      status: finalStatus,
+      failure_reason: finalFailureReason,
+      vacancy_count: finalVacancyCount,
+      duration_ms: Date.now() - scanStartMs,
+      was_first_attempt: !hadPriorCompletedScan,
+      consecutive_failures_after: finalConsecutiveFailures,
+    }),
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/features/vacancies/lib/__tests__/scan-runner.test.ts`
+Expected: PASS — outcome-log test green; all prior tests still green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/vacancies/lib/scan-runner.ts src/features/vacancies/lib/__tests__/scan-runner.test.ts
+git commit -m "feat(vacancies): emit vacancy_scan_outcome log per scan"
+```
+
+---
+
+## Task 9: Cron `tarpitSize` query + `vacancy_cron_summary` log
+
+**Files:**
+- Modify: `src/app/api/cron/scan-vacancies/route.ts:49-150` (handler body)
+- Test: no new automated test (the cron route has no existing tests; manual verification via the per-batch JSON response is sufficient — see Step 4)
+
+- [ ] **Step 1: Add the tarpit query**
+
+In `src/app/api/cron/scan-vacancies/route.ts`, immediately before the existing `await loadSharedJobBoardUrls();` call (around line 54), add:
+
+```ts
+const tarpitSize = await prisma.district.count({
+  where: {
+    jobBoardUrl: { not: null },
+    vacancyConsecutiveFailures: { gte: 5 },
+  },
+});
+```
+
+- [ ] **Step 2: Update each `runScan` result aggregation to capture the failureReason**
+
+In the existing parallel-batch block (around line 175-209), the loop body reads the post-run scan record:
+
+```ts
+const result = await prisma.vacancyScan.findUnique({
+  where: { id: scan.id },
+  select: { status: true, platform: true, startedAt: true, completedAt: true },
+});
+```
+
+Add `failureReason: true` to the select:
+
+```ts
+const result = await prisma.vacancyScan.findUnique({
+  where: { id: scan.id },
+  select: {
+    status: true,
+    platform: true,
+    startedAt: true,
+    completedAt: true,
+    failureReason: true,
+  },
+});
+```
+
+And extend the `results.push` to include the reason:
+
+```ts
+results.push({
+  leaid: representative.leaid,
+  name: representative.name,
+  status: result?.status ?? "unknown",
+  failureReason: result?.failureReason ?? null,
+  statewide: isStatewide,
+});
+```
+
+Update the local `results` array type accordingly:
+
+```ts
+const results: {
+  leaid: string;
+  name: string;
+  status: string;
+  failureReason: string | null;
+  statewide: boolean;
+}[] = [];
+```
+
+- [ ] **Step 3: Emit the cron summary log**
+
+Immediately before the existing `return NextResponse.json({...})` at the end of the handler (around line 221), add:
+
+```ts
+const failureReasonMix = results.reduce<Record<string, number>>((acc, r) => {
+  if (r.failureReason) acc[r.failureReason] = (acc[r.failureReason] ?? 0) + 1;
+  return acc;
+}, {});
+
+console.log(
+  JSON.stringify({
+    event: "vacancy_cron_summary",
+    batch_id: batchId,
+    total_stale: staleDistricts.length,
+    unique_urls: urlGroups.size,
+    scans_run: batch.length,
+    districts_processed: districtsProcessed,
+    never_scanned_groups_remaining: neverScannedGroupsRemaining,
+    sibling_coverage_created: siblingCoverageCreated,
+    tarpit_size_at_start: tarpitSize,
+    failure_reason_mix: failureReasonMix,
+  }),
+);
+```
+
+- [ ] **Step 4: Manual smoke verification**
+
+Run the dev server (`npm run dev` on port 3005), then in another terminal hit the cron locally (CRON_SECRET must be set in `.env.local`):
+
+```bash
+curl "http://localhost:3005/api/cron/scan-vacancies?secret=${CRON_SECRET}&stale=999"
+```
+
+Expected: the response JSON returns successfully. The dev-server console shows a single `{"event":"vacancy_cron_summary",...}` line plus per-scan `vacancy_scan_outcome` lines. Note: `stale=999` ensures the pool is non-empty even on a freshly-scanned local DB.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/api/cron/scan-vacancies/route.ts
+git commit -m "feat(vacancies): emit vacancy_cron_summary log + tarpit_size_at_start"
+```
+
+---
+
+## Task 10: Stats endpoint — add `tarpit`, `adjustedCoveragePct`, `topFailureReason7d`
+
+**Files:**
+- Modify: `src/app/api/admin/vacancy-scan-stats/route.ts`
+- Create: `src/app/api/admin/vacancy-scan-stats/__tests__/route.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/app/api/admin/vacancy-scan-stats/__tests__/route.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const districtCount = vi.fn();
+const districtGroupBy = vi.fn();
+const vacancyCount = vi.fn();
+const vacancyGroupBy = vi.fn();
+const vacancyScanCount = vi.fn();
+const vacancyScanGroupBy = vi.fn();
+const vacancyScanFindFirst = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    district: {
+      count: (...args: unknown[]) => districtCount(...args),
+      groupBy: (...args: unknown[]) => districtGroupBy(...args),
+    },
+    vacancy: {
+      count: (...args: unknown[]) => vacancyCount(...args),
+      groupBy: (...args: unknown[]) => vacancyGroupBy(...args),
+    },
+    vacancyScan: {
+      count: (...args: unknown[]) => vacancyScanCount(...args),
+      groupBy: (...args: unknown[]) => vacancyScanGroupBy(...args),
+      findFirst: (...args: unknown[]) => vacancyScanFindFirst(...args),
+    },
+  },
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  getUser: async () => ({ id: "user-1" }),
+}));
+
+import { GET } from "../route";
+
+beforeEach(() => {
+  districtCount.mockReset();
+  districtGroupBy.mockReset();
+  vacancyCount.mockReset();
+  vacancyGroupBy.mockReset();
+  vacancyScanCount.mockReset();
+  vacancyScanGroupBy.mockReset();
+  vacancyScanFindFirst.mockReset();
+});
+
+function setupHappyPath() {
+  vacancyCount.mockResolvedValueOnce(120).mockResolvedValueOnce(100); // total, verified
+  vacancyGroupBy.mockResolvedValueOnce([{ leaid: "1" }, { leaid: "2" }]); // districts with vacancies
+  districtCount
+    .mockResolvedValueOnce(1000) // totalDistrictsWithUrl
+    .mockResolvedValueOnce(50); // tarpit total
+  vacancyScanCount.mockResolvedValueOnce(60).mockResolvedValueOnce(2); // 7d scans, 24h failures
+  vacancyScanFindFirst.mockResolvedValueOnce({
+    completedAt: new Date("2026-05-03T12:00:00Z"),
+    platform: "applitrack",
+    districtsMatched: 0,
+  });
+  vacancyScanGroupBy
+    .mockResolvedValueOnce([{ platform: "olas", _count: 10 }]) // by platform
+    .mockResolvedValueOnce([
+      { leaid: "1" },
+      { leaid: "2" },
+      { leaid: "3" },
+    ]) // scanned districts
+    .mockResolvedValueOnce([
+      { failureReason: "claude_fallback_failed", _count: 18 },
+      { failureReason: "scan_timeout", _count: 6 },
+    ]); // 7d failure-reason mix
+  districtGroupBy.mockResolvedValueOnce([
+    { jobBoardPlatform: "claude", _count: 38 },
+    { jobBoardPlatform: null, _count: 12 },
+  ]); // tarpit by platform
+}
+
+describe("GET /api/admin/vacancy-scan-stats — new fields", () => {
+  it("returns tarpit, adjustedCoveragePct, and topFailureReason7d", async () => {
+    setupHappyPath();
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.tarpit).toEqual({
+      total: 50,
+      byPlatform: [
+        { platform: "claude", count: 38 },
+        { platform: "unknown", count: 12 },
+      ],
+    });
+    // adjusted = scannedDistricts(3) / (totalWithUrl(1000) - tarpit(50)) = 3/950 = 0.32% rounded
+    expect(body.adjustedCoveragePct).toBe(0);
+    expect(body.topFailureReason7d).toEqual({
+      reason: "claude_fallback_failed",
+      pct: 75, // 18 / (18 + 6) = 0.75
+    });
+  });
+
+  it("returns adjustedCoveragePct == coveragePct when tarpit is empty", async () => {
+    vacancyCount.mockResolvedValueOnce(0).mockResolvedValueOnce(0);
+    vacancyGroupBy.mockResolvedValueOnce([]);
+    districtCount.mockResolvedValueOnce(100).mockResolvedValueOnce(0);
+    vacancyScanCount.mockResolvedValueOnce(0).mockResolvedValueOnce(0);
+    vacancyScanFindFirst.mockResolvedValueOnce(null);
+    vacancyScanGroupBy
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ leaid: "1" }]) // 1 scanned
+      .mockResolvedValueOnce([]);
+    districtGroupBy.mockResolvedValueOnce([]);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.coveragePct).toBe(1);
+    expect(body.adjustedCoveragePct).toBe(1);
+    expect(body.topFailureReason7d).toBeNull();
+    expect(body.tarpit).toEqual({ total: 0, byPlatform: [] });
+  });
+
+  it("floors the adjusted denominator at 1 when every district is tarpitted", async () => {
+    vacancyCount.mockResolvedValueOnce(0).mockResolvedValueOnce(0);
+    vacancyGroupBy.mockResolvedValueOnce([]);
+    districtCount.mockResolvedValueOnce(50).mockResolvedValueOnce(50);
+    vacancyScanCount.mockResolvedValueOnce(0).mockResolvedValueOnce(0);
+    vacancyScanFindFirst.mockResolvedValueOnce(null);
+    vacancyScanGroupBy
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    districtGroupBy.mockResolvedValueOnce([]);
+
+    const res = await GET();
+    const body = await res.json();
+    // 0 / max(1, 0) = 0%
+    expect(body.adjustedCoveragePct).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/app/api/admin/vacancy-scan-stats/__tests__/route.test.ts`
+Expected: FAIL — endpoint doesn't return the new fields yet.
+
+- [ ] **Step 3: Implement the new fields**
+
+Replace the entire body of the `try` block in `src/app/api/admin/vacancy-scan-stats/route.ts` (currently lines 13-84) with:
+
+```ts
+const user = await getUser();
+if (!user) {
+  return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+}
+
+const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+
+const [
+  totalVacancies,
+  verifiedVacancies,
+  districtsWithVacancies,
+  totalDistrictsWithUrl,
+  tarpitTotal,
+  recentScans,
+  failedScans24h,
+  lastScan,
+  byPlatform,
+  scannedDistricts,
+  failureReasonGroups,
+  tarpitByPlatformRaw,
+] = await Promise.all([
+  prisma.vacancy.count({ where: { status: "open" } }),
+  prisma.vacancy.count({ where: { status: "open", districtVerified: true } }),
+  prisma.vacancy.groupBy({ by: ["leaid"], where: { status: "open", districtVerified: true } }),
+  prisma.district.count({ where: { jobBoardUrl: { not: null } } }),
+  prisma.district.count({
+    where: { jobBoardUrl: { not: null }, vacancyConsecutiveFailures: { gte: 5 } },
+  }),
+  prisma.vacancyScan.count({
+    where: {
+      status: { in: ["completed", "completed_partial"] },
+      completedAt: { gte: sevenDaysAgo },
+    },
+  }),
+  prisma.vacancyScan.count({
+    where: {
+      status: "failed",
+      startedAt: { gte: new Date(Date.now() - 24 * 60 * 60 * 1000) },
+    },
+  }),
+  prisma.vacancyScan.findFirst({
+    where: { status: { in: ["completed", "completed_partial"] } },
+    orderBy: { completedAt: "desc" },
+    select: { completedAt: true, platform: true, districtsMatched: true },
+  }),
+  prisma.vacancyScan.groupBy({
+    by: ["platform"],
+    where: {
+      status: { in: ["completed", "completed_partial"] },
+      completedAt: { gte: sevenDaysAgo },
+    },
+    _count: true,
+  }),
+  prisma.vacancyScan.groupBy({
+    by: ["leaid"],
+    where: { status: { in: ["completed", "completed_partial"] } },
+  }),
+  prisma.vacancyScan.groupBy({
+    by: ["failureReason"],
+    where: {
+      status: { in: ["failed", "completed_partial"] },
+      completedAt: { gte: sevenDaysAgo },
+      failureReason: { not: null },
+    },
+    _count: true,
+  }),
+  prisma.district.groupBy({
+    by: ["jobBoardPlatform"],
+    where: { jobBoardUrl: { not: null }, vacancyConsecutiveFailures: { gte: 5 } },
+    _count: true,
+  }),
+]);
+
+const coveragePct = totalDistrictsWithUrl > 0
+  ? Math.round((scannedDistricts.length / totalDistrictsWithUrl) * 100)
+  : 0;
+
+const adjustedDenominator = Math.max(1, totalDistrictsWithUrl - tarpitTotal);
+const adjustedCoveragePct = Math.round(
+  (scannedDistricts.length / adjustedDenominator) * 100,
+);
+
+const tarpitByPlatform = tarpitByPlatformRaw
+  .map((r) => ({
+    platform: r.jobBoardPlatform || "unknown",
+    count: r._count,
+  }))
+  .sort((a, b) => b.count - a.count)
+  .slice(0, 4);
+
+const totalFailures7d = failureReasonGroups.reduce((s, g) => s + g._count, 0);
+const topGroup = failureReasonGroups
+  .slice()
+  .sort((a, b) => b._count - a._count)[0];
+const topFailureReason7d = topGroup && totalFailures7d > 0
+  ? {
+      reason: topGroup.failureReason!,
+      pct: Math.round((topGroup._count / totalFailures7d) * 100),
+    }
+  : null;
+
+return NextResponse.json({
+  totalVacancies,
+  verifiedVacancies,
+  districtsWithVacancies: districtsWithVacancies.length,
+  totalDistrictsWithUrl,
+  districtsScanned: scannedDistricts.length,
+  coveragePct,
+  adjustedCoveragePct,
+  tarpit: {
+    total: tarpitTotal,
+    byPlatform: tarpitByPlatform,
+  },
+  topFailureReason7d,
+  scansLast7d: recentScans,
+  failedLast24h: failedScans24h,
+  lastScanAt: lastScan?.completedAt?.toISOString() ?? null,
+  byPlatform: byPlatform.map((p) => ({
+    platform: p.platform || "unknown",
+    count: p._count,
+  })),
+});
+```
+
+The existing outer `try`/`catch (error)` and 500 fallback (lines 85-92) are preserved unchanged.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/app/api/admin/vacancy-scan-stats/__tests__/route.test.ts`
+Expected: PASS — all three tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/api/admin/vacancy-scan-stats/route.ts src/app/api/admin/vacancy-scan-stats/__tests__/route.test.ts
+git commit -m "feat(admin): add tarpit/adjusted-coverage/top-failure-reason to vacancy stats"
+```
+
+---
+
+## Task 11: Admin card row 2 — Tarpit / Adjusted Coverage / Top Failure Reason
+
+**Files:**
+- Modify: `src/features/admin/components/VacancyScanCard.tsx`
+- Create: `src/features/admin/components/__tests__/VacancyScanCard.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/features/admin/components/__tests__/VacancyScanCard.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import VacancyScanCard from "../VacancyScanCard";
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  global.fetch = mockFetch as never;
+});
+
+function renderCard() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <VacancyScanCard />
+    </QueryClientProvider>,
+  );
+}
+
+function mockStats(overrides: Record<string, unknown> = {}) {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      totalVacancies: 100,
+      verifiedVacancies: 95,
+      districtsWithVacancies: 40,
+      totalDistrictsWithUrl: 1000,
+      districtsScanned: 450,
+      coveragePct: 45,
+      adjustedCoveragePct: 47,
+      tarpit: { total: 50, byPlatform: [{ platform: "claude", count: 38 }] },
+      topFailureReason7d: { reason: "claude_fallback_failed", pct: 75 },
+      scansLast7d: 100,
+      failedLast24h: 0,
+      lastScanAt: new Date().toISOString(),
+      byPlatform: [],
+      ...overrides,
+    }),
+  });
+}
+
+describe("VacancyScanCard row 2 — diagnostics", () => {
+  it("renders Tarpit, Adjusted Coverage, and Top Failure Reason", async () => {
+    mockStats();
+    renderCard();
+
+    expect(await screen.findByText("Tarpit")).toBeInTheDocument();
+    expect(screen.getByText("50")).toBeInTheDocument();
+    expect(screen.getByText(/claude \(38\)/)).toBeInTheDocument();
+
+    expect(screen.getByText("Adjusted Coverage")).toBeInTheDocument();
+    expect(screen.getByText("47%")).toBeInTheDocument();
+
+    expect(screen.getByText("Top Failure Reason")).toBeInTheDocument();
+    expect(screen.getByText("claude_fallback_failed")).toBeInTheDocument();
+    expect(screen.getByText("75% of failures (7d)")).toBeInTheDocument();
+  });
+
+  it("renders dash for top failure reason when null", async () => {
+    mockStats({ topFailureReason7d: null });
+    renderCard();
+    await screen.findByText("Top Failure Reason");
+    expect(screen.getByText("—")).toBeInTheDocument();
+    expect(screen.getByText("no failures")).toBeInTheDocument();
+  });
+
+  it("renders no sub-line when tarpit is empty", async () => {
+    mockStats({ tarpit: { total: 0, byPlatform: [] } });
+    renderCard();
+    expect(await screen.findByText("Tarpit")).toBeInTheDocument();
+    expect(screen.getByText("0")).toBeInTheDocument();
+    // platform sub-line should not appear when total is 0
+    expect(screen.queryByText(/claude \(/)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/features/admin/components/__tests__/VacancyScanCard.test.tsx`
+Expected: FAIL — none of "Tarpit", "Adjusted Coverage", "Top Failure Reason" exist yet.
+
+- [ ] **Step 3: Update the component**
+
+In `src/features/admin/components/VacancyScanCard.tsx`, extend the `VacancyScanStats` interface (lines 5-16):
+
+```ts
+interface VacancyScanStats {
+  totalVacancies: number;
+  verifiedVacancies: number;
+  districtsWithVacancies: number;
+  totalDistrictsWithUrl: number;
+  districtsScanned: number;
+  coveragePct: number;
+  adjustedCoveragePct: number;
+  tarpit: {
+    total: number;
+    byPlatform: { platform: string; count: number }[];
+  };
+  topFailureReason7d: { reason: string; pct: number } | null;
+  scansLast7d: number;
+  failedLast24h: number;
+  lastScanAt: string | null;
+  byPlatform: { platform: string; count: number }[];
+}
+```
+
+Update the `healthColor` computation (line 50-55) to add the tarpit threshold:
+
+```ts
+const tarpitRatio = data.totalDistrictsWithUrl > 0
+  ? data.tarpit.total / data.totalDistrictsWithUrl
+  : 0;
+
+const healthColor =
+  data.failedLast24h > 5 || tarpitRatio > 0.30
+    ? "#F37167"
+    : data.coveragePct < 10
+      ? "#E5A53D"
+      : "#8AA891";
+```
+
+After the existing 4-stat grid (closing `</div>` after line 90) and before the Progress Bar block (line 93), insert a new row:
+
+```tsx
+{/* Diagnostics row */}
+<div className="grid grid-cols-3 gap-4">
+  <Stat
+    label="Tarpit"
+    value={data.tarpit.total.toLocaleString()}
+    sub={
+      data.tarpit.total > 0
+        ? data.tarpit.byPlatform
+            .slice(0, 2)
+            .map((p) => `${p.platform} (${p.count})`)
+            .join(", ")
+        : undefined
+    }
+    alert={data.tarpit.total > 0}
+  />
+  <Stat
+    label="Adjusted Coverage"
+    value={`${data.adjustedCoveragePct}%`}
+    sub="of reachable pool"
+  />
+  <Stat
+    label="Top Failure Reason"
+    value={data.topFailureReason7d?.reason ?? "—"}
+    sub={
+      data.topFailureReason7d
+        ? `${data.topFailureReason7d.pct}% of failures (7d)`
+        : "no failures"
+    }
+  />
+</div>
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/features/admin/components/__tests__/VacancyScanCard.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Visual verification**
+
+Run `npm run dev` and visit `/admin` (or wherever `VacancyScanCard` renders — confirm route by grep if unsure). Confirm row 2 renders with the three new stats and that the alert dot turns red when tarpit > 30% of URL-bearing districts.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/features/admin/components/VacancyScanCard.tsx src/features/admin/components/__tests__/VacancyScanCard.test.tsx
+git commit -m "feat(admin): add coverage-diagnostics row to VacancyScanCard"
+```
+
+---
+
+## Task 12: One-time historical backfill script
+
+**Files:**
+- Create: `scripts/backfill-vacancy-failure-reasons.ts`
+
+- [ ] **Step 1: Write the script**
+
+Create `scripts/backfill-vacancy-failure-reasons.ts`:
+
+```ts
+/**
+ * One-time backfill: categorize historical VacancyScan failures into the
+ * new failureReason column.
+ *
+ * Run:    npx tsx scripts/backfill-vacancy-failure-reasons.ts
+ * Dry:    DRY_RUN=true npx tsx scripts/backfill-vacancy-failure-reasons.ts
+ *
+ * Idempotent — safe to re-run; the WHERE clause skips already-categorized rows.
+ */
+import prisma from "@/lib/prisma";
+import { categorizeFailure } from "@/features/vacancies/lib/failure-reasons";
+import type { VacancyFailureReason } from "@prisma/client";
+
+const BATCH_SIZE = 500;
+const DRY_RUN = process.env.DRY_RUN === "true";
+
+async function main() {
+  const counts: Record<string, number> = {};
+  let totalProcessed = 0;
+  let cursor: string | undefined = undefined;
+
+  for (;;) {
+    const batch = await prisma.vacancyScan.findMany({
+      where: {
+        status: { in: ["failed", "completed_partial"] },
+        failureReason: null,
+      },
+      select: { id: true, errorMessage: true },
+      orderBy: { id: "asc" },
+      ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+      take: BATCH_SIZE,
+    });
+
+    if (batch.length === 0) break;
+
+    const updates: { id: string; reason: VacancyFailureReason }[] = batch.map((row) => {
+      const reason = categorizeFailure({
+        errorMessage: row.errorMessage ?? "",
+        context: "thrown_error",
+      });
+      counts[reason] = (counts[reason] ?? 0) + 1;
+      return { id: row.id, reason };
+    });
+
+    if (!DRY_RUN) {
+      await prisma.$transaction(
+        updates.map((u) =>
+          prisma.vacancyScan.update({
+            where: { id: u.id },
+            data: { failureReason: u.reason },
+          }),
+        ),
+      );
+    }
+
+    totalProcessed += batch.length;
+    cursor = batch[batch.length - 1]!.id;
+    console.log(
+      `[backfill] processed ${totalProcessed} rows so far${DRY_RUN ? " (dry run)" : ""}`,
+    );
+  }
+
+  console.log("\n=== Backfill summary ===");
+  console.log(`Mode: ${DRY_RUN ? "DRY RUN (no writes)" : "LIVE"}`);
+  console.log(`Total rows processed: ${totalProcessed}`);
+  console.log("Bucket counts:");
+  for (const [reason, count] of Object.entries(counts).sort(
+    ([, a], [, b]) => b - a,
+  )) {
+    console.log(`  ${reason.padEnd(28)} ${count}`);
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error("[backfill] failed:", err);
+    process.exit(1);
+  });
+```
+
+- [ ] **Step 2: Dry-run the script**
+
+Run: `DRY_RUN=true npx tsx scripts/backfill-vacancy-failure-reasons.ts`
+Expected: prints batch progress, then a summary table. No DB writes (verify by re-running and seeing the same counts).
+
+- [ ] **Step 3: Live-run the script**
+
+Run: `npx tsx scripts/backfill-vacancy-failure-reasons.ts`
+Expected: same output as dry-run, but writes are committed. Re-running should produce a summary with `Total rows processed: 0` because the WHERE clause now excludes everything.
+
+- [ ] **Step 4: Spot-check the result**
+
+Run a quick prisma query (or psql) to verify a sample:
+
+```bash
+npx prisma studio
+```
+
+Or via psql:
+
+```sql
+SELECT failure_reason, COUNT(*) FROM vacancy_scans
+WHERE status IN ('failed', 'completed_partial')
+GROUP BY failure_reason ORDER BY COUNT(*) DESC;
+```
+
+Expected: every `failed` / `completed_partial` row has a non-null `failure_reason`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/backfill-vacancy-failure-reasons.ts
+git commit -m "chore(vacancies): backfill script for failureReason column"
+```
+
+---
+
+## Task 13: End-to-end verification
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `npm test -- --run`
+Expected: all tests pass — new and existing.
+
+- [ ] **Step 2: Run typecheck and lint**
+
+Run: `npx tsc --noEmit && npm run lint`
+Expected: no errors.
+
+- [ ] **Step 3: Manually verify the admin card**
+
+Visit the admin page in `npm run dev`. Confirm:
+- The card renders 4 stats in row 1 (unchanged) and 3 stats in row 2 (new).
+- "Tarpit" shows a number > 0 if your local DB has districts at 5+ failures (post-backfill, this is likely).
+- "Adjusted Coverage" reads as a percentage.
+- "Top Failure Reason" shows a bucket name with a percentage sub-line.
+- The health dot reflects red/yellow/green correctly.
+
+- [ ] **Step 4: Trigger one cron run and inspect logs**
+
+Run: `curl "http://localhost:3005/api/cron/scan-vacancies?secret=${CRON_SECRET}&stale=999"`
+Expected: dev-server console contains:
+- One `vacancy_cron_summary` JSON line with all keys present.
+- 1–5 `vacancy_scan_outcome` JSON lines, one per scan run.
+- (Possibly) a `vacancy_tarpit_admission` line if any scan crossed 4→5 failures.
+
+- [ ] **Step 5: Final commit and push**
+
+If everything looks good, push the branch:
+
+```bash
+git push -u origin <branch-name>
+```
+
+The branch is ready for PR.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Each spec section maps to a task: Part 1 (taxonomy) → Task 1 enum + Task 2 helper. Part 2 (schema) → Task 1. Part 3 (helper + scan-runner) → Tasks 2-7. Part 4 (cron telemetry) → Task 9. Part 5 (per-scan log) → Task 8. Part 6 (tarpit admission) → Task 7. Part 7 (stats endpoint) → Task 10. Part 8 (admin card) → Task 11. Part 9 (backfill) → Task 12. Migration plan → Tasks 1 + 12 + 13.
+- **TDD:** Every task with code emits a failing test first, then minimal implementation, then green-light verification.
+- **Bite-sized:** No step is more than ~5 minutes of mechanical work; the longest are the helper-write step and the stats-endpoint refactor, both ≤10 minutes.
+- **Type consistency:** `categorizeFailure` returns `VacancyFailureReason` everywhere; `markDistrictScan{Failure,Success}` both return `Promise<number>`; the admin card and stats endpoint share an explicit type for `tarpit`/`topFailureReason7d`.
+- **No placeholders:** every step contains the exact file path, code, and command needed.

--- a/Docs/superpowers/specs/2026-05-03-vacancy-scanner-coverage-diagnostics-design.md
+++ b/Docs/superpowers/specs/2026-05-03-vacancy-scanner-coverage-diagnostics-design.md
@@ -1,0 +1,367 @@
+---
+title: Vacancy Scanner Coverage Diagnostics — Design
+date: 2026-05-03
+status: draft
+owner: sierra.arcega@fullmindlearning.com
+---
+
+# Vacancy Scanner Coverage Diagnostics — Design
+
+## Problem
+
+The admin `VacancyScanCard` reports scan coverage — `districts_ever_scanned / districts_with_jobBoardUrl` — at roughly **45%** and the number does not move. Investigation in `src/app/api/cron/scan-vacancies/route.ts`, `src/features/vacancies/lib/scan-runner.ts`, and `src/app/api/admin/vacancy-scan-stats/route.ts` identified three structural ratchets that pin the metric at the percentage of districts whose URL is actually scrapable, not at the percentage we *intend* to scrape:
+
+1. **5-strikes tarpit, no reset.** The cron filter `vacancyConsecutiveFailures: { lt: 5 }` permanently excludes any district whose URL has failed five times. The counter only resets on a successful scan; no other job touches it. Once admitted, a district stays in the tarpit indefinitely while still counting in the denominator.
+2. **Unknown-platform throttle vs. ~80% Claude-fallback failure rate.** `MAX_UNKNOWN_PER_RUN = 1` reserves one of five hourly slots for unknown-platform groups because the Claude fallback path has been unreliable since the 2026-04-23 regression. Most attempts fail; five fails sends the district to the tarpit, where it never returns.
+3. **Throughput ceiling.** `SCANS_PER_RUN = 5` × hourly cron = 120 scans/day max. State-wide boards (OLAS, SchoolSpring) cover many districts per scan via sibling-coverage records, but per-district platforms scale linearly.
+
+The user already understands the symptom. What they cannot see today, because no instrumentation captures it, is **where the loss is concentrated** — which platforms own the tarpit, which failure modes dominate the last 7 days, whether the scanner is doing well on the reachable pool or poorly across the board. Without that visibility, any fix is a guess.
+
+This spec covers the **logging-and-instrumentation phase** only. Edge-case fixes (failure-counter reset job, Claude fallback regression, parser improvements) are explicitly out of scope and will be designed in a follow-up brainstorm informed by the data this work produces.
+
+This work is complementary to the 2026-04-14 vacancy scanner monitoring spec, which addresses freshness/health (verdict line, sparkline, stuck scans). Both extend the same card and same stats endpoint with non-overlapping fields; if both ship, layout will need a small reconciliation pass at that time.
+
+## Goals
+
+1. Categorize every scan failure into a fixed taxonomy so failure reasons are queryable, not free-text.
+2. Surface three new diagnostic numbers on `VacancyScanCard`: tarpit size (with platform breakdown), adjusted coverage (against the reachable pool), and top failure reason in the trailing 7 days.
+3. Emit three structured log events that let an operator answer "where did coverage go?" via Vercel log search alone.
+4. Make the new column meaningful on day one via a one-time historical backfill.
+
+## Non-goals
+
+- No fix to the failure-counter ratchet, the Claude fallback regression, or any parser. Those are separate efforts informed by this work.
+- No dedicated `/admin/vacancy-diagnostics` page. The existing card is the surface.
+- No changes to `vacancy-hygiene`, scan scheduling, or any cron cadence.
+- No retry logic, alerting, or paging.
+- No `parser_empty` *detection* — the bucket exists in the enum for future use (e.g., comparing to prior-scan vacancy counts) but no code path sets it in this PR.
+
+## Design
+
+### Part 1 — Failure-reason taxonomy
+
+A fixed enum of ten buckets, designed to map cleanly onto every existing failure path in `scan-runner.ts` and the cron, with one catch-all:
+
+| Bucket | What triggers it |
+|---|---|
+| `http_4xx` | URL returns 404/403/410 (string-matched in catch path) |
+| `http_5xx` | URL returns 500-class error |
+| `network_timeout` | fetch itself times out / connection refused |
+| `scan_timeout` | 3-min `SCAN_TIMEOUT_MS` hit |
+| `parser_empty` | reserved for future: parser ran cleanly but page format changed (no code path sets this in this PR) |
+| `claude_fallback_failed` | Claude path errored OR returned 0 vacancies (see Part 3 — explicit policy choice) |
+| `statewide_unattributable` | >50% of jobs lack `employerName` (existing safety net at `scan-runner.ts:163`) |
+| `enrollment_ratio_skip` | suspicious-inflation safety net (existing at `scan-runner.ts:240`) |
+| `no_job_board_url` | district had URL nulled out between scheduling and runtime |
+| `unknown_error` | catch-all when the catch-path string match doesn't recognize the error |
+
+`failureReason` is `null` on successful scans (`status: 'completed'` with non-zero or genuinely-empty results from a known parser). It is set on every `'failed'` and every `'completed_partial'` row.
+
+### Part 2 — Schema change
+
+Additive Prisma migration. No existing data altered.
+
+```prisma
+enum VacancyFailureReason {
+  http_4xx
+  http_5xx
+  network_timeout
+  scan_timeout
+  parser_empty
+  claude_fallback_failed
+  statewide_unattributable
+  enrollment_ratio_skip
+  no_job_board_url
+  unknown_error
+}
+
+model VacancyScan {
+  // ...existing fields preserved
+  failureReason VacancyFailureReason?
+}
+```
+
+The existing free-text `errorMessage` column stays. `failureReason` is the machine-categorized companion; the human-readable detail still lives in `errorMessage`.
+
+### Part 3 — Categorization helper and scan-runner integration
+
+New file `src/features/vacancies/lib/failure-reasons.ts`:
+
+```ts
+import { VacancyFailureReason } from "@prisma/client";
+
+export type FailureContext =
+  | "no_job_board_url"
+  | "scan_timeout"
+  | "statewide_unattributable"
+  | "enrollment_ratio_skip"
+  | "claude_fallback_empty"
+  | "thrown_error";
+
+export function categorizeFailure(args: {
+  errorMessage: string;
+  context?: FailureContext;
+}): VacancyFailureReason;
+```
+
+When `context` is supplied and unambiguous, it maps directly: `"no_job_board_url"` → `no_job_board_url`, `"scan_timeout"` → `scan_timeout`, `"statewide_unattributable"` → `statewide_unattributable`, `"enrollment_ratio_skip"` → `enrollment_ratio_skip`, `"claude_fallback_empty"` → `claude_fallback_failed`. When `context` is `"thrown_error"` (or omitted), the function string-matches `errorMessage` against patterns in this order — first match wins:
+
+- `/timed out|abort|aborted/i` → `scan_timeout`
+- `/anthropic|claude api/i` → `claude_fallback_failed` (catches exceptions thrown from the Claude fallback path)
+- `/statewide board returned/i` → `statewide_unattributable` (backfill-only; runtime path supplies explicit context)
+- `/regional aggregator/i` → `enrollment_ratio_skip` (backfill-only; runtime path supplies explicit context)
+- `/no job board url/i` → `no_job_board_url` (backfill-only; runtime path supplies explicit context)
+- `/4\d\d|not found|forbidden|gone/i` → `http_4xx`
+- `/5\d\d|server error|bad gateway|service unavailable/i` → `http_5xx`
+- `/econnrefused|enotfound|network|fetch failed|getaddrinfo/i` → `network_timeout`
+- everything else → `unknown_error`
+
+Patterns are case-insensitive. The three "backfill-only" patterns match `errorMessage` strings produced by today's code at sites that, post-this-PR, supply explicit `context` — they exist so the one-time backfill (Part 9) can categorize historical rows correctly without rewriting their messages. The function is pure and exhaustively unit-tested.
+
+**Wiring in `scan-runner.ts`**, every site that sets a non-success status now also writes `failureReason`:
+
+| Existing line range | Status set | Context to pass |
+|---|---|---|
+| 82–91 | `failed` (no jobBoardUrl) | `no_job_board_url` |
+| 152–153 (timeout check) → 286 (catch) | `failed` | helper called with `errorMessage="Scan timed out"` and context `"scan_timeout"` |
+| 168–177 | `completed_partial` (statewide unattributable) | `statewide_unattributable` |
+| 247–256 | `completed_partial` (enrollment ratio) | `enrollment_ratio_skip` |
+| 286–309 | `failed` (outer catch) | `thrown_error` (string-match) |
+
+**Explicit policy choice — Claude-fallback-empty.** Today, when the serverless Claude fallback returns `[]` (no exception, just empty), `scan-runner.ts:130–148` falls through with `rawVacancies = []` and the scan is marked `status: 'completed'`, `vacancyCount: 0`, no failure. This is the dominant failure mode behind the 2026-04-23 regression, and unless we differentiate it the `claude_fallback_failed` bucket would be empty in practice.
+
+**This spec changes that behavior.** When the path that ran was Claude-fallback AND `rawVacancies.length === 0`, the scan is now marked `status: 'completed_partial'` with `failureReason: 'claude_fallback_failed'`, AND `markDistrictScanFailure` is invoked instead of `markDistrictScanSuccess`. This means:
+
+- The metric reflects reality (the bucket fills with the dominant failure mode).
+- These districts now accrue `vacancyConsecutiveFailures` and become eligible for the future failure-counter-reset PR.
+- Effective tarpit growth rate is unchanged in *truth* — these districts were already silently broken — but is now *visible* in the counter.
+
+This is a small but real behavior change beyond pure logging. It is included intentionally because the alternative — leaving Claude-empty as silent success — defeats the purpose of the taxonomy.
+
+### Part 4 — Cron telemetry
+
+`src/app/api/cron/scan-vacancies/route.ts` adds one query before the existing `Promise.all` block:
+
+```ts
+const tarpitSize = await prisma.district.count({
+  where: { jobBoardUrl: { not: null }, vacancyConsecutiveFailures: { gte: 5 } },
+});
+```
+
+After the batch finishes, the existing JSON response is preserved unchanged. A new structured log line is emitted via `console.log(JSON.stringify({...}))`:
+
+```ts
+{
+  event: "vacancy_cron_summary",
+  batch_id: batchId,
+  total_stale: staleDistricts.length,
+  unique_urls: urlGroups.size,
+  scans_run: batch.length,
+  districts_processed: districtsProcessed,
+  never_scanned_groups_remaining: neverScannedGroupsRemaining,
+  sibling_coverage_created: siblingCoverageCreated,
+  tarpit_size_at_start: tarpitSize,
+  failure_reason_mix: { http_4xx: 1, claude_fallback_failed: 3, ... }
+}
+```
+
+`failure_reason_mix` is computed by re-reading the `failureReason` of each scan in `batch` after `runScan` completes (the existing post-run `findUnique` already reads each row; one extra column is selected).
+
+### Part 5 — Per-scan log
+
+`scan-runner.ts` emits one log line per scan in the existing `finally` block, before `clearTimeout`:
+
+```ts
+{
+  event: "vacancy_scan_outcome",
+  leaid: scan?.district.leaid,
+  platform: detectedPlatform,
+  status: finalStatus,
+  failure_reason: finalFailureReason ?? null,
+  vacancy_count: finalVacancyCount,
+  duration_ms: Date.now() - scanStartMs,
+  was_first_attempt: !hadPriorCompletedScan,
+  consecutive_failures_after: finalConsecutiveFailures
+}
+```
+
+Two additional reads are required:
+
+- `was_first_attempt` — one `prisma.vacancyScan.count` at runner start, scoped to `leaid` and `status: { in: ['completed','completed_partial'] }`. Captured into a hoisted variable so it's available from the `finally` block.
+- `consecutive_failures_after` — `markDistrictScanFailure` already returns the new counter (Part 6 update). `markDistrictScanSuccess` is updated symmetrically to return `0` (its post-update value is always 0 by definition). Both helpers' return values are captured into a hoisted variable that the `finally` reads. No extra DB read is needed beyond what those helpers already do.
+
+These are cheap (indexed point reads) and run once per scan.
+
+`scanStartMs` is captured at the top of `runScan` as `Date.now()`. It joins `scan` in the hoist-out-of-try block, alongside `finalStatus`, `finalFailureReason`, `finalVacancyCount`, `finalConsecutiveFailures`, and `hadPriorCompletedScan` — all the fields the `finally` log needs. The hoist is a small ergonomic addition; no logic moves out of the `try`.
+
+### Part 6 — Tarpit admission log
+
+`markDistrictScanFailure` (currently at `scan-runner.ts:20–28`) gains a returned value and one conditional log line:
+
+```ts
+async function markDistrictScanFailure(leaid: string, failureReason: VacancyFailureReason | null) {
+  const updated = await prisma.district.update({
+    where: { leaid },
+    data: {
+      vacancyConsecutiveFailures: { increment: 1 },
+      vacancyLastFailureAt: new Date(),
+    },
+    select: {
+      leaid: true,
+      name: true,
+      jobBoardPlatform: true,
+      jobBoardUrl: true,
+      vacancyConsecutiveFailures: true,
+    },
+  });
+
+  if (updated.vacancyConsecutiveFailures === 5) {
+    console.log(JSON.stringify({
+      event: "vacancy_tarpit_admission",
+      leaid: updated.leaid,
+      name: updated.name,
+      platform: updated.jobBoardPlatform,
+      job_board_url: updated.jobBoardUrl,
+      last_failure_reason: failureReason,
+    }));
+  }
+
+  return updated.vacancyConsecutiveFailures;
+}
+```
+
+The strict equality (`=== 5`) ensures the event fires exactly once per district per admission — increments past 5 (which shouldn't happen since the tarpit excludes from the cron pool, but could theoretically happen if a district is enqueued some other way) don't re-fire it.
+
+### Part 7 — Stats endpoint additions
+
+`src/app/api/admin/vacancy-scan-stats/route.ts` adds three fields to its response:
+
+```ts
+{
+  // ...existing fields preserved
+  tarpit: {
+    total: number,
+    byPlatform: { platform: string, count: number }[]  // top 4 by count
+  },
+  adjustedCoveragePct: number,  // scanned / max(1, totalDistrictsWithUrl - tarpit.total)
+  topFailureReason7d: { reason: string, pct: number } | null
+}
+```
+
+Three new prisma calls added to the existing `Promise.all`:
+
+```ts
+prisma.district.count({
+  where: { jobBoardUrl: { not: null }, vacancyConsecutiveFailures: { gte: 5 } },
+}),
+prisma.district.groupBy({
+  by: ["jobBoardPlatform"],
+  where: { jobBoardUrl: { not: null }, vacancyConsecutiveFailures: { gte: 5 } },
+  _count: true,
+}),  // null jobBoardPlatform mapped to "unknown" in the response,
+     // matching the existing platform-mix line's handling at route.ts:81.
+prisma.vacancyScan.groupBy({
+  by: ["failureReason"],
+  where: {
+    status: { in: ["failed", "completed_partial"] },
+    completedAt: { gte: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000) },
+    failureReason: { not: null },
+  },
+  _count: true,
+}),
+```
+
+`adjustedCoveragePct` uses `Math.max(1, denominator)` to handle the edge case where every URL-bearing district is in the tarpit (no division by zero). When the tarpit is empty, `adjustedCoveragePct === coveragePct`.
+
+`topFailureReason7d` is computed by sorting the third query's results by `_count` descending, taking the top entry, and computing the percentage against the total of all 7d failures. Returns `null` if there are no failures in the window.
+
+### Part 8 — Admin card additions
+
+`VacancyScanCard.tsx` adopts a two-row stat layout. Existing row 1 is preserved exactly:
+
+```
+Open Vacancies | Districts | Coverage | Scans (7d)
+```
+
+New row 2 (3 columns, full-width):
+
+```
+Tarpit | Adjusted Coverage | Top Failure Reason
+```
+
+Each new stat uses the existing `<Stat>` component with its `label` / `value` / `sub` props:
+
+- **Tarpit** — `value` = `data.tarpit.total.toLocaleString()`, `sub` = top-2 platforms joined like `"claude (38), unknown (12)"`. `alert` = true when total > 0.
+- **Adjusted Coverage** — `value` = `${data.adjustedCoveragePct}%`, `sub` = `"of reachable pool"`.
+- **Top Failure Reason** — `value` = `data.topFailureReason7d?.reason ?? "—"`, `sub` = `data.topFailureReason7d ? `${pct}% of failures (7d)` : "no failures"`.
+
+The existing health-dot logic gains one trigger: red also when `tarpit.total / totalDistrictsWithUrl > 0.30`. This ensures a glance at the dot reflects reality even before the user scans the row 2 numbers.
+
+The existing platform breakdown line and progress bar remain unchanged.
+
+Tailwind tokens follow the existing card — `text-[#403770]` for values, `text-[#8A80A8]` for labels, `text-[#A69DC0]` for subs, `text-[#F37167]` when `alert`. No new tokens.
+
+### Part 9 — Historical backfill
+
+One-time script: `scripts/backfill-vacancy-failure-reasons.ts`. Reads all rows where `status IN ('failed', 'completed_partial') AND failureReason IS NULL`, runs each `errorMessage` through `categorizeFailure({ errorMessage, context: "thrown_error" })`, and writes back in batches of 500. The script is idempotent (the `failureReason IS NULL` filter ensures re-runs are no-ops), logs progress every batch, and prints a final summary keyed by bucket so the result of the backfill is verifiable at a glance.
+
+The script uses the same `categorizeFailure` helper as the runtime path — categorization logic exists in exactly one place. Historical `errorMessage` wordings produced by today's code are categorized via the regex chain documented in Part 3:
+
+- `"Scan timed out"` and `"Scan timed out (stale recovery)"` → `scan_timeout`
+- `"District has no job board URL"` → `no_job_board_url`
+- `"Skipped: statewide board returned ..."` → `statewide_unattributable`
+- `"Skipped: ... regional aggregator ..."` → `enrollment_ratio_skip`
+- Anthropic SDK errors → `claude_fallback_failed`
+- 4xx/5xx HTTP errors thrown by `fetch` callers → `http_4xx` / `http_5xx`
+- Network errors → `network_timeout`
+- Anything else → `unknown_error`
+
+The "backfill-only" regex patterns called out in Part 3 (`statewide board returned`, `regional aggregator`, `no job board url`) exist solely to make this backfill possible — at runtime, the corresponding code paths supply explicit `context` and never reach the regex chain.
+
+## Data flow
+
+A scan's failure now flows like this:
+
+1. Scan-runner hits a non-success branch (timeout, exception, statewide-skip, etc.).
+2. The branch builds an `errorMessage` and a known `FailureContext`.
+3. `categorizeFailure({ errorMessage, context })` returns a `VacancyFailureReason`.
+4. The `prisma.vacancyScan.update` call writes both `errorMessage` and `failureReason` in the same transaction.
+5. `markDistrictScanFailure(leaid, failureReason)` increments the counter and, if the new value equals 5, emits `vacancy_tarpit_admission`.
+6. The `finally` block emits `vacancy_scan_outcome` with the categorized reason.
+7. Back in the cron handler, the per-batch summary aggregates each scan's `failureReason` into `failure_reason_mix` and emits `vacancy_cron_summary`.
+
+The admin card pulls all three new stats from the extended endpoint and renders row 2 of the stat grid. The structured logs are searchable in Vercel logs by `event:` key.
+
+## Error handling
+
+- The new prisma queries in the stats endpoint are added to the existing `Promise.all` — any failure is caught by the existing `try/catch` and returns the existing 500 response.
+- `categorizeFailure` is total — every input maps to a bucket, with `unknown_error` as the floor. There is no input that throws.
+- The tarpit-admission log uses strict equality (`=== 5`) so spurious increments past 5 don't re-fire it. If `vacancyConsecutiveFailures` is somehow ever 0 when we increment (it shouldn't be), the increment-then-read still produces a correct value — the log just won't fire until 5 is reached.
+- The backfill script uses transactional batches of 500 with `prisma.$transaction`. A mid-batch failure rolls that batch back; subsequent runs pick up where the failure left off because the `failureReason IS NULL` filter is the resumption signal.
+
+## Testing strategy
+
+- **`failure-reasons.test.ts`** (new) — exhaustive table-driven tests for `categorizeFailure`. Every bucket has at least three positive cases and the catch-all has its own coverage. The string-match path is tested via a fixture of historical `errorMessage` strings (collected from a quick prod-DB sample). This file is the foundation; everything else relies on it.
+- **`scan-runner.test.ts`** (extend existing) — assert that `failureReason` is written at each of the five failure sites and at the new B1 Claude-empty path. Assert that `markDistrictScanFailure` returns the new counter and that the tarpit-admission log is emitted exactly when the post-increment value is 5.
+- **`vacancy-scan-stats/__tests__/route.test.ts`** (new) — mock prisma, assert the three new response fields are computed correctly. Edge cases: zero tarpit (adjusted = base coverage), every district in tarpit (adjusted denominator floors at 1), zero failures in 7d (`topFailureReason7d === null`).
+- **Cron summary log shape** — one happy-path test in `scan-vacancies` route tests that asserts the `vacancy_cron_summary` event is emitted with the expected JSON keys and types after a batch run.
+- **Admin card** — Vitest+RTL test of `VacancyScanCard` with mocked stats covering: empty tarpit (no alert dot), populated tarpit (alert dot, sub-line shows top platforms), null `topFailureReason7d` (renders "—"), populated reason (renders bucket name and percentage). Co-located in `src/features/admin/components/__tests__/`.
+- **Backfill script** — manual test only. The script's effect is observable in DB state and in its summary output; a unit test would mostly re-test `categorizeFailure`.
+
+## Out of scope (deliberate)
+
+- **Failure-counter reset job.** A periodic or manual mechanism to clear `vacancyConsecutiveFailures` on tarpit residents so they get retried. Separate brainstorm; this work makes that future job's targeting trivial via the new column.
+- **Claude fallback regression fix.** The 2026-04-23 issue itself. Separate effort; the new metrics will tell us when it's resolved.
+- **Dedicated `/admin/vacancy-diagnostics` page.** Drillable tarpit roster, per-platform coverage, full failure-reason histogram. May graduate from this card if the row-2 numbers consistently point us toward needing a deeper view.
+- **Coverage delta over 7d.** "+N districts this week" stat. Useful but redundant with the existing 7-day scan count for an instrumentation pass.
+- **Never-scanned pool size as a separate stat.** Largely redundant with the tarpit number once the future reset job exists; if it doesn't, "never-scanned but not in tarpit" is a small population and the card is already adding three numbers.
+- **Per-parser timing breakdown.** Possible future log fields; not included because timing isn't currently a pain point and the per-scan event is already wide.
+
+## Migration plan
+
+1. Apply the additive Prisma migration. Existing rows get `failureReason = NULL`.
+2. Deploy the code changes (helper, scan-runner wiring, cron telemetry, stats endpoint, admin card).
+3. Run the backfill script once. Verify the summary output makes sense before committing the result (the script can be run in dry-run mode by setting `DRY_RUN=true` to print summary without writing).
+4. Verify the admin card now shows non-zero values in row 2 within one cron cycle.
+
+No reverse-migration path is required — the column is nullable and additive, so a rollback is just deploying the prior code with the column unused.

--- a/prisma/migrations/20260503210355_add_vacancy_failure_reason/migration.sql
+++ b/prisma/migrations/20260503210355_add_vacancy_failure_reason/migration.sql
@@ -1,5 +1,12 @@
--- CreateEnum
-CREATE TYPE "vacancy_failure_reason" AS ENUM ('http_4xx', 'http_5xx', 'network_timeout', 'scan_timeout', 'parser_empty', 'claude_fallback_failed', 'statewide_unattributable', 'enrollment_ratio_skip', 'no_job_board_url', 'unknown_error');
+-- CreateEnum (idempotent — Postgres has no CREATE TYPE IF NOT EXISTS for enums)
+DO $$ BEGIN
+  CREATE TYPE "vacancy_failure_reason" AS ENUM (
+    'http_4xx', 'http_5xx', 'network_timeout', 'scan_timeout', 'parser_empty',
+    'claude_fallback_failed', 'statewide_unattributable', 'enrollment_ratio_skip',
+    'no_job_board_url', 'unknown_error'
+  );
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
 
 -- AlterTable
 ALTER TABLE "vacancy_scans" ADD COLUMN "failure_reason" "vacancy_failure_reason";

--- a/prisma/migrations/20260503210355_add_vacancy_failure_reason/migration.sql
+++ b/prisma/migrations/20260503210355_add_vacancy_failure_reason/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "vacancy_failure_reason" AS ENUM ('http_4xx', 'http_5xx', 'network_timeout', 'scan_timeout', 'parser_empty', 'claude_fallback_failed', 'statewide_unattributable', 'enrollment_ratio_skip', 'no_job_board_url', 'unknown_error');
+
+-- AlterTable
+ALTER TABLE "vacancy_scans" ADD COLUMN "failure_reason" "vacancy_failure_reason";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -867,6 +867,21 @@ enum UserRole {
   @@map("user_role")
 }
 
+enum VacancyFailureReason {
+  http_4xx
+  http_5xx
+  network_timeout
+  scan_timeout
+  parser_empty
+  claude_fallback_failed
+  statewide_unattributable
+  enrollment_ratio_skip
+  no_job_board_url
+  unknown_error
+
+  @@map("vacancy_failure_reason")
+}
+
 // ===== User Profile & Goals =====
 // User profile - synced from Supabase Auth on login
 // Stores user preferences and tracks whether they've completed the initial setup wizard
@@ -1483,6 +1498,7 @@ model VacancyScan {
   startedAt             DateTime  @default(now()) @map("started_at")
   completedAt           DateTime? @map("completed_at")
   errorMessage          String?   @map("error_message") @db.Text
+  failureReason         VacancyFailureReason? @map("failure_reason")
   triggeredBy           String    @map("triggered_by") @db.VarChar(100)
   batchId               String?   @map("batch_id") @db.VarChar(50)
 

--- a/scripts/backfill-vacancy-failure-reasons.ts
+++ b/scripts/backfill-vacancy-failure-reasons.ts
@@ -7,6 +7,9 @@
  *
  * Idempotent — safe to re-run; the WHERE clause skips already-categorized rows.
  */
+import { config } from "dotenv";
+config();
+
 import prisma from "@/lib/prisma";
 import { categorizeFailure } from "@/features/vacancies/lib/failure-reasons";
 import type { VacancyFailureReason } from "@prisma/client";
@@ -72,8 +75,8 @@ async function main() {
 }
 
 main()
-  .then(() => process.exit(0))
   .catch((err) => {
     console.error("[backfill] failed:", err);
     process.exit(1);
-  });
+  })
+  .finally(() => prisma.$disconnect());

--- a/scripts/backfill-vacancy-failure-reasons.ts
+++ b/scripts/backfill-vacancy-failure-reasons.ts
@@ -1,0 +1,79 @@
+/**
+ * One-time backfill: categorize historical VacancyScan failures into the
+ * new failureReason column.
+ *
+ * Run:    npx tsx scripts/backfill-vacancy-failure-reasons.ts
+ * Dry:    DRY_RUN=true npx tsx scripts/backfill-vacancy-failure-reasons.ts
+ *
+ * Idempotent — safe to re-run; the WHERE clause skips already-categorized rows.
+ */
+import prisma from "@/lib/prisma";
+import { categorizeFailure } from "@/features/vacancies/lib/failure-reasons";
+import type { VacancyFailureReason } from "@prisma/client";
+
+const BATCH_SIZE = 500;
+const DRY_RUN = process.env.DRY_RUN === "true";
+
+async function main() {
+  const counts: Record<string, number> = {};
+  let totalProcessed = 0;
+  let cursor: string | undefined = undefined;
+
+  for (;;) {
+    const batch = await prisma.vacancyScan.findMany({
+      where: {
+        status: { in: ["failed", "completed_partial"] },
+        failureReason: null,
+      },
+      select: { id: true, errorMessage: true },
+      orderBy: { id: "asc" },
+      ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+      take: BATCH_SIZE,
+    });
+
+    if (batch.length === 0) break;
+
+    const updates: { id: string; reason: VacancyFailureReason }[] = batch.map((row) => {
+      const reason = categorizeFailure({
+        errorMessage: row.errorMessage ?? "",
+        context: "thrown_error",
+      });
+      counts[reason] = (counts[reason] ?? 0) + 1;
+      return { id: row.id, reason };
+    });
+
+    if (!DRY_RUN) {
+      await prisma.$transaction(
+        updates.map((u) =>
+          prisma.vacancyScan.update({
+            where: { id: u.id },
+            data: { failureReason: u.reason },
+          }),
+        ),
+      );
+    }
+
+    totalProcessed += batch.length;
+    cursor = batch[batch.length - 1]!.id;
+    console.log(
+      `[backfill] processed ${totalProcessed} rows so far${DRY_RUN ? " (dry run)" : ""}`,
+    );
+  }
+
+  console.log("\n=== Backfill summary ===");
+  console.log(`Mode: ${DRY_RUN ? "DRY RUN (no writes)" : "LIVE"}`);
+  console.log(`Total rows processed: ${totalProcessed}`);
+  console.log("Bucket counts:");
+  for (const [reason, count] of Object.entries(counts).sort(
+    ([, a], [, b]) => b - a,
+  )) {
+    console.log(`  ${reason.padEnd(28)} ${count}`);
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error("[backfill] failed:", err);
+    process.exit(1);
+  });

--- a/src/app/api/admin/vacancy-scan-stats/__tests__/route.test.ts
+++ b/src/app/api/admin/vacancy-scan-stats/__tests__/route.test.ts
@@ -45,9 +45,7 @@ beforeEach(() => {
 function setupHappyPath() {
   vacancyCount.mockResolvedValueOnce(120).mockResolvedValueOnce(100); // total, verified
   vacancyGroupBy.mockResolvedValueOnce([{ leaid: "1" }, { leaid: "2" }]); // districts with vacancies
-  districtCount
-    .mockResolvedValueOnce(1000) // totalDistrictsWithUrl
-    .mockResolvedValueOnce(50); // tarpit total
+  districtCount.mockResolvedValueOnce(1000); // totalDistrictsWithUrl (tarpit derived from groupBy)
   vacancyScanCount.mockResolvedValueOnce(60).mockResolvedValueOnce(2); // 7d scans, 24h failures
   vacancyScanFindFirst.mockResolvedValueOnce({
     completedAt: new Date("2026-05-03T12:00:00Z"),
@@ -65,10 +63,11 @@ function setupHappyPath() {
       { failureReason: "claude_fallback_failed", _count: 18 },
       { failureReason: "scan_timeout", _count: 6 },
     ]); // 7d failure-reason mix
+  // Tarpit by platform sums to 50 (was previously a separate count mock).
   districtGroupBy.mockResolvedValueOnce([
     { jobBoardPlatform: "claude", _count: 38 },
     { jobBoardPlatform: null, _count: 12 },
-  ]); // tarpit by platform
+  ]);
 }
 
 describe("GET /api/admin/vacancy-scan-stats — new fields", () => {
@@ -95,7 +94,7 @@ describe("GET /api/admin/vacancy-scan-stats — new fields", () => {
   it("returns adjustedCoveragePct == coveragePct when tarpit is empty", async () => {
     vacancyCount.mockResolvedValueOnce(0).mockResolvedValueOnce(0);
     vacancyGroupBy.mockResolvedValueOnce([]);
-    districtCount.mockResolvedValueOnce(100).mockResolvedValueOnce(0);
+    districtCount.mockResolvedValueOnce(100);
     vacancyScanCount.mockResolvedValueOnce(0).mockResolvedValueOnce(0);
     vacancyScanFindFirst.mockResolvedValueOnce(null);
     vacancyScanGroupBy
@@ -116,18 +115,46 @@ describe("GET /api/admin/vacancy-scan-stats — new fields", () => {
   it("floors the adjusted denominator at 1 when every district is tarpitted", async () => {
     vacancyCount.mockResolvedValueOnce(0).mockResolvedValueOnce(0);
     vacancyGroupBy.mockResolvedValueOnce([]);
-    districtCount.mockResolvedValueOnce(50).mockResolvedValueOnce(50);
+    districtCount.mockResolvedValueOnce(50);
     vacancyScanCount.mockResolvedValueOnce(0).mockResolvedValueOnce(0);
     vacancyScanFindFirst.mockResolvedValueOnce(null);
     vacancyScanGroupBy
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([]);
-    districtGroupBy.mockResolvedValueOnce([]);
+    // Whole pool is in the tarpit (sums to 50, matches totalWithUrl).
+    districtGroupBy.mockResolvedValueOnce([
+      { jobBoardPlatform: "applitrack", _count: 50 },
+    ]);
 
     const res = await GET();
     const body = await res.json();
     // 0 / max(1, 0) = 0%
     expect(body.adjustedCoveragePct).toBe(0);
+    expect(body.tarpit.total).toBe(50);
+  });
+
+  it("clamps adjustedCoveragePct at 100 when scan history exceeds reachable pool", async () => {
+    // Long-running system: 1000 districts with URL, 900 in the tarpit, but
+    // 850 districts have at least one historical successful scan. Naive
+    // formula: 850 / max(1, 1000-900) = 850/100 = 850%. Should clamp to 100.
+    vacancyCount.mockResolvedValueOnce(0).mockResolvedValueOnce(0);
+    vacancyGroupBy.mockResolvedValueOnce([]);
+    districtCount.mockResolvedValueOnce(1000);
+    vacancyScanCount.mockResolvedValueOnce(0).mockResolvedValueOnce(0);
+    vacancyScanFindFirst.mockResolvedValueOnce(null);
+    vacancyScanGroupBy
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(
+        Array.from({ length: 850 }, (_, i) => ({ leaid: String(i) })),
+      )
+      .mockResolvedValueOnce([]);
+    districtGroupBy.mockResolvedValueOnce([
+      { jobBoardPlatform: "applitrack", _count: 900 },
+    ]);
+
+    const res = await GET();
+    const body = await res.json();
+    expect(body.adjustedCoveragePct).toBe(100);
   });
 });

--- a/src/app/api/admin/vacancy-scan-stats/__tests__/route.test.ts
+++ b/src/app/api/admin/vacancy-scan-stats/__tests__/route.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const districtCount = vi.fn();
+const districtGroupBy = vi.fn();
+const vacancyCount = vi.fn();
+const vacancyGroupBy = vi.fn();
+const vacancyScanCount = vi.fn();
+const vacancyScanGroupBy = vi.fn();
+const vacancyScanFindFirst = vi.fn();
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    district: {
+      count: (...args: unknown[]) => districtCount(...args),
+      groupBy: (...args: unknown[]) => districtGroupBy(...args),
+    },
+    vacancy: {
+      count: (...args: unknown[]) => vacancyCount(...args),
+      groupBy: (...args: unknown[]) => vacancyGroupBy(...args),
+    },
+    vacancyScan: {
+      count: (...args: unknown[]) => vacancyScanCount(...args),
+      groupBy: (...args: unknown[]) => vacancyScanGroupBy(...args),
+      findFirst: (...args: unknown[]) => vacancyScanFindFirst(...args),
+    },
+  },
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  getUser: async () => ({ id: "user-1" }),
+}));
+
+import { GET } from "../route";
+
+beforeEach(() => {
+  districtCount.mockReset();
+  districtGroupBy.mockReset();
+  vacancyCount.mockReset();
+  vacancyGroupBy.mockReset();
+  vacancyScanCount.mockReset();
+  vacancyScanGroupBy.mockReset();
+  vacancyScanFindFirst.mockReset();
+});
+
+function setupHappyPath() {
+  vacancyCount.mockResolvedValueOnce(120).mockResolvedValueOnce(100); // total, verified
+  vacancyGroupBy.mockResolvedValueOnce([{ leaid: "1" }, { leaid: "2" }]); // districts with vacancies
+  districtCount
+    .mockResolvedValueOnce(1000) // totalDistrictsWithUrl
+    .mockResolvedValueOnce(50); // tarpit total
+  vacancyScanCount.mockResolvedValueOnce(60).mockResolvedValueOnce(2); // 7d scans, 24h failures
+  vacancyScanFindFirst.mockResolvedValueOnce({
+    completedAt: new Date("2026-05-03T12:00:00Z"),
+    platform: "applitrack",
+    districtsMatched: 0,
+  });
+  vacancyScanGroupBy
+    .mockResolvedValueOnce([{ platform: "olas", _count: 10 }]) // by platform
+    .mockResolvedValueOnce([
+      { leaid: "1" },
+      { leaid: "2" },
+      { leaid: "3" },
+    ]) // scanned districts
+    .mockResolvedValueOnce([
+      { failureReason: "claude_fallback_failed", _count: 18 },
+      { failureReason: "scan_timeout", _count: 6 },
+    ]); // 7d failure-reason mix
+  districtGroupBy.mockResolvedValueOnce([
+    { jobBoardPlatform: "claude", _count: 38 },
+    { jobBoardPlatform: null, _count: 12 },
+  ]); // tarpit by platform
+}
+
+describe("GET /api/admin/vacancy-scan-stats — new fields", () => {
+  it("returns tarpit, adjustedCoveragePct, and topFailureReason7d", async () => {
+    setupHappyPath();
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.tarpit).toEqual({
+      total: 50,
+      byPlatform: [
+        { platform: "claude", count: 38 },
+        { platform: "unknown", count: 12 },
+      ],
+    });
+    // adjusted = scannedDistricts(3) / (totalWithUrl(1000) - tarpit(50)) = 3/950 = 0.32% rounded
+    expect(body.adjustedCoveragePct).toBe(0);
+    expect(body.topFailureReason7d).toEqual({
+      reason: "claude_fallback_failed",
+      pct: 75, // 18 / (18 + 6) = 0.75
+    });
+  });
+
+  it("returns adjustedCoveragePct == coveragePct when tarpit is empty", async () => {
+    vacancyCount.mockResolvedValueOnce(0).mockResolvedValueOnce(0);
+    vacancyGroupBy.mockResolvedValueOnce([]);
+    districtCount.mockResolvedValueOnce(100).mockResolvedValueOnce(0);
+    vacancyScanCount.mockResolvedValueOnce(0).mockResolvedValueOnce(0);
+    vacancyScanFindFirst.mockResolvedValueOnce(null);
+    vacancyScanGroupBy
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ leaid: "1" }]) // 1 scanned
+      .mockResolvedValueOnce([]);
+    districtGroupBy.mockResolvedValueOnce([]);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.coveragePct).toBe(1);
+    expect(body.adjustedCoveragePct).toBe(1);
+    expect(body.topFailureReason7d).toBeNull();
+    expect(body.tarpit).toEqual({ total: 0, byPlatform: [] });
+  });
+
+  it("floors the adjusted denominator at 1 when every district is tarpitted", async () => {
+    vacancyCount.mockResolvedValueOnce(0).mockResolvedValueOnce(0);
+    vacancyGroupBy.mockResolvedValueOnce([]);
+    districtCount.mockResolvedValueOnce(50).mockResolvedValueOnce(50);
+    vacancyScanCount.mockResolvedValueOnce(0).mockResolvedValueOnce(0);
+    vacancyScanFindFirst.mockResolvedValueOnce(null);
+    vacancyScanGroupBy
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    districtGroupBy.mockResolvedValueOnce([]);
+
+    const res = await GET();
+    const body = await res.json();
+    // 0 / max(1, 0) = 0%
+    expect(body.adjustedCoveragePct).toBe(0);
+  });
+});

--- a/src/app/api/admin/vacancy-scan-stats/route.ts
+++ b/src/app/api/admin/vacancy-scan-stats/route.ts
@@ -16,24 +16,33 @@ export async function GET() {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
+    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+
     const [
       totalVacancies,
       verifiedVacancies,
       districtsWithVacancies,
       totalDistrictsWithUrl,
+      tarpitTotal,
       recentScans,
       failedScans24h,
       lastScan,
       byPlatform,
+      scannedDistricts,
+      failureReasonGroups,
+      tarpitByPlatformRaw,
     ] = await Promise.all([
       prisma.vacancy.count({ where: { status: "open" } }),
       prisma.vacancy.count({ where: { status: "open", districtVerified: true } }),
       prisma.vacancy.groupBy({ by: ["leaid"], where: { status: "open", districtVerified: true } }),
       prisma.district.count({ where: { jobBoardUrl: { not: null } } }),
+      prisma.district.count({
+        where: { jobBoardUrl: { not: null }, vacancyConsecutiveFailures: { gte: 5 } },
+      }),
       prisma.vacancyScan.count({
         where: {
           status: { in: ["completed", "completed_partial"] },
-          completedAt: { gte: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000) },
+          completedAt: { gte: sevenDaysAgo },
         },
       }),
       prisma.vacancyScan.count({
@@ -51,21 +60,57 @@ export async function GET() {
         by: ["platform"],
         where: {
           status: { in: ["completed", "completed_partial"] },
-          completedAt: { gte: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000) },
+          completedAt: { gte: sevenDaysAgo },
         },
+        _count: true,
+      }),
+      prisma.vacancyScan.groupBy({
+        by: ["leaid"],
+        where: { status: { in: ["completed", "completed_partial"] } },
+      }),
+      prisma.vacancyScan.groupBy({
+        by: ["failureReason"],
+        where: {
+          status: { in: ["failed", "completed_partial"] },
+          completedAt: { gte: sevenDaysAgo },
+          failureReason: { not: null },
+        },
+        _count: true,
+      }),
+      prisma.district.groupBy({
+        by: ["jobBoardPlatform"],
+        where: { jobBoardUrl: { not: null }, vacancyConsecutiveFailures: { gte: 5 } },
         _count: true,
       }),
     ]);
 
-    // Districts scanned (unique leaids with a completed scan)
-    const scannedDistricts = await prisma.vacancyScan.groupBy({
-      by: ["leaid"],
-      where: { status: { in: ["completed", "completed_partial"] } },
-    });
-
     const coveragePct = totalDistrictsWithUrl > 0
       ? Math.round((scannedDistricts.length / totalDistrictsWithUrl) * 100)
       : 0;
+
+    const adjustedDenominator = Math.max(1, totalDistrictsWithUrl - tarpitTotal);
+    const adjustedCoveragePct = Math.round(
+      (scannedDistricts.length / adjustedDenominator) * 100,
+    );
+
+    const tarpitByPlatform = tarpitByPlatformRaw
+      .map((r) => ({
+        platform: r.jobBoardPlatform || "unknown",
+        count: r._count,
+      }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 4);
+
+    const totalFailures7d = failureReasonGroups.reduce((s, g) => s + g._count, 0);
+    const topGroup = failureReasonGroups
+      .slice()
+      .sort((a, b) => b._count - a._count)[0];
+    const topFailureReason7d = topGroup && totalFailures7d > 0
+      ? {
+          reason: topGroup.failureReason!,
+          pct: Math.round((topGroup._count / totalFailures7d) * 100),
+        }
+      : null;
 
     return NextResponse.json({
       totalVacancies,
@@ -74,6 +119,12 @@ export async function GET() {
       totalDistrictsWithUrl,
       districtsScanned: scannedDistricts.length,
       coveragePct,
+      adjustedCoveragePct,
+      tarpit: {
+        total: tarpitTotal,
+        byPlatform: tarpitByPlatform,
+      },
+      topFailureReason7d,
       scansLast7d: recentScans,
       failedLast24h: failedScans24h,
       lastScanAt: lastScan?.completedAt?.toISOString() ?? null,

--- a/src/app/api/admin/vacancy-scan-stats/route.ts
+++ b/src/app/api/admin/vacancy-scan-stats/route.ts
@@ -23,7 +23,6 @@ export async function GET() {
       verifiedVacancies,
       districtsWithVacancies,
       totalDistrictsWithUrl,
-      tarpitTotal,
       recentScans,
       failedScans24h,
       lastScan,
@@ -36,9 +35,6 @@ export async function GET() {
       prisma.vacancy.count({ where: { status: "open", districtVerified: true } }),
       prisma.vacancy.groupBy({ by: ["leaid"], where: { status: "open", districtVerified: true } }),
       prisma.district.count({ where: { jobBoardUrl: { not: null } } }),
-      prisma.district.count({
-        where: { jobBoardUrl: { not: null }, vacancyConsecutiveFailures: { gte: 5 } },
-      }),
       prisma.vacancyScan.count({
         where: {
           status: { in: ["completed", "completed_partial"] },
@@ -84,13 +80,20 @@ export async function GET() {
       }),
     ]);
 
+    // Derive tarpit total from the per-platform groupBy to avoid a redundant count query.
+    const tarpitTotal = tarpitByPlatformRaw.reduce((s, r) => s + r._count, 0);
+
     const coveragePct = totalDistrictsWithUrl > 0
       ? Math.round((scannedDistricts.length / totalDistrictsWithUrl) * 100)
       : 0;
 
+    // Clamp at 100: if scannedDistricts (all-time) exceeds the current
+    // reachable pool (totalWithUrl - tarpit), the ratio could exceed 1.0
+    // when the tarpit grows faster than new districts get added.
     const adjustedDenominator = Math.max(1, totalDistrictsWithUrl - tarpitTotal);
-    const adjustedCoveragePct = Math.round(
-      (scannedDistricts.length / adjustedDenominator) * 100,
+    const adjustedCoveragePct = Math.min(
+      100,
+      Math.round((scannedDistricts.length / adjustedDenominator) * 100),
     );
 
     const tarpitByPlatform = tarpitByPlatformRaw

--- a/src/app/api/cron/scan-vacancies/route.ts
+++ b/src/app/api/cron/scan-vacancies/route.ts
@@ -50,6 +50,13 @@ export async function GET(request: NextRequest) {
     const staleDate = new Date();
     staleDate.setDate(staleDate.getDate() - staleDays);
 
+    const tarpitSize = await prisma.district.count({
+      where: {
+        jobBoardUrl: { not: null },
+        vacancyConsecutiveFailures: { gte: 5 },
+      },
+    });
+
     // Warm shared job-board cache before grouping
     await loadSharedJobBoardUrls();
 
@@ -149,7 +156,13 @@ export async function GET(request: NextRequest) {
 
     // Run scans in parallel with capped concurrency
     const batchId = crypto.randomUUID();
-    const results: { leaid: string; name: string; status: string; statewide: boolean }[] = [];
+    const results: {
+      leaid: string;
+      name: string;
+      status: string;
+      failureReason: string | null;
+      statewide: boolean;
+    }[] = [];
 
     const batch = orderedGroups.slice(0, SCANS_PER_RUN);
     const queue = new PQueue({ concurrency: CONCURRENCY });
@@ -178,7 +191,13 @@ export async function GET(request: NextRequest) {
 
         const result = await prisma.vacancyScan.findUnique({
           where: { id: scan.id },
-          select: { status: true, platform: true, startedAt: true, completedAt: true },
+          select: {
+            status: true,
+            platform: true,
+            startedAt: true,
+            completedAt: true,
+            failureReason: true,
+          },
         });
 
         const isStatewide = isStatewideBoard(group.platform, group.url);
@@ -203,6 +222,7 @@ export async function GET(request: NextRequest) {
           leaid: representative.leaid,
           name: representative.name,
           status: result?.status ?? "unknown",
+          failureReason: result?.failureReason ?? null,
           statewide: isStatewide,
         });
       })
@@ -217,6 +237,26 @@ export async function GET(request: NextRequest) {
     const neverScannedGroupsRemaining = orderedGroups
       .slice(batch.length)
       .filter((g) => g.hasNeverScanned).length;
+
+    const failureReasonMix = results.reduce<Record<string, number>>((acc, r) => {
+      if (r.failureReason) acc[r.failureReason] = (acc[r.failureReason] ?? 0) + 1;
+      return acc;
+    }, {});
+
+    console.log(
+      JSON.stringify({
+        event: "vacancy_cron_summary",
+        batch_id: batchId,
+        total_stale: staleDistricts.length,
+        unique_urls: urlGroups.size,
+        scans_run: batch.length,
+        districts_processed: districtsProcessed,
+        never_scanned_groups_remaining: neverScannedGroupsRemaining,
+        sibling_coverage_created: siblingCoverageCreated,
+        tarpit_size_at_start: tarpitSize,
+        failure_reason_mix: failureReasonMix,
+      }),
+    );
 
     return NextResponse.json({
       batchId,

--- a/src/app/api/cron/scan-vacancies/route.ts
+++ b/src/app/api/cron/scan-vacancies/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import PQueue from "p-queue";
+import type { VacancyFailureReason } from "@prisma/client";
 import prisma from "@/lib/prisma";
 import { detectPlatform, isStatewideBoard, loadSharedJobBoardUrls, normalizeJobBoardKey } from "@/features/vacancies/lib/platform-detector";
 import { runScan } from "@/features/vacancies/lib/scan-runner";
@@ -160,7 +161,7 @@ export async function GET(request: NextRequest) {
       leaid: string;
       name: string;
       status: string;
-      failureReason: string | null;
+      failureReason: VacancyFailureReason | null;
       statewide: boolean;
     }[] = [];
 

--- a/src/features/admin/components/VacancyScanCard.tsx
+++ b/src/features/admin/components/VacancyScanCard.tsx
@@ -176,13 +176,13 @@ function Stat({
   alert?: boolean;
 }) {
   return (
-    <div>
-      <div className="text-[11px] text-[#8A80A8] font-medium uppercase tracking-wider">
+    <div className="min-w-0">
+      <div className="text-[11px] text-[#8A80A8] font-medium uppercase tracking-wider whitespace-nowrap">
         {label}
       </div>
-      <div className="text-lg font-bold text-[#403770] mt-0.5">{value}</div>
+      <div className="text-lg font-bold text-[#403770] mt-0.5 truncate">{value}</div>
       {sub && (
-        <div className={`text-[11px] mt-0.5 ${alert ? "text-[#F37167]" : "text-[#A69DC0]"}`}>
+        <div className={`text-[11px] mt-0.5 truncate ${alert ? "text-[#F37167]" : "text-[#A69DC0]"}`}>
           {sub}
         </div>
       )}

--- a/src/features/admin/components/VacancyScanCard.tsx
+++ b/src/features/admin/components/VacancyScanCard.tsx
@@ -9,6 +9,12 @@ interface VacancyScanStats {
   totalDistrictsWithUrl: number;
   districtsScanned: number;
   coveragePct: number;
+  adjustedCoveragePct: number;
+  tarpit: {
+    total: number;
+    byPlatform: { platform: string; count: number }[];
+  };
+  topFailureReason7d: { reason: string; pct: number } | null;
   scansLast7d: number;
   failedLast24h: number;
   lastScanAt: string | null;
@@ -47,8 +53,12 @@ export default function VacancyScanCard() {
     );
   }
 
+  const tarpitRatio = data.totalDistrictsWithUrl > 0
+    ? data.tarpit.total / data.totalDistrictsWithUrl
+    : 0;
+
   const healthColor =
-    data.failedLast24h > 5
+    data.failedLast24h > 5 || tarpitRatio > 0.30
       ? "#F37167"
       : data.coveragePct < 10
         ? "#E5A53D"
@@ -86,6 +96,37 @@ export default function VacancyScanCard() {
           value={data.scansLast7d.toLocaleString()}
           sub={data.failedLast24h > 0 ? `${data.failedLast24h} failed (24h)` : "0 failed"}
           alert={data.failedLast24h > 0}
+        />
+      </div>
+
+      {/* Diagnostics row */}
+      <div className="grid grid-cols-3 gap-4">
+        <Stat
+          label="Tarpit"
+          value={data.tarpit.total.toLocaleString()}
+          sub={
+            data.tarpit.total > 0
+              ? data.tarpit.byPlatform
+                  .slice(0, 2)
+                  .map((p) => `${p.platform} (${p.count})`)
+                  .join(", ")
+              : undefined
+          }
+          alert={data.tarpit.total > 0}
+        />
+        <Stat
+          label="Adjusted Coverage"
+          value={`${data.adjustedCoveragePct}%`}
+          sub="of reachable pool"
+        />
+        <Stat
+          label="Top Failure Reason"
+          value={data.topFailureReason7d?.reason ?? "—"}
+          sub={
+            data.topFailureReason7d
+              ? `${data.topFailureReason7d.pct}% of failures (7d)`
+              : "no failures"
+          }
         />
       </div>
 

--- a/src/features/admin/components/__tests__/VacancyScanCard.test.tsx
+++ b/src/features/admin/components/__tests__/VacancyScanCard.test.tsx
@@ -1,13 +1,19 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import VacancyScanCard from "../VacancyScanCard";
 
 const mockFetch = vi.fn();
+let originalFetch: typeof global.fetch;
 
 beforeEach(() => {
+  originalFetch = global.fetch;
   mockFetch.mockReset();
   global.fetch = mockFetch as never;
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
 });
 
 function renderCard() {

--- a/src/features/admin/components/__tests__/VacancyScanCard.test.tsx
+++ b/src/features/admin/components/__tests__/VacancyScanCard.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import VacancyScanCard from "../VacancyScanCard";
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  global.fetch = mockFetch as never;
+});
+
+function renderCard() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <VacancyScanCard />
+    </QueryClientProvider>,
+  );
+}
+
+function mockStats(overrides: Record<string, unknown> = {}) {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({
+      totalVacancies: 100,
+      verifiedVacancies: 95,
+      districtsWithVacancies: 40,
+      totalDistrictsWithUrl: 1000,
+      districtsScanned: 450,
+      coveragePct: 45,
+      adjustedCoveragePct: 47,
+      tarpit: { total: 50, byPlatform: [{ platform: "claude", count: 38 }] },
+      topFailureReason7d: { reason: "claude_fallback_failed", pct: 75 },
+      scansLast7d: 100,
+      failedLast24h: 0,
+      lastScanAt: new Date().toISOString(),
+      byPlatform: [],
+      ...overrides,
+    }),
+  });
+}
+
+describe("VacancyScanCard row 2 — diagnostics", () => {
+  it("renders Tarpit, Adjusted Coverage, and Top Failure Reason", async () => {
+    mockStats();
+    renderCard();
+
+    expect(await screen.findByText("Tarpit")).toBeInTheDocument();
+    expect(screen.getByText("50")).toBeInTheDocument();
+    expect(screen.getByText(/claude \(38\)/)).toBeInTheDocument();
+
+    expect(screen.getByText("Adjusted Coverage")).toBeInTheDocument();
+    expect(screen.getByText("47%")).toBeInTheDocument();
+
+    expect(screen.getByText("Top Failure Reason")).toBeInTheDocument();
+    expect(screen.getByText("claude_fallback_failed")).toBeInTheDocument();
+    expect(screen.getByText("75% of failures (7d)")).toBeInTheDocument();
+  });
+
+  it("renders dash for top failure reason when null", async () => {
+    mockStats({ topFailureReason7d: null });
+    renderCard();
+    await screen.findByText("Top Failure Reason");
+    expect(screen.getByText("—")).toBeInTheDocument();
+    expect(screen.getByText("no failures")).toBeInTheDocument();
+  });
+
+  it("renders no sub-line when tarpit is empty", async () => {
+    mockStats({ tarpit: { total: 0, byPlatform: [] } });
+    renderCard();
+    expect(await screen.findByText("Tarpit")).toBeInTheDocument();
+    expect(screen.getByText("0")).toBeInTheDocument();
+    // platform sub-line should not appear when total is 0
+    expect(screen.queryByText(/claude \(/)).toBeNull();
+  });
+});

--- a/src/features/vacancies/lib/__tests__/failure-reasons.test.ts
+++ b/src/features/vacancies/lib/__tests__/failure-reasons.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { categorizeFailure } from "../failure-reasons";
+
+describe("categorizeFailure — explicit context", () => {
+  it.each([
+    ["no_job_board_url", "no_job_board_url"],
+    ["scan_timeout", "scan_timeout"],
+    ["statewide_unattributable", "statewide_unattributable"],
+    ["enrollment_ratio_skip", "enrollment_ratio_skip"],
+    ["claude_fallback_empty", "claude_fallback_failed"],
+  ] as const)("context %s -> %s", (context, expected) => {
+    expect(categorizeFailure({ errorMessage: "anything", context })).toBe(expected);
+  });
+});
+
+describe("categorizeFailure — string match (thrown_error)", () => {
+  const cases: Array<[string, string]> = [
+    ["Scan timed out", "scan_timeout"],
+    ["Scan timed out (stale recovery)", "scan_timeout"],
+    ["AbortError: aborted", "scan_timeout"],
+    ["Anthropic API error: 529 overloaded", "claude_fallback_failed"],
+    ["Claude API rate limit exceeded", "claude_fallback_failed"],
+    ["Skipped: statewide board returned 412 vacancies", "statewide_unattributable"],
+    ["Skipped: 200 vacancies looks like a regional aggregator", "enrollment_ratio_skip"],
+    ["District has no job board URL", "no_job_board_url"],
+    ["Request failed with status 404", "http_4xx"],
+    ["403 Forbidden", "http_4xx"],
+    ["Page Not Found", "http_4xx"],
+    ["410 Gone", "http_4xx"],
+    ["Server returned 500", "http_5xx"],
+    ["502 Bad Gateway", "http_5xx"],
+    ["503 Service Unavailable", "http_5xx"],
+    ["fetch failed", "network_timeout"],
+    ["ECONNREFUSED", "network_timeout"],
+    ["getaddrinfo ENOTFOUND example.com", "network_timeout"],
+    ["Some weird error nobody saw before", "unknown_error"],
+    ["", "unknown_error"],
+  ];
+
+  it.each(cases)("%s -> %s", (errorMessage, expected) => {
+    expect(categorizeFailure({ errorMessage, context: "thrown_error" })).toBe(expected);
+  });
+
+  it("defaults to thrown_error when context is omitted", () => {
+    expect(categorizeFailure({ errorMessage: "Scan timed out" })).toBe("scan_timeout");
+  });
+});
+
+describe("categorizeFailure — first-match-wins ordering", () => {
+  it("scan_timeout beats http_4xx when both could match", () => {
+    expect(
+      categorizeFailure({ errorMessage: "Scan timed out: 404", context: "thrown_error" }),
+    ).toBe("scan_timeout");
+  });
+
+  it("claude_fallback_failed beats http_5xx when both could match", () => {
+    expect(
+      categorizeFailure({
+        errorMessage: "Anthropic API error: 503 service unavailable",
+        context: "thrown_error",
+      }),
+    ).toBe("claude_fallback_failed");
+  });
+});

--- a/src/features/vacancies/lib/__tests__/failure-reasons.test.ts
+++ b/src/features/vacancies/lib/__tests__/failure-reasons.test.ts
@@ -62,3 +62,16 @@ describe("categorizeFailure — first-match-wins ordering", () => {
     ).toBe("claude_fallback_failed");
   });
 });
+
+describe("categorizeFailure — bounded patterns reject numeric false-positives", () => {
+  it.each([
+    ["took 500ms to load", "unknown_error"],
+    ["processed 4000 records", "unknown_error"],
+    ["1500 items found", "unknown_error"],
+    ["port 4444 unreachable", "unknown_error"],
+    ["long gone session", "unknown_error"],
+    ["social network failure", "unknown_error"],
+  ] as const)("%s -> %s", (errorMessage, expected) => {
+    expect(categorizeFailure({ errorMessage, context: "thrown_error" })).toBe(expected);
+  });
+});

--- a/src/features/vacancies/lib/__tests__/scan-runner.test.ts
+++ b/src/features/vacancies/lib/__tests__/scan-runner.test.ts
@@ -94,6 +94,19 @@ describe("runScan health-column updates", () => {
     expect(last?.data?.vacancyLastFailureAt).toBeInstanceOf(Date);
   });
 
+  it("on failed: writes failureReason via categorizeFailure", async () => {
+    getParserMock.mockImplementation(() => async () => {
+      throw new Error("Request failed with status 404");
+    });
+
+    await runScan("scan_abc");
+
+    const failedCall = vacancyScanUpdate.mock.calls.find(
+      (c) => (c[0] as any)?.data?.status === "failed",
+    );
+    expect((failedCall?.[0] as any)?.data?.failureReason).toBe("http_4xx");
+  });
+
   it("on no-jobBoardUrl early-return: counts as a failure", async () => {
     vacancyScanFindUnique.mockResolvedValueOnce({
       ...baseScan,

--- a/src/features/vacancies/lib/__tests__/scan-runner.test.ts
+++ b/src/features/vacancies/lib/__tests__/scan-runner.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const districtUpdate = vi.fn();
 const vacancyScanFindUnique = vi.fn();
 const vacancyScanUpdate = vi.fn();
+const vacancyScanCount = vi.fn();
 const getParserMock = vi.fn();
 const parseWithClaudeMock = vi.fn();
 const isStatewideBoardAsyncMock = vi.fn<(...args: unknown[]) => Promise<boolean>>(async () => false);
@@ -19,6 +20,7 @@ vi.mock("@/lib/prisma", () => ({
     vacancyScan: {
       findUnique: (...args: unknown[]) => vacancyScanFindUnique(...args),
       update: (...args: unknown[]) => vacancyScanUpdate(...args),
+      count: (...args: unknown[]) => vacancyScanCount(...args),
     },
   },
 }));
@@ -59,6 +61,7 @@ beforeEach(() => {
   districtUpdate.mockReset().mockResolvedValue({});
   vacancyScanFindUnique.mockReset().mockResolvedValue(baseScan);
   vacancyScanUpdate.mockReset().mockResolvedValue({});
+  vacancyScanCount.mockReset().mockResolvedValue(0); // default: first attempt
   // Default parser: returns 0 vacancies — drives runScan to the success path.
   getParserMock.mockReset().mockImplementation(() => async () => []);
   parseWithClaudeMock.mockReset().mockResolvedValue([]);
@@ -327,4 +330,46 @@ describe("runScan tarpit-admission log", () => {
       consoleLogSpy.mockRestore();
     },
   );
+});
+
+describe("runScan per-scan outcome log", () => {
+  it("emits vacancy_scan_outcome with all required fields", async () => {
+    const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    // Successful scan path
+    getParserMock.mockImplementation(() => async () => []);
+    districtUpdate.mockResolvedValue({
+      leaid: "0100001",
+      name: "Test District",
+      jobBoardPlatform: "applitrack",
+      jobBoardUrl: "https://example.applitrack.com/onlineapp",
+      vacancyConsecutiveFailures: 0,
+    });
+
+    await runScan("scan_abc");
+
+    const outcomeLog = consoleLogSpy.mock.calls
+      .map((args) => {
+        try {
+          return JSON.parse(args[0] as string);
+        } catch {
+          return null;
+        }
+      })
+      .find((p) => p?.event === "vacancy_scan_outcome");
+    expect(outcomeLog).toBeDefined();
+    expect(outcomeLog).toMatchObject({
+      event: "vacancy_scan_outcome",
+      leaid: "0100001",
+      platform: "applitrack",
+      status: "completed",
+      failure_reason: null,
+      vacancy_count: 0,
+      consecutive_failures_after: 0,
+    });
+    expect(typeof outcomeLog.duration_ms).toBe("number");
+    expect(typeof outcomeLog.was_first_attempt).toBe("boolean");
+
+    consoleLogSpy.mockRestore();
+  });
 });

--- a/src/features/vacancies/lib/__tests__/scan-runner.test.ts
+++ b/src/features/vacancies/lib/__tests__/scan-runner.test.ts
@@ -9,6 +9,7 @@ const vacancyScanFindUnique = vi.fn();
 const vacancyScanUpdate = vi.fn();
 const getParserMock = vi.fn();
 const parseWithClaudeMock = vi.fn();
+const isStatewideBoardAsyncMock = vi.fn(async () => false);
 
 vi.mock("@/lib/prisma", () => ({
   default: {
@@ -24,7 +25,7 @@ vi.mock("@/lib/prisma", () => ({
 
 vi.mock("@/features/vacancies/lib/platform-detector", () => ({
   detectPlatform: () => "applitrack",
-  isStatewideBoardAsync: async () => false,
+  isStatewideBoardAsync: (...args: unknown[]) => (isStatewideBoardAsyncMock as (...a: unknown[]) => unknown)(...args),
   getAppliTrackInstance: () => null,
 }));
 vi.mock("@/features/vacancies/lib/post-processor", () => ({
@@ -61,6 +62,7 @@ beforeEach(() => {
   // Default parser: returns 0 vacancies — drives runScan to the success path.
   getParserMock.mockReset().mockImplementation(() => async () => []);
   parseWithClaudeMock.mockReset().mockResolvedValue([]);
+  isStatewideBoardAsyncMock.mockReset().mockResolvedValue(false);
 });
 
 describe("runScan health-column updates", () => {
@@ -141,5 +143,49 @@ describe("runScan health-column updates", () => {
       (c) => (c[0] as any)?.data?.status === "failed",
     );
     expect((failedCall?.[0] as any)?.data?.failureReason).toBe("scan_timeout");
+  });
+});
+
+describe("runScan completed_partial paths write failureReason", () => {
+  it("statewide_unattributable: >50% missing employerName", async () => {
+    // Override the mocked isStatewideBoardAsync for this test only
+    isStatewideBoardAsyncMock.mockResolvedValueOnce(true);
+
+    // Parser returns 25 jobs, 20 without employerName -> 80% missing -> trigger
+    const rawJobs = Array.from({ length: 25 }, (_, i) => ({
+      title: `Job ${i}`,
+      url: `https://example.com/${i}`,
+      ...(i < 5 ? { employerName: "Test District" } : {}),
+    }));
+    getParserMock.mockImplementation(() => async () => rawJobs);
+
+    await runScan("scan_abc");
+
+    const partialCall = vacancyScanUpdate.mock.calls.find(
+      (c) => (c[0] as any)?.data?.status === "completed_partial",
+    );
+    expect((partialCall?.[0] as any)?.data?.failureReason).toBe(
+      "statewide_unattributable",
+    );
+  });
+
+  it("enrollment_ratio_skip: too many vacancies for enrollment", async () => {
+    // 600 vacancies on a district with enrollment 1000 -> ratio 0.6 > 0.5 -> trigger
+    getParserMock.mockImplementation(() => async () =>
+      Array.from({ length: 600 }, (_, i) => ({
+        title: `Job ${i}`,
+        url: `https://example.com/${i}`,
+        employerName: "Test District",
+      })),
+    );
+
+    await runScan("scan_abc");
+
+    const partialCall = vacancyScanUpdate.mock.calls.find(
+      (c) => (c[0] as any)?.data?.status === "completed_partial",
+    );
+    expect((partialCall?.[0] as any)?.data?.failureReason).toBe(
+      "enrollment_ratio_skip",
+    );
   });
 });

--- a/src/features/vacancies/lib/__tests__/scan-runner.test.ts
+++ b/src/features/vacancies/lib/__tests__/scan-runner.test.ts
@@ -121,5 +121,25 @@ describe("runScan health-column updates", () => {
     expect(districtCalls.length).toBeGreaterThan(0);
     const last = districtCalls.at(-1)?.[0] as any;
     expect(last?.data?.vacancyConsecutiveFailures).toMatchObject({ increment: 1 });
+
+    const failedScanCall = vacancyScanUpdate.mock.calls.find(
+      (c) => (c[0] as any)?.data?.status === "failed",
+    );
+    expect((failedScanCall?.[0] as any)?.data?.failureReason).toBe("no_job_board_url");
+  });
+
+  it("on scan_timeout: writes failureReason='scan_timeout'", async () => {
+    // Make the parser hang past the timeout. The runner aborts via the controller
+    // and throws "Scan timed out" — caught by the outer catch.
+    getParserMock.mockImplementation(() => async () => {
+      throw new Error("Scan timed out");
+    });
+
+    await runScan("scan_abc");
+
+    const failedCall = vacancyScanUpdate.mock.calls.find(
+      (c) => (c[0] as any)?.data?.status === "failed",
+    );
+    expect((failedCall?.[0] as any)?.data?.failureReason).toBe("scan_timeout");
   });
 });

--- a/src/features/vacancies/lib/__tests__/scan-runner.test.ts
+++ b/src/features/vacancies/lib/__tests__/scan-runner.test.ts
@@ -299,29 +299,32 @@ describe("runScan tarpit-admission log", () => {
     consoleLogSpy.mockRestore();
   });
 
-  it("does NOT log vacancy_tarpit_admission when counter is 4 or 6", async () => {
-    const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  it.each([4, 6])(
+    "does NOT log vacancy_tarpit_admission when counter is %i (not exactly 5)",
+    async (counterValue) => {
+      const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
-    districtUpdate.mockResolvedValue({
-      leaid: "0100001",
-      name: "Test District",
-      jobBoardPlatform: "applitrack",
-      jobBoardUrl: "https://example.applitrack.com/onlineapp",
-      vacancyConsecutiveFailures: 4,
-    });
+      districtUpdate.mockResolvedValue({
+        leaid: "0100001",
+        name: "Test District",
+        jobBoardPlatform: "applitrack",
+        jobBoardUrl: "https://example.applitrack.com/onlineapp",
+        vacancyConsecutiveFailures: counterValue,
+      });
 
-    getParserMock.mockImplementation(() => async () => {
-      throw new Error("boom");
-    });
+      getParserMock.mockImplementation(() => async () => {
+        throw new Error("boom");
+      });
 
-    await runScan("scan_abc");
+      await runScan("scan_abc");
 
-    const tarpitLog = consoleLogSpy.mock.calls.find((args) => {
-      const first = args[0];
-      return typeof first === "string" && first.includes("vacancy_tarpit_admission");
-    });
-    expect(tarpitLog).toBeUndefined();
+      const tarpitLog = consoleLogSpy.mock.calls.find((args) => {
+        const first = args[0];
+        return typeof first === "string" && first.includes("vacancy_tarpit_admission");
+      });
+      expect(tarpitLog).toBeUndefined();
 
-    consoleLogSpy.mockRestore();
-  });
+      consoleLogSpy.mockRestore();
+    },
+  );
 });

--- a/src/features/vacancies/lib/__tests__/scan-runner.test.ts
+++ b/src/features/vacancies/lib/__tests__/scan-runner.test.ts
@@ -9,7 +9,7 @@ const vacancyScanFindUnique = vi.fn();
 const vacancyScanUpdate = vi.fn();
 const getParserMock = vi.fn();
 const parseWithClaudeMock = vi.fn();
-const isStatewideBoardAsyncMock = vi.fn(async () => false);
+const isStatewideBoardAsyncMock = vi.fn<(...args: unknown[]) => Promise<boolean>>(async () => false);
 
 vi.mock("@/lib/prisma", () => ({
   default: {
@@ -25,7 +25,7 @@ vi.mock("@/lib/prisma", () => ({
 
 vi.mock("@/features/vacancies/lib/platform-detector", () => ({
   detectPlatform: () => "applitrack",
-  isStatewideBoardAsync: (...args: unknown[]) => (isStatewideBoardAsyncMock as (...a: unknown[]) => unknown)(...args),
+  isStatewideBoardAsync: (...args: unknown[]) => isStatewideBoardAsyncMock(...args),
   getAppliTrackInstance: () => null,
 }));
 vi.mock("@/features/vacancies/lib/post-processor", () => ({

--- a/src/features/vacancies/lib/__tests__/scan-runner.test.ts
+++ b/src/features/vacancies/lib/__tests__/scan-runner.test.ts
@@ -256,3 +256,72 @@ describe("runScan completed_partial paths write failureReason", () => {
     }
   });
 });
+
+describe("runScan tarpit-admission log", () => {
+  it("logs vacancy_tarpit_admission when consecutive_failures hits 5", async () => {
+    const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    // Simulate the fifth failure: districtUpdate returns counter = 5
+    districtUpdate.mockResolvedValue({
+      leaid: "0100001",
+      name: "Test District",
+      jobBoardPlatform: "applitrack",
+      jobBoardUrl: "https://example.applitrack.com/onlineapp",
+      vacancyConsecutiveFailures: 5,
+    });
+
+    getParserMock.mockImplementation(() => async () => {
+      throw new Error("Request failed with status 404");
+    });
+
+    await runScan("scan_abc");
+
+    const tarpitLog = consoleLogSpy.mock.calls.find((args) => {
+      const first = args[0];
+      if (typeof first !== "string") return false;
+      try {
+        const parsed = JSON.parse(first);
+        return parsed.event === "vacancy_tarpit_admission";
+      } catch {
+        return false;
+      }
+    });
+    expect(tarpitLog).toBeDefined();
+    const parsed = JSON.parse(tarpitLog![0] as string);
+    expect(parsed).toMatchObject({
+      event: "vacancy_tarpit_admission",
+      leaid: "0100001",
+      name: "Test District",
+      platform: "applitrack",
+      last_failure_reason: "http_4xx",
+    });
+
+    consoleLogSpy.mockRestore();
+  });
+
+  it("does NOT log vacancy_tarpit_admission when counter is 4 or 6", async () => {
+    const consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    districtUpdate.mockResolvedValue({
+      leaid: "0100001",
+      name: "Test District",
+      jobBoardPlatform: "applitrack",
+      jobBoardUrl: "https://example.applitrack.com/onlineapp",
+      vacancyConsecutiveFailures: 4,
+    });
+
+    getParserMock.mockImplementation(() => async () => {
+      throw new Error("boom");
+    });
+
+    await runScan("scan_abc");
+
+    const tarpitLog = consoleLogSpy.mock.calls.find((args) => {
+      const first = args[0];
+      return typeof first === "string" && first.includes("vacancy_tarpit_admission");
+    });
+    expect(tarpitLog).toBeUndefined();
+
+    consoleLogSpy.mockRestore();
+  });
+});

--- a/src/features/vacancies/lib/__tests__/scan-runner.test.ts
+++ b/src/features/vacancies/lib/__tests__/scan-runner.test.ts
@@ -188,4 +188,35 @@ describe("runScan completed_partial paths write failureReason", () => {
       "enrollment_ratio_skip",
     );
   });
+
+  it("claude_fallback_failed: serverless Claude returns []", async () => {
+    // Force the dispatch into the Claude-fallback branch:
+    // 1) no parser for the platform, 2) running serverless, 3) Claude returns []
+    getParserMock.mockReturnValue(null);
+    process.env.VERCEL = "1";
+    process.env.ANTHROPIC_API_KEY = "test-key";
+    parseWithClaudeMock.mockResolvedValue([]);
+
+    try {
+      await runScan("scan_abc");
+
+      const partialCall = vacancyScanUpdate.mock.calls.find(
+        (c) => (c[0] as any)?.data?.status === "completed_partial",
+      );
+      expect((partialCall?.[0] as any)?.data?.failureReason).toBe(
+        "claude_fallback_failed",
+      );
+
+      // District counter must increment (B1 policy) — markDistrictScanFailure path
+      const districtFailureCall = districtUpdate.mock.calls.find(
+        (c) =>
+          (c[0] as any)?.where?.leaid === "0100001" &&
+          (c[0] as any)?.data?.vacancyConsecutiveFailures?.increment === 1,
+      );
+      expect(districtFailureCall).toBeDefined();
+    } finally {
+      delete process.env.VERCEL;
+      delete process.env.ANTHROPIC_API_KEY;
+    }
+  });
 });

--- a/src/features/vacancies/lib/__tests__/scan-runner.test.ts
+++ b/src/features/vacancies/lib/__tests__/scan-runner.test.ts
@@ -190,8 +190,9 @@ describe("runScan completed_partial paths write failureReason", () => {
   });
 
   it("claude_fallback_failed: serverless Claude returns []", async () => {
-    // Force the dispatch into the Claude-fallback branch:
-    // 1) no parser for the platform, 2) running serverless, 3) Claude returns []
+    // Force the no-parser path (getParser returns null), set serverless +
+    // an API key so the runner actually invokes Claude, then have Claude
+    // return [].
     getParserMock.mockReturnValue(null);
     process.env.VERCEL = "1";
     process.env.ANTHROPIC_API_KEY = "test-key";
@@ -206,6 +207,9 @@ describe("runScan completed_partial paths write failureReason", () => {
       expect((partialCall?.[0] as any)?.data?.failureReason).toBe(
         "claude_fallback_failed",
       );
+      expect((partialCall?.[0] as any)?.data?.errorMessage).toBe(
+        "Claude fallback returned no vacancies",
+      );
 
       // District counter must increment (B1 policy) — markDistrictScanFailure path
       const districtFailureCall = districtUpdate.mock.calls.find(
@@ -217,6 +221,38 @@ describe("runScan completed_partial paths write failureReason", () => {
     } finally {
       delete process.env.VERCEL;
       delete process.env.ANTHROPIC_API_KEY;
+    }
+  });
+
+  it("claude_fallback_failed: serverless without ANTHROPIC_API_KEY", async () => {
+    // No-key serverless path: Claude is never invoked, but the symptom is
+    // the same as a Claude empty-return. B1 policy still fires; the
+    // errorMessage distinguishes the cause.
+    getParserMock.mockReturnValue(null);
+    process.env.VERCEL = "1";
+    delete process.env.ANTHROPIC_API_KEY;
+
+    try {
+      await runScan("scan_abc");
+
+      const partialCall = vacancyScanUpdate.mock.calls.find(
+        (c) => (c[0] as any)?.data?.status === "completed_partial",
+      );
+      expect((partialCall?.[0] as any)?.data?.failureReason).toBe(
+        "claude_fallback_failed",
+      );
+      expect((partialCall?.[0] as any)?.data?.errorMessage).toBe(
+        "Serverless: no ANTHROPIC_API_KEY — cannot parse",
+      );
+
+      const districtFailureCall = districtUpdate.mock.calls.find(
+        (c) =>
+          (c[0] as any)?.where?.leaid === "0100001" &&
+          (c[0] as any)?.data?.vacancyConsecutiveFailures?.increment === 1,
+      );
+      expect(districtFailureCall).toBeDefined();
+    } finally {
+      delete process.env.VERCEL;
     }
   });
 });

--- a/src/features/vacancies/lib/failure-reasons.ts
+++ b/src/features/vacancies/lib/failure-reasons.ts
@@ -17,15 +17,24 @@ const CONTEXT_MAP: Partial<Record<FailureContext, VacancyFailureReason>> = {
 };
 
 // Order matters: first match wins. More-specific patterns precede more-generic ones.
+// Digit tokens use \b boundaries so "took 500ms" doesn't match http_5xx.
+// Bare ambiguous English words ("gone", "network") were intentionally NOT
+// included — "410 Gone" is caught by the \b4\d\d\b digit, and the network
+// alternatives (econnrefused, enotfound, fetch failed, getaddrinfo) cover
+// the real failure modes without false-matching phrases like "social network".
+//
+// Note: `parser_empty` is reserved in the schema for a future detection path
+// (parser ran cleanly but page format changed) and is intentionally not
+// reachable from this helper today — see the design spec.
 const PATTERNS: Array<{ regex: RegExp; reason: VacancyFailureReason }> = [
-  { regex: /timed out|aborted|abort/i, reason: "scan_timeout" },
+  { regex: /timed out|abort/i, reason: "scan_timeout" },
   { regex: /anthropic|claude api/i, reason: "claude_fallback_failed" },
   { regex: /statewide board returned/i, reason: "statewide_unattributable" },
   { regex: /regional aggregator/i, reason: "enrollment_ratio_skip" },
   { regex: /no job board url/i, reason: "no_job_board_url" },
-  { regex: /4\d\d|not found|forbidden|gone/i, reason: "http_4xx" },
-  { regex: /5\d\d|server error|bad gateway|service unavailable/i, reason: "http_5xx" },
-  { regex: /econnrefused|enotfound|network|fetch failed|getaddrinfo/i, reason: "network_timeout" },
+  { regex: /\b4\d\d\b|\bnot found\b|\bforbidden\b/i, reason: "http_4xx" },
+  { regex: /\b5\d\d\b|\bserver error\b|\bbad gateway\b|\bservice unavailable\b/i, reason: "http_5xx" },
+  { regex: /econnrefused|enotfound|fetch failed|getaddrinfo/i, reason: "network_timeout" },
 ];
 
 export function categorizeFailure(args: {

--- a/src/features/vacancies/lib/failure-reasons.ts
+++ b/src/features/vacancies/lib/failure-reasons.ts
@@ -1,0 +1,44 @@
+import type { VacancyFailureReason } from "@prisma/client";
+
+export type FailureContext =
+  | "no_job_board_url"
+  | "scan_timeout"
+  | "statewide_unattributable"
+  | "enrollment_ratio_skip"
+  | "claude_fallback_empty"
+  | "thrown_error";
+
+const CONTEXT_MAP: Partial<Record<FailureContext, VacancyFailureReason>> = {
+  no_job_board_url: "no_job_board_url",
+  scan_timeout: "scan_timeout",
+  statewide_unattributable: "statewide_unattributable",
+  enrollment_ratio_skip: "enrollment_ratio_skip",
+  claude_fallback_empty: "claude_fallback_failed",
+};
+
+// Order matters: first match wins. More-specific patterns precede more-generic ones.
+const PATTERNS: Array<{ regex: RegExp; reason: VacancyFailureReason }> = [
+  { regex: /timed out|aborted|abort/i, reason: "scan_timeout" },
+  { regex: /anthropic|claude api/i, reason: "claude_fallback_failed" },
+  { regex: /statewide board returned/i, reason: "statewide_unattributable" },
+  { regex: /regional aggregator/i, reason: "enrollment_ratio_skip" },
+  { regex: /no job board url/i, reason: "no_job_board_url" },
+  { regex: /4\d\d|not found|forbidden|gone/i, reason: "http_4xx" },
+  { regex: /5\d\d|server error|bad gateway|service unavailable/i, reason: "http_5xx" },
+  { regex: /econnrefused|enotfound|network|fetch failed|getaddrinfo/i, reason: "network_timeout" },
+];
+
+export function categorizeFailure(args: {
+  errorMessage: string;
+  context?: FailureContext;
+}): VacancyFailureReason {
+  const ctx = args.context ?? "thrown_error";
+  const direct = CONTEXT_MAP[ctx];
+  if (direct) return direct;
+
+  // Fall through to regex matching for thrown_error context
+  for (const { regex, reason } of PATTERNS) {
+    if (regex.test(args.errorMessage)) return reason;
+  }
+  return "unknown_error";
+}

--- a/src/features/vacancies/lib/scan-runner.ts
+++ b/src/features/vacancies/lib/scan-runner.ts
@@ -1,4 +1,4 @@
-import { Prisma } from "@prisma/client";
+import { Prisma, type VacancyFailureReason } from "@prisma/client";
 import prisma from "@/lib/prisma";
 import { detectPlatform, isStatewideBoardAsync, getAppliTrackInstance } from "./platform-detector";
 import { processVacancies } from "./post-processor";
@@ -11,21 +11,47 @@ import type { RawVacancy } from "./parsers/types";
 /** Maximum time (ms) a single scan is allowed to run before timing out. */
 const SCAN_TIMEOUT_MS = 180_000; // 3 min for state-wide redistribution
 
-async function markDistrictScanSuccess(leaid: string) {
+async function markDistrictScanSuccess(leaid: string): Promise<number> {
   await prisma.district.update({
     where: { leaid },
     data: { vacancyConsecutiveFailures: 0, vacancyLastFailureAt: null },
   });
+  return 0;
 }
 
-async function markDistrictScanFailure(leaid: string) {
-  await prisma.district.update({
+async function markDistrictScanFailure(
+  leaid: string,
+  failureReason: VacancyFailureReason | null = null,
+): Promise<number> {
+  const updated = await prisma.district.update({
     where: { leaid },
     data: {
       vacancyConsecutiveFailures: { increment: 1 },
       vacancyLastFailureAt: new Date(),
     },
+    select: {
+      leaid: true,
+      name: true,
+      jobBoardPlatform: true,
+      jobBoardUrl: true,
+      vacancyConsecutiveFailures: true,
+    },
   });
+
+  if (updated.vacancyConsecutiveFailures === 5) {
+    console.log(
+      JSON.stringify({
+        event: "vacancy_tarpit_admission",
+        leaid: updated.leaid,
+        name: updated.name,
+        platform: updated.jobBoardPlatform,
+        job_board_url: updated.jobBoardUrl,
+        last_failure_reason: failureReason,
+      }),
+    );
+  }
+
+  return updated.vacancyConsecutiveFailures;
 }
 
 /**
@@ -80,19 +106,20 @@ export async function runScan(scanId: string): Promise<void> {
     }
 
     if (!scan.district.jobBoardUrl) {
+      const failureReason = categorizeFailure({
+        errorMessage: "",
+        context: "no_job_board_url",
+      });
       await prisma.vacancyScan.update({
         where: { id: scanId },
         data: {
           status: "failed",
           errorMessage: "District has no job board URL",
-          failureReason: categorizeFailure({
-            errorMessage: "",
-            context: "no_job_board_url",
-          }),
+          failureReason,
           completedAt: new Date(),
         },
       });
-      await markDistrictScanFailure(scan.district.leaid);
+      await markDistrictScanFailure(scan.district.leaid, failureReason);
       return;
     }
 
@@ -171,20 +198,21 @@ export async function runScan(scanId: string): Promise<void> {
     // case — Claude wasn't actually called, but the symptom is the same
     // (silent zero-vacancy completion); the errorMessage distinguishes them.
     if (usedClaudeFallback && rawVacancies.length === 0) {
+      const failureReason = categorizeFailure({
+        errorMessage: "",
+        context: "claude_fallback_empty",
+      });
       await prisma.vacancyScan.update({
         where: { id: scanId },
         data: {
           status: "completed_partial",
           vacancyCount: 0,
           errorMessage: claudeFallbackMessage,
-          failureReason: categorizeFailure({
-            errorMessage: "",
-            context: "claude_fallback_empty",
-          }),
+          failureReason,
           completedAt: new Date(),
         },
       });
-      await markDistrictScanFailure(scan.district.leaid);
+      await markDistrictScanFailure(scan.district.leaid, failureReason);
       return;
     }
 
@@ -347,7 +375,7 @@ export async function runScan(scanId: string): Promise<void> {
         },
       });
       if (scan?.district?.leaid) {
-        await markDistrictScanFailure(scan.district.leaid);
+        await markDistrictScanFailure(scan.district.leaid, failureReason);
       }
     } catch (updateError) {
       console.error(

--- a/src/features/vacancies/lib/scan-runner.ts
+++ b/src/features/vacancies/lib/scan-runner.ts
@@ -85,6 +85,10 @@ export async function runScan(scanId: string): Promise<void> {
         data: {
           status: "failed",
           errorMessage: "District has no job board URL",
+          failureReason: categorizeFailure({
+            errorMessage: "",
+            context: "no_job_board_url",
+          }),
           completedAt: new Date(),
         },
       });

--- a/src/features/vacancies/lib/scan-runner.ts
+++ b/src/features/vacancies/lib/scan-runner.ts
@@ -122,6 +122,7 @@ export async function runScan(scanId: string): Promise<void> {
     // Step 4: Get parser and run it
     const parser = getParser(platform);
     let rawVacancies: RawVacancy[];
+    let usedClaudeFallback = false;
     const isServerless = !!process.env.VERCEL;
 
     // Unknown platforms fall back to Playwright locally or Claude on Vercel.
@@ -137,9 +138,11 @@ export async function runScan(scanId: string): Promise<void> {
       if (process.env.ANTHROPIC_API_KEY) {
         console.log(`[scan-runner] Serverless env, using Claude fallback for "${platform}"...`);
         rawVacancies = await parseWithClaude(scan.district.jobBoardUrl);
+        usedClaudeFallback = true;
       } else {
         console.log(`[scan-runner] Serverless env, no ANTHROPIC_API_KEY — cannot parse "${platform}"`);
         rawVacancies = [];
+        usedClaudeFallback = true;
       }
     } else {
       // Local / self-hosted: try Playwright first (free, no API cost),
@@ -150,12 +153,35 @@ export async function runScan(scanId: string): Promise<void> {
       if (rawVacancies.length === 0 && process.env.ANTHROPIC_API_KEY) {
         console.log(`[scan-runner] Playwright found nothing, trying Claude fallback...`);
         rawVacancies = await parseWithClaude(scan.district.jobBoardUrl);
+        usedClaudeFallback = true;
       }
     }
 
     // Check if aborted
     if (timeoutController.signal.aborted) {
       throw new Error("Scan timed out");
+    }
+
+    // B1: Claude-fallback returning [] is the dominant silent-failure mode.
+    // Mark as completed_partial + claude_fallback_failed AND increment the
+    // district failure counter so these districts become eligible for the
+    // future failure-reset job.
+    if (usedClaudeFallback && rawVacancies.length === 0) {
+      await prisma.vacancyScan.update({
+        where: { id: scanId },
+        data: {
+          status: "completed_partial",
+          vacancyCount: 0,
+          errorMessage: "Claude fallback returned no vacancies",
+          failureReason: categorizeFailure({
+            errorMessage: "",
+            context: "claude_fallback_empty",
+          }),
+          completedAt: new Date(),
+        },
+      });
+      await markDistrictScanFailure(scan.district.leaid);
+      return;
     }
 
     // Step 5: Post-process

--- a/src/features/vacancies/lib/scan-runner.ts
+++ b/src/features/vacancies/lib/scan-runner.ts
@@ -3,6 +3,7 @@ import prisma from "@/lib/prisma";
 import { detectPlatform, isStatewideBoardAsync, getAppliTrackInstance } from "./platform-detector";
 import { processVacancies } from "./post-processor";
 import { getParser } from "./parsers";
+import { categorizeFailure } from "./failure-reasons";
 import { parseWithPlaywright } from "./parsers/playwright-fallback";
 import { parseWithClaude } from "./parsers/claude-fallback";
 import type { RawVacancy } from "./parsers/types";
@@ -290,11 +291,16 @@ export async function runScan(scanId: string): Promise<void> {
     console.error(`[scan-runner] Scan ${scanId} failed:`, errorMessage);
 
     try {
+      const failureReason = categorizeFailure({
+        errorMessage,
+        context: "thrown_error",
+      });
       await prisma.vacancyScan.update({
         where: { id: scanId },
         data: {
           status: "failed",
           errorMessage,
+          failureReason,
           completedAt: new Date(),
         },
       });
@@ -304,7 +310,7 @@ export async function runScan(scanId: string): Promise<void> {
     } catch (updateError) {
       console.error(
         `[scan-runner] Failed to update scan ${scanId} status:`,
-        updateError
+        updateError,
       );
     }
   } finally {

--- a/src/features/vacancies/lib/scan-runner.ts
+++ b/src/features/vacancies/lib/scan-runner.ts
@@ -123,6 +123,7 @@ export async function runScan(scanId: string): Promise<void> {
     const parser = getParser(platform);
     let rawVacancies: RawVacancy[];
     let usedClaudeFallback = false;
+    let claudeFallbackMessage = "Claude fallback returned no vacancies";
     const isServerless = !!process.env.VERCEL;
 
     // Unknown platforms fall back to Playwright locally or Claude on Vercel.
@@ -143,6 +144,7 @@ export async function runScan(scanId: string): Promise<void> {
         console.log(`[scan-runner] Serverless env, no ANTHROPIC_API_KEY — cannot parse "${platform}"`);
         rawVacancies = [];
         usedClaudeFallback = true;
+        claudeFallbackMessage = "Serverless: no ANTHROPIC_API_KEY — cannot parse";
       }
     } else {
       // Local / self-hosted: try Playwright first (free, no API cost),
@@ -165,14 +167,16 @@ export async function runScan(scanId: string): Promise<void> {
     // B1: Claude-fallback returning [] is the dominant silent-failure mode.
     // Mark as completed_partial + claude_fallback_failed AND increment the
     // district failure counter so these districts become eligible for the
-    // future failure-reset job.
+    // future failure-reset job. Also fires for the serverless-no-API-key
+    // case — Claude wasn't actually called, but the symptom is the same
+    // (silent zero-vacancy completion); the errorMessage distinguishes them.
     if (usedClaudeFallback && rawVacancies.length === 0) {
       await prisma.vacancyScan.update({
         where: { id: scanId },
         data: {
           status: "completed_partial",
           vacancyCount: 0,
-          errorMessage: "Claude fallback returned no vacancies",
+          errorMessage: claudeFallbackMessage,
           failureReason: categorizeFailure({
             errorMessage: "",
             context: "claude_fallback_empty",

--- a/src/features/vacancies/lib/scan-runner.ts
+++ b/src/features/vacancies/lib/scan-runner.ts
@@ -88,6 +88,14 @@ export async function runScan(scanId: string): Promise<void> {
     };
   }> | null = null;
 
+  const scanStartMs = Date.now();
+  let finalStatus: string = "unknown";
+  let finalFailureReason: VacancyFailureReason | null = null;
+  let finalVacancyCount = 0;
+  let finalConsecutiveFailures = 0;
+  let detectedPlatform: string | null = null;
+  let hadPriorCompletedScan = false;
+
   try {
     // Step 1: Fetch scan + district
     scan = await prisma.vacancyScan.findUnique({
@@ -110,6 +118,15 @@ export async function runScan(scanId: string): Promise<void> {
       return;
     }
 
+    const priorCount = await prisma.vacancyScan.count({
+      where: {
+        leaid: scan.district.leaid,
+        status: { in: ["completed", "completed_partial"] },
+        NOT: { id: scanId },
+      },
+    });
+    hadPriorCompletedScan = priorCount > 0;
+
     if (!scan.district.jobBoardUrl) {
       const failureReason = categorizeFailure({
         errorMessage: "",
@@ -124,7 +141,9 @@ export async function runScan(scanId: string): Promise<void> {
           completedAt: new Date(),
         },
       });
-      await markDistrictScanFailure(scan.district.leaid, failureReason);
+      finalStatus = "failed";
+      finalFailureReason = failureReason;
+      finalConsecutiveFailures = await markDistrictScanFailure(scan.district.leaid, failureReason);
       return;
     }
 
@@ -136,6 +155,7 @@ export async function runScan(scanId: string): Promise<void> {
 
     // Step 3: Detect platform
     const platform = detectPlatform(scan.district.jobBoardUrl);
+    detectedPlatform = platform;
 
     // Update district platform if different
     if (platform !== scan.district.jobBoardPlatform) {
@@ -217,7 +237,9 @@ export async function runScan(scanId: string): Promise<void> {
           completedAt: new Date(),
         },
       });
-      await markDistrictScanFailure(scan.district.leaid, failureReason);
+      finalStatus = "completed_partial";
+      finalFailureReason = failureReason;
+      finalConsecutiveFailures = await markDistrictScanFailure(scan.district.leaid, failureReason);
       return;
     }
 
@@ -246,7 +268,9 @@ export async function runScan(scanId: string): Promise<void> {
             completedAt: new Date(),
           },
         });
-        await markDistrictScanSuccess(scan.district.leaid);
+        finalStatus = "completed_partial";
+        finalFailureReason = "statewide_unattributable";
+        finalConsecutiveFailures = await markDistrictScanSuccess(scan.district.leaid);
         return;
       }
 
@@ -288,7 +312,9 @@ export async function runScan(scanId: string): Promise<void> {
           completedAt: new Date(),
         },
       });
-      await markDistrictScanSuccess(scan.district.leaid);
+      finalStatus = "completed";
+      finalVacancyCount = result.vacancyCount;
+      finalConsecutiveFailures = await markDistrictScanSuccess(scan.district.leaid);
 
       // Redistribute remaining jobs to other districts in the background
       // — but ONLY if the URL is properly scoped (has applitrackclient param)
@@ -329,7 +355,9 @@ export async function runScan(scanId: string): Promise<void> {
               completedAt: new Date(),
             },
           });
-          await markDistrictScanSuccess(scan.district.leaid);
+          finalStatus = "completed_partial";
+          finalFailureReason = "enrollment_ratio_skip";
+          finalConsecutiveFailures = await markDistrictScanSuccess(scan.district.leaid);
           return;
         }
       }
@@ -357,7 +385,9 @@ export async function runScan(scanId: string): Promise<void> {
           completedAt: new Date(),
         },
       });
-      await markDistrictScanSuccess(scan.district.leaid);
+      finalStatus = "completed";
+      finalVacancyCount = result.vacancyCount;
+      finalConsecutiveFailures = await markDistrictScanSuccess(scan.district.leaid);
     }
   } catch (error) {
     const errorMessage =
@@ -379,8 +409,10 @@ export async function runScan(scanId: string): Promise<void> {
           completedAt: new Date(),
         },
       });
+      finalStatus = "failed";
+      finalFailureReason = failureReason;
       if (scan?.district?.leaid) {
-        await markDistrictScanFailure(scan.district.leaid, failureReason);
+        finalConsecutiveFailures = await markDistrictScanFailure(scan.district.leaid, failureReason);
       }
     } catch (updateError) {
       console.error(
@@ -390,6 +422,19 @@ export async function runScan(scanId: string): Promise<void> {
     }
   } finally {
     clearTimeout(timeoutId);
+    console.log(
+      JSON.stringify({
+        event: "vacancy_scan_outcome",
+        leaid: scan?.district.leaid ?? null,
+        platform: detectedPlatform,
+        status: finalStatus,
+        failure_reason: finalFailureReason,
+        vacancy_count: finalVacancyCount,
+        duration_ms: Date.now() - scanStartMs,
+        was_first_attempt: !hadPriorCompletedScan,
+        consecutive_failures_after: finalConsecutiveFailures,
+      }),
+    );
   }
 }
 

--- a/src/features/vacancies/lib/scan-runner.ts
+++ b/src/features/vacancies/lib/scan-runner.ts
@@ -38,6 +38,11 @@ async function markDistrictScanFailure(
     },
   });
 
+  // Strict equality: fires exactly once per district at the 4→5 transition.
+  // The cron filter excludes districts at >= 5 from the pool, so this counter
+  // never re-increments through normal scheduling. Manual re-enqueue past 5
+  // (admin trigger, future feature) intentionally does not re-fire the log —
+  // tarpit admission is a one-time event.
   if (updated.vacancyConsecutiveFailures === 5) {
     console.log(
       JSON.stringify({

--- a/src/features/vacancies/lib/scan-runner.ts
+++ b/src/features/vacancies/lib/scan-runner.ts
@@ -400,6 +400,12 @@ export async function runScan(scanId: string): Promise<void> {
         errorMessage,
         context: "thrown_error",
       });
+      // Capture outcome state BEFORE the DB write so the finally-block log
+      // still records status="failed" if the update itself throws (double-
+      // failure path). Otherwise the log would emit status="unknown" for a
+      // scan that unambiguously failed.
+      finalStatus = "failed";
+      finalFailureReason = failureReason;
       await prisma.vacancyScan.update({
         where: { id: scanId },
         data: {
@@ -409,8 +415,6 @@ export async function runScan(scanId: string): Promise<void> {
           completedAt: new Date(),
         },
       });
-      finalStatus = "failed";
-      finalFailureReason = failureReason;
       if (scan?.district?.leaid) {
         finalConsecutiveFailures = await markDistrictScanFailure(scan.district.leaid, failureReason);
       }

--- a/src/features/vacancies/lib/scan-runner.ts
+++ b/src/features/vacancies/lib/scan-runner.ts
@@ -176,6 +176,10 @@ export async function runScan(scanId: string): Promise<void> {
             status: "completed_partial",
             vacancyCount: 0,
             errorMessage: `Skipped: statewide board returned ${rawVacancies.length} vacancies but ${withoutEmployer} lack employer info (cannot attribute to district)`,
+            failureReason: categorizeFailure({
+              errorMessage: "",
+              context: "statewide_unattributable",
+            }),
             completedAt: new Date(),
           },
         });
@@ -255,6 +259,10 @@ export async function runScan(scanId: string): Promise<void> {
               status: "completed_partial",
               vacancyCount: 0,
               errorMessage: `Skipped: ${rawVacancies.length} vacancies looks like a regional aggregator (enrollment: ${enrollment}, ratio: ${ratio.toFixed(2)})`,
+              failureReason: categorizeFailure({
+                errorMessage: "",
+                context: "enrollment_ratio_skip",
+              }),
               completedAt: new Date(),
             },
           });


### PR DESCRIPTION
## Summary

Logging-and-instrumentation phase for the vacancy scanner coverage problem (the admin card has been pinned at ~45% coverage). This PR makes the loss visible — it does **not** fix the underlying parser/regression issues (those get a separate brainstorm informed by the data this work produces).

- Adds a `VacancyFailureReason` Prisma enum + nullable column on `VacancyScan`. Every scan-runner failure site now writes a categorized bucket alongside the existing free-text `errorMessage`.
- Emits 3 new structured Vercel log events: `vacancy_scan_outcome` (per scan), `vacancy_cron_summary` (per cron run with failure-reason mix + tarpit snapshot), `vacancy_tarpit_admission` (once per district at the 4→5 transition).
- Extends `/api/admin/vacancy-scan-stats` with `tarpit`, `adjustedCoveragePct`, and `topFailureReason7d` — surfaced as a new row on `VacancyScanCard` so the loss is visible at a glance.
- One behavior change beyond pure logging: Claude-fallback returning `[]` (the dominant ~80% silent-failure mode since the 2026-04-23 regression) is now `completed_partial` with `claude_fallback_failed` and increments the failure counter. Previously it was a silent `completed` and never accrued strikes.
- Backfill script (`scripts/backfill-vacancy-failure-reasons.ts`, `DRY_RUN=true` supported) categorizes existing rows so the new card stat is meaningful on day one.

Spec: `Docs/superpowers/specs/2026-05-03-vacancy-scanner-coverage-diagnostics-design.md`
Plan: `Docs/superpowers/plans/2026-05-03-vacancy-scanner-coverage-diagnostics.md`

Also includes the previously-committed-but-unpushed SchoolSpring docs from local main (commits `06e1a724`, `4280c982`).

## Out of scope (deliberate)

- Failure-counter reset job (separate brainstorm)
- Claude-fallback regression fix (separate effort — informed by the new metrics)
- Dedicated `/admin/vacancy-diagnostics` page

## Test plan

- [ ] CI: `npm test`, `npx tsc --noEmit`, `npm run lint` (note: there are 25 pre-existing-pattern `as any` lint warnings in `scan-runner.test.ts` — same pattern the file used before this PR)
- [ ] Apply the migration and run `DRY_RUN=true npx tsx scripts/backfill-vacancy-failure-reasons.ts`; confirm bucket counts look reasonable
- [ ] Run live: `npx tsx scripts/backfill-vacancy-failure-reasons.ts`; re-run and confirm "Total rows processed: 0" (idempotency)
- [ ] Verify the admin card's new row 2 renders Tarpit / Adjusted Coverage / Top Failure Reason
- [ ] After a cron cycle, grep Vercel logs for \`event:"vacancy_cron_summary"\` and confirm `failure_reason_mix` is populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)