### PR TITLE
Build out services catalog with EK12 reconciliation and alias mapping

### DIFF
--- a/prisma/migrations/20260504_enrich_services_catalog/migration.sql
+++ b/prisma/migrations/20260504_enrich_services_catalog/migration.sql
@@ -1,0 +1,148 @@
+-- Enrich the services catalog with descriptive content sourced from
+-- src/features/shared/components/views/resources/OurServiceModelPage.tsx.
+-- Adds two enums, twelve new columns, and re-seeds all ten services
+-- (introducing iTutor and aligning names with the customer-facing page).
+
+-- CreateEnum (idempotent — Postgres has no CREATE TYPE IF NOT EXISTS for enums)
+DO $$ BEGIN
+  CREATE TYPE "instruction_type" AS ENUM ('core_credit_bearing', 'supplemental');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  CREATE TYPE "teacher_of_record" AS ENUM ('required', 'optional');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- AlterTable
+ALTER TABLE "services"
+  ADD COLUMN IF NOT EXISTS "instruction_type" "instruction_type",
+  ADD COLUMN IF NOT EXISTS "icon" VARCHAR(50),
+  ADD COLUMN IF NOT EXISTS "delivery_types" TEXT[] NOT NULL DEFAULT '{}',
+  ADD COLUMN IF NOT EXISTS "challenge" TEXT,
+  ADD COLUMN IF NOT EXISTS "solution" TEXT,
+  ADD COLUMN IF NOT EXISTS "teacher_of_record" "teacher_of_record",
+  ADD COLUMN IF NOT EXISTS "has_lms" BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS "has_exit_tickets" BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS "has_mini_lesson" BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS "has_swd_progress" BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS "gradebooks_included" BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS "gradebooks_note" TEXT;
+
+-- Seed / upsert all ten services in customer-facing order (core first, then supplemental).
+-- ON CONFLICT (slug) updates existing rows; renames Suspension Alternatives -> Suspension Alternative
+-- and Resource Rooms -> Resource Room to match the page copy.
+INSERT INTO "services" (
+  "name", "slug", "color", "sort_order",
+  "instruction_type", "icon", "delivery_types",
+  "challenge", "solution",
+  "teacher_of_record",
+  "has_lms", "has_exit_tickets", "has_mini_lesson", "has_swd_progress",
+  "gradebooks_included", "gradebooks_note"
+) VALUES
+  (
+    'Homebound', 'homebound', '#6EA3BE', 1,
+    'core_credit_bearing', 'House', ARRAY['1:1'],
+    'Mental and physical health challenges, as well as long-term suspension, can prevent students from attending school in a traditional setting. As a result, students often fall behind and require personalized, student-centered instruction.',
+    'Our educators collaborate directly with the teacher of record to deliver instruction fully aligned with the school''s curriculum, ensuring students stay on track. When needed, we also provide customized, state-standards-aligned curriculum to meet students at their current level. Our educator pool includes certified teachers experienced in supporting students with disabilities and other specialized needs.',
+    'required',
+    TRUE, TRUE, TRUE, TRUE,
+    TRUE, NULL
+  ),
+  (
+    'Whole Class Virtual Instruction', 'wcvi', '#8AA891', 2,
+    'core_credit_bearing', 'Users', ARRAY['SG', 'WC'],
+    'Staffing shortages can leave schools unable to offer certain courses or reliant on uncertified educators.',
+    'Fullmind ensures every course is led by a certified educator through high-quality virtual instruction. We specialize in supporting hard-to-staff subject areas so schools can maintain full course offerings.',
+    'optional',
+    TRUE, TRUE, TRUE, TRUE,
+    TRUE, NULL
+  ),
+  (
+    'Credit Recovery', 'credit-recovery', '#D4A84B', 3,
+    'core_credit_bearing', 'GraduationCap', ARRAY['1:1', 'SG', 'WC'],
+    'Dropout rates and academic underperformance increase when students struggle with coursework, absenteeism, or behavioral challenges.',
+    'Our flexible credit recovery program helps students earn missed credits and regain academic progress. Live, state-certified educators provide real-time instruction aligned with the school''s curriculum. We track attendance, participation, and progress, keeping schools informed every step of the way.',
+    'required',
+    TRUE, TRUE, TRUE, FALSE,
+    TRUE, NULL
+  ),
+  (
+    'Suspension Alternative', 'suspension-alt', '#F37167', 4,
+    'core_credit_bearing', 'PauseCircle', ARRAY['WC', 'SG'],
+    'Rising suspension rates disrupt learning, negatively impact academic progress, and raise concerns around students'' mental and emotional wellbeing.',
+    'Our carefully selected educators partner with classroom teachers to ensure students remain on track academically during suspension periods. We also incorporate social-emotional learning supports to promote a smooth and successful transition back into the classroom.',
+    'optional',
+    TRUE, TRUE, TRUE, FALSE,
+    TRUE, NULL
+  ),
+  (
+    'Hybrid Staffing', 'hybrid-staffing', '#9B7EDE', 5,
+    'core_credit_bearing', 'UsersRound', ARRAY['1:1', 'SG', 'WC'],
+    'Staffing shortages can prevent schools from fully supporting specialized programs, including services for students with disabilities, resource rooms, and self-contained classrooms.',
+    'Our hybrid educators collaborate closely with school leaders and in-person facilitators, integrating seamlessly into the school team. Together, we ensure students receive consistent, high-quality instruction and support.',
+    'optional',
+    FALSE, FALSE, FALSE, FALSE,
+    FALSE, 'School''s platform'
+  ),
+  (
+    'Tutoring', 'tutoring', '#403770', 6,
+    'supplemental', 'BookOpen', ARRAY['1:1', 'SG', 'WC'],
+    'Some students require additional support or acceleration beyond what classroom teachers can provide within the school day.',
+    'We deliver high-dosage, K–12 tutoring through frequent, data-driven sessions led by certified educators. Programs are customized to each school''s goals and designed to accelerate student growth.',
+    'optional',
+    TRUE, TRUE, TRUE, FALSE,
+    FALSE, NULL
+  ),
+  (
+    'Resource Room', 'resource-rooms', '#7C6FA0', 7,
+    'supplemental', 'Accessibility', ARRAY['1:1', 'SG', 'WC'],
+    'Shortages of certified special-education teachers make it challenging for schools to meet IEP requirements and ensure FAPE compliance.',
+    'Our educators design instruction aligned to each student''s unique IEP goals, providing required accommodations and targeted support. We share regular progress-monitoring updates to ensure transparency and alignment with school teams and families.',
+    'optional',
+    TRUE, TRUE, TRUE, TRUE,
+    FALSE, NULL
+  ),
+  (
+    'Test Prep', 'test-prep', '#5EADB0', 8,
+    'supplemental', 'ClipboardCheck', ARRAY['1:1', 'SG', 'WC'],
+    'Students may struggle on high-stakes assessments due to content gaps, limited familiarity with test structure, or testing anxiety.',
+    'Our educators deliver data-driven instruction to close academic gaps, build confidence, and prepare students for success on high-stakes assessments.',
+    'optional',
+    TRUE, TRUE, TRUE, FALSE,
+    FALSE, NULL
+  ),
+  (
+    'Homework Help', 'homework-help', '#E8926B', 9,
+    'supplemental', 'HelpCircle', ARRAY['1:1', 'SG', 'WC'],
+    'Students may need additional guidance to complete assignments successfully or benefit from extra practice with a certified teacher.',
+    'We provide virtual after-school homework support, where certified educators offer real-time assistance tailored to students'' immediate needs.',
+    'optional',
+    TRUE, TRUE, TRUE, FALSE,
+    FALSE, NULL
+  ),
+  (
+    'iTutor', 'itutor', '#C7A4E0', 10,
+    'supplemental', 'Sparkles', ARRAY['1:1'],
+    'Families often seek supplemental instruction to support students who need additional academic growth or enrichment.',
+    'Our educators create fully customized instruction plans based on each student''s needs, helping them build skills, confidence, and measurable academic progress.',
+    'optional',
+    FALSE, FALSE, FALSE, FALSE,
+    FALSE, NULL
+  )
+ON CONFLICT (slug) DO UPDATE SET
+  name                 = EXCLUDED.name,
+  color                = EXCLUDED.color,
+  sort_order           = EXCLUDED.sort_order,
+  instruction_type     = EXCLUDED.instruction_type,
+  icon                 = EXCLUDED.icon,
+  delivery_types       = EXCLUDED.delivery_types,
+  challenge            = EXCLUDED.challenge,
+  solution             = EXCLUDED.solution,
+  teacher_of_record    = EXCLUDED.teacher_of_record,
+  has_lms              = EXCLUDED.has_lms,
+  has_exit_tickets     = EXCLUDED.has_exit_tickets,
+  has_mini_lesson      = EXCLUDED.has_mini_lesson,
+  has_swd_progress     = EXCLUDED.has_swd_progress,
+  gradebooks_included  = EXCLUDED.gradebooks_included,
+  gradebooks_note      = EXCLUDED.gradebooks_note;

--- a/prisma/migrations/20260505_add_service_pricing_and_aliases/migration.sql
+++ b/prisma/migrations/20260505_add_service_pricing_and_aliases/migration.sql
@@ -1,0 +1,111 @@
+-- Adds two new services (Homebased, Virtual Medical Classroom) with blank
+-- enriched fields, plus the per-fiscal-year service_pricing table and the
+-- service_aliases mapping (with an unmapped_service_aliases drift view to
+-- catch new alias strings showing up in synced sessions/subscriptions).
+
+-- CreateEnum (idempotent)
+DO $$ BEGIN
+  CREATE TYPE "delivery_type" AS ENUM ('1:1', '1:10', '1:30');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Insert Homebased + Virtual Medical Classroom. Fields beyond the required
+-- ones stay NULL until someone fills them in.
+INSERT INTO "services" ("name", "slug", "color", "sort_order") VALUES
+  ('Homebased', 'homebased', '#7AAFC4', 11),
+  ('Virtual Medical Classroom', 'virtual-medical-classroom', '#B89FCC', 12)
+ON CONFLICT (slug) DO NOTHING;
+
+-- CreateTable: service_pricing
+CREATE TABLE IF NOT EXISTS "service_pricing" (
+  "id"             SERIAL          NOT NULL,
+  "service_id"     INTEGER         NOT NULL,
+  "fiscal_year"    INTEGER         NOT NULL,
+  "delivery"       "delivery_type" NOT NULL,
+  "rate_cents"     INTEGER         NOT NULL,
+  "description"    TEXT,
+  "effective_from" TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+  CONSTRAINT "service_pricing_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "service_pricing_service_id_fkey"
+    FOREIGN KEY ("service_id") REFERENCES "services"("id") ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "service_pricing_service_year_delivery_key"
+  ON "service_pricing"("service_id", "fiscal_year", "delivery");
+
+CREATE INDEX IF NOT EXISTS "service_pricing_fiscal_year_idx"
+  ON "service_pricing"("fiscal_year");
+
+-- CreateTable: service_aliases
+-- One row per alias string seen in sessions/subscriptions. Maps to a
+-- canonical Service (or ignored=true to suppress an alias we don't care about).
+CREATE TABLE IF NOT EXISTS "service_aliases" (
+  "alias"      TEXT        NOT NULL,
+  "service_id" INTEGER,
+  "ignored"    BOOLEAN     NOT NULL DEFAULT FALSE,
+  "created_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "updated_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT "service_aliases_pkey" PRIMARY KEY ("alias"),
+  CONSTRAINT "service_aliases_service_id_fkey"
+    FOREIGN KEY ("service_id") REFERENCES "services"("id") ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS "service_aliases_service_id_idx"
+  ON "service_aliases"("service_id");
+
+-- View: unmapped_service_aliases
+-- Surfaces alias strings present in synced data that have no row in
+-- service_aliases. The admin UI reads this to show drift.
+CREATE OR REPLACE VIEW "unmapped_service_aliases" AS
+SELECT
+  alias,
+  STRING_AGG(DISTINCT source, ', ' ORDER BY source) AS sources,
+  SUM(row_count)::int                                AS row_count,
+  MAX(last_seen)                                     AS last_seen
+FROM (
+  SELECT service_type AS alias, 'sessions.service_type' AS source,
+         COUNT(*) AS row_count, MAX(synced_at) AS last_seen
+  FROM "sessions"
+  WHERE service_type IS NOT NULL AND service_type <> ''
+  GROUP BY service_type
+  UNION ALL
+  SELECT service_name, 'sessions.service_name',
+         COUNT(*), MAX(synced_at)
+  FROM "sessions"
+  WHERE service_name IS NOT NULL AND service_name <> ''
+  GROUP BY service_name
+  UNION ALL
+  SELECT product, 'subscriptions.product',
+         COUNT(*), MAX(synced_at)
+  FROM "subscriptions"
+  WHERE product IS NOT NULL AND product <> ''
+  GROUP BY product
+  UNION ALL
+  SELECT product_type, 'subscriptions.product_type',
+         COUNT(*), MAX(synced_at)
+  FROM "subscriptions"
+  WHERE product_type IS NOT NULL AND product_type <> ''
+  GROUP BY product_type
+  UNION ALL
+  SELECT sub_product, 'subscriptions.sub_product',
+         COUNT(*), MAX(synced_at)
+  FROM "subscriptions"
+  WHERE sub_product IS NOT NULL AND sub_product <> ''
+  GROUP BY sub_product
+) src
+WHERE alias NOT IN (SELECT alias FROM "service_aliases")
+GROUP BY alias
+ORDER BY row_count DESC;
+
+-- Trigger: keep service_aliases.updated_at fresh on UPDATE
+CREATE OR REPLACE FUNCTION "service_aliases_set_updated_at"() RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS "service_aliases_updated_at" ON "service_aliases";
+CREATE TRIGGER "service_aliases_updated_at"
+  BEFORE UPDATE ON "service_aliases"
+  FOR EACH ROW EXECUTE FUNCTION "service_aliases_set_updated_at"();

--- a/prisma/migrations/20260506_service_hierarchy_and_alias_seed/migration.sql
+++ b/prisma/migrations/20260506_service_hierarchy_and_alias_seed/migration.sql
@@ -1,0 +1,105 @@
+-- Adds service hierarchy (parent_service_id), four new top-level services
+-- (Extra Help, AP, College Level, AVID) and three Homebound subtypes
+-- (General, Medical, Suspension), seeds service_aliases from prod
+-- sessions.service_type values, and tightens the unmapped view to scan
+-- only sessions.service_type (subscription columns and sessions.service_name
+-- aren't service taxonomy and produce noise).
+
+-- ==========================================================================
+-- 1. Service hierarchy
+-- ==========================================================================
+ALTER TABLE "services"
+  ADD COLUMN IF NOT EXISTS "parent_service_id" INTEGER;
+
+DO $$ BEGIN
+  ALTER TABLE "services"
+    ADD CONSTRAINT "services_parent_service_id_fkey"
+    FOREIGN KEY ("parent_service_id") REFERENCES "services"("id") ON DELETE SET NULL;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE INDEX IF NOT EXISTS "services_parent_service_id_idx"
+  ON "services"("parent_service_id");
+
+-- ==========================================================================
+-- 2. New top-level services (Extra Help, AP, College Level, AVID)
+-- ==========================================================================
+INSERT INTO "services" ("name", "slug", "color", "sort_order") VALUES
+  ('Extra Help',    'extra-help',    '#E89055', 13),
+  ('AP',            'ap',            '#4A6B8C', 14),
+  ('College Level', 'college-level', '#5C8D6F', 15),
+  ('AVID',          'avid',          '#B5836A', 16)
+ON CONFLICT (slug) DO NOTHING;
+
+-- ==========================================================================
+-- 3. Homebound subtypes — parent_service_id resolved by slug lookup
+-- ==========================================================================
+INSERT INTO "services" ("name", "slug", "color", "sort_order", "parent_service_id")
+SELECT subtype.name, subtype.slug, subtype.color, subtype.sort_order, parent.id
+FROM (VALUES
+  ('Homebound - General',    'homebound-general',    '#6EA3BE', 17),
+  ('Homebound - Medical',    'homebound-medical',    '#4F8CAB', 18),
+  ('Homebound - Suspension', 'homebound-suspension', '#8FBAD0', 19)
+) AS subtype(name, slug, color, sort_order)
+CROSS JOIN (SELECT id FROM "services" WHERE slug = 'homebound') AS parent
+ON CONFLICT (slug) DO NOTHING;
+
+-- ==========================================================================
+-- 4. Seed service_aliases from prod sessions.service_type values
+--    (covers ~436K of ~437K total session rows; ignores 'n/a')
+-- ==========================================================================
+INSERT INTO "service_aliases" ("alias", "service_id", "ignored")
+SELECT a.alias, s.id, FALSE
+FROM (VALUES
+  ('Homebound',                            'homebound'),
+  ('homebounds',                           'homebound'),
+  ('Homebound - General',                  'homebound-general'),
+  ('Homebound - Medical',                  'homebound-medical'),
+  ('Homebound - Suspension',               'homebound-suspension'),
+  ('Whole Class Virtual Instruction',      'wcvi'),
+  ('Suspension Alternative - WC',          'suspension-alt'),
+  ('Credit Recovery',                      'credit-recovery'),
+  ('Tutoring',                             'tutoring'),
+  ('Tutoring (Acceleration/Remediation)',  'tutoring'),
+  ('Homework Help',                        'homework-help'),
+  ('Resource Room',                        'resource-rooms'),
+  ('Test Prep',                            'test-prep'),
+  ('State Test Prep',                      'test-prep'),
+  ('SAT Test Prep',                        'test-prep'),
+  ('Extra Help',                           'extra-help'),
+  ('AP',                                   'ap'),
+  ('College Level',                        'college-level'),
+  ('AVID',                                 'avid'),
+  ('virtualStaffing',                      'hybrid-staffing')
+) AS a(alias, slug)
+JOIN "services" s ON s.slug = a.slug
+ON CONFLICT (alias) DO UPDATE SET
+  service_id = EXCLUDED.service_id,
+  ignored    = FALSE;
+
+-- 'n/a' is real but meaningless — mark ignored so it stops appearing in the view.
+INSERT INTO "service_aliases" ("alias", "service_id", "ignored")
+VALUES ('n/a', NULL, TRUE)
+ON CONFLICT (alias) DO UPDATE SET service_id = NULL, ignored = TRUE;
+
+-- ==========================================================================
+-- 5. Tighten unmapped view to sessions.service_type only.
+--    sessions.service_name is a SKU (service_type + modifiers) not a service.
+--    subscriptions.* are billing tiers/SKUs from Elevate, not service taxonomy.
+-- ==========================================================================
+CREATE OR REPLACE VIEW "unmapped_service_aliases" AS
+SELECT
+  alias,
+  STRING_AGG(DISTINCT source, ', ' ORDER BY source) AS sources,
+  SUM(row_count)::int                                AS row_count,
+  MAX(last_seen)                                     AS last_seen
+FROM (
+  SELECT service_type AS alias, 'sessions.service_type' AS source,
+         COUNT(*) AS row_count, MAX(synced_at) AS last_seen
+  FROM "sessions"
+  WHERE service_type IS NOT NULL AND service_type <> ''
+  GROUP BY service_type
+) src
+WHERE alias NOT IN (SELECT alias FROM "service_aliases")
+GROUP BY alias
+ORDER BY row_count DESC;

--- a/prisma/migrations/20260507_add_ek12_services/migration.sql
+++ b/prisma/migrations/20260507_add_ek12_services/migration.sql
@@ -1,0 +1,75 @@
+-- Adds the four EK12 (Elevate K12) instructional service buckets as catalog
+-- rows, seeds aliases for all 11 known subscriptions.product_type values
+-- (instructional → mapped, add-ons + billing artifacts → ignored), and
+-- expands the unmapped_service_aliases view to scan subscriptions.product_type
+-- in addition to sessions.service_type.
+
+-- ==========================================================================
+-- 1. Four new EK12 instructional services. Enriched fields stay NULL.
+-- ==========================================================================
+INSERT INTO "services" ("name", "slug", "color", "sort_order") VALUES
+  ('EK12 Tier 1',           'ek12-tier-1',           '#2D7E8C', 20),
+  ('EK12 Diverse Learning', 'ek12-diverse-learning', '#6B4C8C', 21),
+  ('EK12 Enrichment',       'ek12-enrichment',       '#A8923C', 22),
+  ('EK12 Supplemental',     'ek12-supplemental',     '#C46B8A', 23)
+ON CONFLICT (slug) DO NOTHING;
+
+-- ==========================================================================
+-- 2. Map the four instructional product_type values to the new services.
+-- ==========================================================================
+INSERT INTO "service_aliases" ("alias", "service_id", "ignored")
+SELECT a.alias, s.id, FALSE
+FROM (VALUES
+  ('Tier 1',           'ek12-tier-1'),
+  ('Diverse Learning', 'ek12-diverse-learning'),
+  ('Enrichment',       'ek12-enrichment'),
+  ('Supplemental',     'ek12-supplemental')
+) AS a(alias, slug)
+JOIN "services" s ON s.slug = a.slug
+ON CONFLICT (alias) DO UPDATE SET
+  service_id = EXCLUDED.service_id,
+  ignored    = FALSE;
+
+-- ==========================================================================
+-- 3. Mark add-ons and billing artifacts as ignored. They have real revenue
+--    but aren't catalog services — same separation as the Add-Ons section in
+--    PricingAndPackagingPage. Ignored=true keeps them out of the unmapped
+--    drift view so the admin tab stays focused on real gaps.
+-- ==========================================================================
+INSERT INTO "service_aliases" ("alias", "service_id", "ignored") VALUES
+  ('Teacher Collaberation Meetings', NULL, TRUE),
+  ('Teacher Collaboration Hours',    NULL, TRUE),
+  ('Office Hours',                   NULL, TRUE),
+  ('Student Office Hours',           NULL, TRUE),
+  ('Fee',                            NULL, TRUE),
+  ('Credit',                         NULL, TRUE),
+  ('Placeholder Product',            NULL, TRUE)
+ON CONFLICT (alias) DO UPDATE SET service_id = NULL, ignored = TRUE;
+
+-- ==========================================================================
+-- 4. Expand unmapped view to also scan subscriptions.product_type.
+--    sessions.service_name and subscriptions.product / sub_product remain
+--    excluded — they're SKUs/subjects, not service taxonomy.
+-- ==========================================================================
+CREATE OR REPLACE VIEW "unmapped_service_aliases" AS
+SELECT
+  alias,
+  STRING_AGG(DISTINCT source, ', ' ORDER BY source) AS sources,
+  SUM(row_count)::int                                AS row_count,
+  MAX(last_seen)                                     AS last_seen
+FROM (
+  SELECT service_type AS alias, 'sessions.service_type' AS source,
+         COUNT(*) AS row_count, MAX(synced_at) AS last_seen
+  FROM "sessions"
+  WHERE service_type IS NOT NULL AND service_type <> ''
+  GROUP BY service_type
+  UNION ALL
+  SELECT product_type, 'subscriptions.product_type',
+         COUNT(*), MAX(synced_at)
+  FROM "subscriptions"
+  WHERE product_type IS NOT NULL AND product_type <> ''
+  GROUP BY product_type
+) src
+WHERE alias NOT IN (SELECT alias FROM "service_aliases")
+GROUP BY alias
+ORDER BY row_count DESC;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -974,18 +974,93 @@ enum ServiceCategory {
   @@map("service_category")
 }
 
+enum InstructionType {
+  core_credit_bearing
+  supplemental
+
+  @@map("instruction_type")
+}
+
+enum TeacherOfRecord {
+  required
+  optional
+
+  @@map("teacher_of_record")
+}
+
+enum DeliveryType {
+  one_to_one    @map("1:1")
+  one_to_ten    @map("1:10")
+  one_to_thirty @map("1:30")
+
+  @@map("delivery_type")
+}
+
 // ===== Service Catalog =====
 // Fullmind's service offerings that can be targeted for districts
 model Service {
-  id        Int    @id @default(autoincrement())
-  name      String @unique @db.VarChar(100)
-  slug      String @unique @db.VarChar(50)
-  color     String @db.VarChar(7)
-  sortOrder Int    @default(0) @map("sort_order")
+  id                 Int              @id @default(autoincrement())
+  name               String           @unique @db.VarChar(100)
+  slug               String           @unique @db.VarChar(50)
+  color              String           @db.VarChar(7)
+  sortOrder          Int              @default(0) @map("sort_order")
+  instructionType    InstructionType? @map("instruction_type")
+  icon               String?          @db.VarChar(50)
+  deliveryTypes      String[]         @default([]) @map("delivery_types")
+  challenge          String?
+  solution           String?
+  teacherOfRecord    TeacherOfRecord? @map("teacher_of_record")
+  hasLms             Boolean          @default(false) @map("has_lms")
+  hasExitTickets     Boolean          @default(false) @map("has_exit_tickets")
+  hasMiniLesson      Boolean          @default(false) @map("has_mini_lesson")
+  hasSwdProgress     Boolean          @default(false) @map("has_swd_progress")
+  gradebooksIncluded Boolean          @default(false) @map("gradebooks_included")
+  gradebooksNote     String?          @map("gradebooks_note")
+  parentServiceId    Int?             @map("parent_service_id")
+
+  parent   Service?  @relation("ServiceHierarchy", fields: [parentServiceId], references: [id])
+  subtypes Service[] @relation("ServiceHierarchy")
 
   planDistrictServices TerritoryPlanDistrictService[]
+  pricing              ServicePricing[]
+  aliases              ServiceAlias[]
 
+  @@index([parentServiceId])
   @@map("services")
+}
+
+// Per-fiscal-year pricing for instructional services. One row per
+// (service, fiscal_year, delivery). rate_cents avoids float drift.
+model ServicePricing {
+  id            Int          @id @default(autoincrement())
+  serviceId     Int          @map("service_id")
+  fiscalYear    Int          @map("fiscal_year")
+  delivery      DeliveryType
+  rateCents     Int          @map("rate_cents")
+  description   String?
+  effectiveFrom DateTime     @default(now()) @map("effective_from") @db.Timestamptz
+
+  service Service @relation(fields: [serviceId], references: [id], onDelete: Cascade)
+
+  @@unique([serviceId, fiscalYear, delivery])
+  @@index([fiscalYear])
+  @@map("service_pricing")
+}
+
+// Maps free-form service strings from synced sessions/subscriptions to a
+// canonical Service. ignored=true suppresses the alias from the unmapped
+// view without tying it to a service.
+model ServiceAlias {
+  alias     String   @id
+  serviceId Int?     @map("service_id")
+  ignored   Boolean  @default(false)
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt DateTime @updatedAt @map("updated_at") @db.Timestamptz
+
+  service Service? @relation(fields: [serviceId], references: [id], onDelete: SetNull)
+
+  @@index([serviceId])
+  @@map("service_aliases")
 }
 
 // Junction table linking plan-districts to target services
@@ -1488,19 +1563,19 @@ model UnmatchedOpportunity {
 // ===== Vacancy Scanner =====
 // Tracks job board scan runs for audit and progress reporting
 model VacancyScan {
-  id                    String    @id @default(cuid())
-  leaid                 String    @db.VarChar(7)
-  status                String    @db.VarChar(20) // pending, running, completed, completed_partial, failed
-  platform              String?   @db.VarChar(50)
-  vacancyCount          Int?      @map("vacancy_count")
-  fullmindRelevantCount Int?      @map("fullmind_relevant_count")
-  districtsMatched      Int?      @map("districts_matched")
-  startedAt             DateTime  @default(now()) @map("started_at")
-  completedAt           DateTime? @map("completed_at")
-  errorMessage          String?   @map("error_message") @db.Text
+  id                    String                @id @default(cuid())
+  leaid                 String                @db.VarChar(7)
+  status                String                @db.VarChar(20) // pending, running, completed, completed_partial, failed
+  platform              String?               @db.VarChar(50)
+  vacancyCount          Int?                  @map("vacancy_count")
+  fullmindRelevantCount Int?                  @map("fullmind_relevant_count")
+  districtsMatched      Int?                  @map("districts_matched")
+  startedAt             DateTime              @default(now()) @map("started_at")
+  completedAt           DateTime?             @map("completed_at")
+  errorMessage          String?               @map("error_message") @db.Text
   failureReason         VacancyFailureReason? @map("failure_reason")
-  triggeredBy           String    @map("triggered_by") @db.VarChar(100)
-  batchId               String?   @map("batch_id") @db.VarChar(50)
+  triggeredBy           String                @map("triggered_by") @db.VarChar(100)
+  batchId               String?               @map("batch_id") @db.VarChar(50)
 
   district  District  @relation(fields: [leaid], references: [leaid])
   vacancies Vacancy[]

--- a/src/app/api/admin/service-aliases/route.ts
+++ b/src/app/api/admin/service-aliases/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { getAdminUser } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/admin/service-aliases — list existing alias mappings.
+export async function GET() {
+  const admin = await getAdminUser();
+  if (!admin) return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+
+  const aliases = await prisma.serviceAlias.findMany({
+    orderBy: { alias: "asc" },
+    include: { service: { select: { id: true, name: true, slug: true } } },
+  });
+  return NextResponse.json({ aliases });
+}
+
+// POST /api/admin/service-aliases — create or update a mapping.
+// Body: { alias: string, serviceId?: number | null, ignored?: boolean }
+// Either serviceId or ignored=true must be set; not both.
+export async function POST(request: NextRequest) {
+  const admin = await getAdminUser();
+  if (!admin) return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+
+  const body = await request.json().catch(() => null);
+  if (!body || typeof body !== "object") {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { alias, serviceId, ignored } = body as {
+    alias?: unknown;
+    serviceId?: unknown;
+    ignored?: unknown;
+  };
+
+  if (typeof alias !== "string" || alias.trim().length === 0) {
+    return NextResponse.json({ error: "alias is required" }, { status: 400 });
+  }
+
+  const ignoredBool = ignored === true;
+  const serviceIdNum =
+    typeof serviceId === "number" ? serviceId : serviceId == null ? null : NaN;
+
+  if (Number.isNaN(serviceIdNum)) {
+    return NextResponse.json({ error: "serviceId must be a number or null" }, { status: 400 });
+  }
+
+  if (ignoredBool && serviceIdNum != null) {
+    return NextResponse.json(
+      { error: "Cannot set both serviceId and ignored=true" },
+      { status: 400 }
+    );
+  }
+
+  if (!ignoredBool && serviceIdNum == null) {
+    return NextResponse.json(
+      { error: "Must set either serviceId or ignored=true" },
+      { status: 400 }
+    );
+  }
+
+  if (serviceIdNum != null) {
+    const exists = await prisma.service.findUnique({ where: { id: serviceIdNum } });
+    if (!exists) return NextResponse.json({ error: "Service not found" }, { status: 404 });
+  }
+
+  const row = await prisma.serviceAlias.upsert({
+    where: { alias: alias.trim() },
+    update: { serviceId: serviceIdNum, ignored: ignoredBool },
+    create: { alias: alias.trim(), serviceId: serviceIdNum, ignored: ignoredBool },
+  });
+
+  return NextResponse.json({ alias: row });
+}

--- a/src/app/api/admin/service-aliases/unmapped/route.ts
+++ b/src/app/api/admin/service-aliases/unmapped/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { getAdminUser } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+type UnmappedRow = {
+  alias: string;
+  sources: string;
+  row_count: number;
+  last_seen: Date | null;
+};
+
+// GET /api/admin/service-aliases/unmapped — drift list of alias strings
+// present in synced sessions/subscriptions that have no service_aliases row yet.
+export async function GET() {
+  const admin = await getAdminUser();
+  if (!admin) return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+
+  const rows = await prisma.$queryRaw<UnmappedRow[]>`
+    SELECT alias, sources, row_count, last_seen
+    FROM "unmapped_service_aliases"
+  `;
+
+  return NextResponse.json({
+    rows: rows.map((r) => ({
+      alias: r.alias,
+      sources: r.sources,
+      rowCount: Number(r.row_count),
+      lastSeen: r.last_seen?.toISOString() ?? null,
+    })),
+  });
+}

--- a/src/features/admin/components/AdminDashboard.tsx
+++ b/src/features/admin/components/AdminDashboard.tsx
@@ -8,7 +8,14 @@ const UsersTab = lazy(() => import("./UsersTab"));
 const IntegrationsTab = lazy(() => import("./IntegrationsTab"));
 const IngestHealthTab = lazy(() => import("./IngestHealthTab"));
 const VacancyConfigTab = lazy(() => import("./VacancyConfigTab"));
-type AdminTab = "unmatched" | "users" | "integrations" | "ingest-health" | "vacancy-config";
+const ServiceAliasesTab = lazy(() => import("./ServiceAliasesTab"));
+type AdminTab =
+  | "unmatched"
+  | "users"
+  | "integrations"
+  | "ingest-health"
+  | "vacancy-config"
+  | "service-aliases";
 
 const TABS: { id: AdminTab; label: string }[] = [
   { id: "unmatched", label: "Unmatched Opps" },
@@ -16,6 +23,7 @@ const TABS: { id: AdminTab; label: string }[] = [
   { id: "integrations", label: "Integrations" },
   { id: "ingest-health", label: "Ingest Health" },
   { id: "vacancy-config", label: "Vacancy Config" },
+  { id: "service-aliases", label: "Service Aliases" },
 ];
 
 // Legacy slug alias: old bookmarks to ?section=sync should still land here.
@@ -118,6 +126,7 @@ export default function AdminDashboard({ initialSection }: AdminDashboardProps) 
             {activeTab === "integrations" && <IntegrationsTab />}
             {activeTab === "ingest-health" && <IngestHealthTab />}
             {activeTab === "vacancy-config" && <VacancyConfigTab />}
+            {activeTab === "service-aliases" && <ServiceAliasesTab />}
           </Suspense>
         </div>
       </div>

--- a/src/features/admin/components/ServiceAliasesTab.tsx
+++ b/src/features/admin/components/ServiceAliasesTab.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { fetchJson, API_BASE } from "@/features/shared/lib/api-client";
+
+interface UnmappedAlias {
+  alias: string;
+  sources: string;
+  rowCount: number;
+  lastSeen: string | null;
+}
+
+interface Service {
+  id: number;
+  name: string;
+  slug: string;
+}
+
+interface UnmappedResponse {
+  rows: UnmappedAlias[];
+}
+
+function useUnmappedAliases() {
+  return useQuery({
+    queryKey: ["admin", "serviceAliases", "unmapped"],
+    queryFn: () =>
+      fetchJson<UnmappedResponse>(`${API_BASE}/admin/service-aliases/unmapped`),
+    staleTime: 60_000,
+  });
+}
+
+function useServices() {
+  return useQuery({
+    queryKey: ["services"],
+    queryFn: () => fetchJson<Service[]>(`${API_BASE}/services`),
+    staleTime: 5 * 60_000,
+  });
+}
+
+function useMapAlias() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: { alias: string; serviceId?: number | null; ignored?: boolean }) =>
+      fetchJson<unknown>(`${API_BASE}/admin/service-aliases`, {
+        method: "POST",
+        body: JSON.stringify(data),
+      }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["admin", "serviceAliases"] });
+    },
+  });
+}
+
+function relativeTime(iso: string | null): string {
+  if (!iso) return "—";
+  const diff = Date.now() - new Date(iso).getTime();
+  const days = Math.floor(diff / 86_400_000);
+  if (days < 1) return "Today";
+  if (days === 1) return "1 day ago";
+  if (days < 30) return `${days} days ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
+function AliasRow({
+  row,
+  services,
+  onMap,
+  pending,
+}: {
+  row: UnmappedAlias;
+  services: Service[];
+  onMap: (alias: string, serviceId: number | null, ignored: boolean) => void;
+  pending: boolean;
+}) {
+  const [selected, setSelected] = useState<string>("");
+
+  const handleApply = () => {
+    if (!selected) return;
+    if (selected === "__ignore__") {
+      onMap(row.alias, null, true);
+    } else {
+      onMap(row.alias, Number(selected), false);
+    }
+  };
+
+  return (
+    <tr className="border-t border-[#E2DEEC]">
+      <td className="px-3 py-3 font-medium text-[#403770] whitespace-nowrap">
+        {row.alias}
+      </td>
+      <td className="px-3 py-3 text-xs text-[#8A80A8] whitespace-nowrap">{row.sources}</td>
+      <td className="px-3 py-3 text-sm text-[#6E6390] tabular-nums">
+        {row.rowCount.toLocaleString()}
+      </td>
+      <td className="px-3 py-3 text-xs text-[#8A80A8] whitespace-nowrap">
+        {relativeTime(row.lastSeen)}
+      </td>
+      <td className="px-3 py-3">
+        <div className="flex items-center gap-2">
+          <select
+            value={selected}
+            onChange={(e) => setSelected(e.target.value)}
+            disabled={pending}
+            className="text-xs border border-[#E2DEEC] rounded-md px-2 py-1.5 bg-white text-[#403770] focus:outline-none focus:border-[#F37167]"
+          >
+            <option value="">Map to…</option>
+            {services.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+            <option value="__ignore__">— Ignore</option>
+          </select>
+          <button
+            type="button"
+            onClick={handleApply}
+            disabled={!selected || pending}
+            className="text-xs font-medium px-3 py-1.5 rounded-md bg-[#403770] text-white disabled:bg-[#E2DEEC] disabled:text-[#A69DC0]"
+          >
+            Apply
+          </button>
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+export default function ServiceAliasesTab() {
+  const unmapped = useUnmappedAliases();
+  const services = useServices();
+  const map = useMapAlias();
+
+  if (unmapped.isLoading || services.isLoading) {
+    return (
+      <div className="space-y-3">
+        {[...Array(4)].map((_, i) => (
+          <div key={i} className="h-12 bg-[#E2DEEC]/40 rounded-lg animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  if (unmapped.error || services.error) {
+    return (
+      <div className="text-sm text-[#c25a52] bg-[#F37167]/10 rounded-lg p-4">
+        Failed to load service aliases.{" "}
+        {(unmapped.error as Error | null)?.message ?? (services.error as Error | null)?.message}
+      </div>
+    );
+  }
+
+  const rows = unmapped.data?.rows ?? [];
+  const allServices = services.data ?? [];
+
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-xl border border-[#E2DEEC] bg-white p-8 text-center">
+        <p className="text-sm font-medium text-[#403770]">All service aliases are mapped.</p>
+        <p className="text-xs text-[#8A80A8] mt-1">
+          New strings appearing in synced sessions or subscriptions will show up here.
+        </p>
+      </div>
+    );
+  }
+
+  const handleMap = (alias: string, serviceId: number | null, ignored: boolean) => {
+    map.mutate({ alias, serviceId, ignored });
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg bg-[#F7F5FA] border border-[#E2DEEC] px-4 py-3">
+        <p className="text-sm text-[#6E6390]">
+          <span className="font-semibold text-[#403770]">{rows.length}</span> alias
+          {rows.length === 1 ? "" : "es"} from synced sessions/subscriptions{" "}
+          {rows.length === 1 ? "is" : "are"} not mapped to a service in the catalog.
+        </p>
+      </div>
+
+      <div className="border border-[#E2DEEC] rounded-xl overflow-hidden bg-white">
+        <table className="w-full">
+          <thead>
+            <tr className="bg-[#F7F5FA] text-[10px] font-semibold text-[#8A80A8] uppercase tracking-wider">
+              <th className="text-left px-3 py-3">Alias</th>
+              <th className="text-left px-3 py-3">Sources</th>
+              <th className="text-left px-3 py-3 w-24">Rows</th>
+              <th className="text-left px-3 py-3 w-32">Last seen</th>
+              <th className="text-left px-3 py-3 w-72">Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <AliasRow
+                key={row.alias}
+                row={row}
+                services={allServices}
+                onMap={handleMap}
+                pending={map.isPending}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/district-column-metadata.ts
+++ b/src/lib/district-column-metadata.ts
@@ -2100,7 +2100,7 @@ export const SUBSCRIPTION_COLUMNS: ColumnMetadata[] = [
     field: "product",
     column: "product",
     label: "Product",
-    description: "Top-level product name on an EK12 subscription line (Elevate taxonomy) — the subscription-side equivalent of a session's service_type. Reps use this for 'EK12 subscription revenue by product', 'which districts purchased product X', or 'our Algebra subscription mix'. Pair with product_type (category) and sub_product (detail) for finer breakdowns. See SEMANTIC_CONTEXT.conceptMappings.service_type_breakdown for the cross-table pattern when a rep asks about service breakdowns including both sessions and subscriptions.",
+    description: "EK12 subscription SKU string (e.g., '45-60 min 5DaysStandard Full Year'). NOT a service taxonomy — this is the time-format SKU. For service-level rollups, use product_type (the actual taxonomy column) joined through service_aliases. See SEMANTIC_CONTEXT.conceptMappings.service_type_breakdown.",
     domain: "subscription",
     format: "text",
     source: "elevate_k12",
@@ -2110,7 +2110,7 @@ export const SUBSCRIPTION_COLUMNS: ColumnMetadata[] = [
     field: "productType",
     column: "product_type",
     label: "Product Type",
-    description: "Category tier of the EK12 product (Elevate taxonomy) — one level of hierarchy above product. Use for high-level breakdowns like 'subscription revenue by product type'. Pair with product and sub_product for drill-down.",
+    description: "EK12 service taxonomy category. Full enum: 'Tier 1', 'Diverse Learning', 'Enrichment', 'Supplemental' (the four instructional buckets), plus add-ons/billing artifacts ('Office Hours', 'Student Office Hours', 'Teacher Collaboration Hours', 'Teacher Collaberation Meetings' [sic typo], 'Fee', 'Credit', 'Placeholder Product'). For service-level rollups join through service_aliases (alias=product_type → service_id → services), filtering ignored=FALSE — see SEMANTIC_CONTEXT.conceptMappings.service_type_breakdown. For drill-down into subjects use sub_product.",
     domain: "subscription",
     format: "text",
     source: "elevate_k12",
@@ -2546,7 +2546,7 @@ export const SCHOOL_ENROLLMENT_HISTORY_COLUMNS: ColumnMetadata[] = [
 export const SESSION_COLUMNS: ColumnMetadata[] = [
   { field: "id", column: "id", label: "Session ID", description: "Fullmind LMS session PK.", domain: "session", format: "text", source: "opensearch", queryable: true },
   { field: "opportunityId", column: "opportunity_id", label: "Opportunity ID", description: "FK to opportunities.id. NOT a hard FK — 33% of sessions point to historical opps not in our opportunities table (scheduler sync lag).", domain: "opportunity", format: "text", source: "opensearch", queryable: true },
-  { field: "serviceType", column: "service_type", label: "Service Type", description: "Service type code for this session (e.g., math, tutoring, SPED, ELL, enrichment, science) — the canonical per-session tag used for 'math sessions this month', 'science sessions by district', 'SPED sessions', 'session revenue by service type', or 'which services did we deliver in Texas' breakdowns. Pair with service_name for human-readable labels. Session-level; session_price × sessions aggregates give per-service session revenue. See SEMANTIC_CONTEXT.conceptMappings.service_type_breakdown for the cross-table pattern.", domain: "session", format: "text", source: "opensearch", queryable: true },
+  { field: "serviceType", column: "service_type", label: "Service Type", description: "Raw per-session service tag from OpenSearch (e.g., 'Homebound - Medical', 'Tutoring (Acceleration/Remediation)', 'virtualStaffing'). DO NOT GROUP BY this column directly for service rollups — it has 20+ variants and was never normalized. Always join through service_aliases (alias → service_id → services) to roll up to canonical service names. See SEMANTIC_CONTEXT.conceptMappings.service_type_breakdown for the canonical join pattern. Pair with service_name for the human-readable label when displaying individual session rows.", domain: "session", format: "text", source: "opensearch", queryable: true },
   { field: "sessionPrice", column: "session_price", label: "Session Price", description: "Customer-facing price per session — the revenue side of the session economics. Reps ask about this as 'session revenue' (SUM(session_price) on completed sessions), 'price per session', or as the top line of margin math. Per-session margin = session_price − educator_price. For deal-level or rep-level revenue rollups, prefer opportunities.completed_revenue / scheduled_revenue (or DOA / DF); aggregate sessions directly only when the question is session-grain.", domain: "session", format: "currency", source: "opensearch", queryable: true },
   { field: "educatorPrice", column: "educator_price", label: "Educator Price", description: "Amount paid to the educator for the session — the cost side of the session economics. Reps ask about this as 'educator cost' (SUM(educator_price) on completed sessions), 'pay rate', or as the bottom line of margin math. Per-session margin = session_price − educator_price. See educator_approved_price for the approved-rate variant.", domain: "session", format: "currency", source: "opensearch", queryable: true },
   { field: "educatorApprovedPrice", column: "educator_approved_price", label: "Educator Approved Price", description: "Admin-approved educator rate. In most cases matches educator_price; diverges only when the approved rate is set but the actual paid rate has been adjusted. For margin math or 'educator cost' questions, default to educator_price — only reach for educator_approved_price when the rep specifically asks about approved/contracted rates vs paid.", domain: "session", format: "currency", source: "opensearch", queryable: true },
@@ -2642,6 +2642,48 @@ export const SAVED_REPORT_COLUMNS: ColumnMetadata[] = [
   { field: "runCount", column: "run_count", label: "Run Count", description: "How many times the report has been executed.", domain: "audit", format: "integer", source: "query_tool", queryable: true },
   { field: "createdAt", column: "created_at", label: "Created At", description: "When the report was saved.", domain: "audit", format: "date", source: "query_tool", queryable: true },
   { field: "updatedAt", column: "updated_at", label: "Updated At", description: "When the report was last modified.", domain: "audit", format: "date", source: "query_tool", queryable: true },
+];
+
+/** services — Fullmind + EK12 service catalog. Canonical taxonomy used to roll up sessions and EK12 subscriptions via service_aliases. Some rows are subtypes of a parent (parent_service_id NOT NULL) — Homebound has General/Medical/Suspension subtypes. */
+export const SERVICE_COLUMNS: ColumnMetadata[] = [
+  { field: "id", column: "id", label: "Service ID", description: "Auto-increment primary key.", domain: "core", format: "integer", source: "user", queryable: true },
+  { field: "name", column: "name", label: "Service Name", description: "Customer-facing service name (e.g., 'Homebound', 'Whole Class Virtual Instruction', 'EK12 Tier 1'). Unique. Use this column when surfacing service names to reps. Subtypes carry their parent name with a suffix ('Homebound - Medical').", domain: "core", format: "text", source: "user", queryable: true },
+  { field: "slug", column: "slug", label: "Slug", description: "URL-safe identifier (e.g., 'homebound', 'wcvi', 'ek12-tier-1'). Stable across renames; useful as a stable filter key. Reps usually filter by name, not slug.", domain: "core", format: "text", source: "user", queryable: true },
+  { field: "color", column: "color", label: "Brand Color", description: "Hex color used for chips/charts. UI-only; never select for reps.", domain: "core", format: "text", source: "user", queryable: false },
+  { field: "sortOrder", column: "sort_order", label: "Sort Order", description: "Stable ordering within the catalog. Lower = earlier. Use for ORDER BY when listing services.", domain: "core", format: "integer", source: "user", queryable: true },
+  { field: "instructionType", column: "instruction_type", label: "Instruction Type", description: "Enum: 'core_credit_bearing' (services that grant seat-time credit — Homebound, WCVI, Credit Recovery, Suspension Alternative, Hybrid Staffing) or 'supplemental' (additional support — Tutoring, Resource Room, Test Prep, Homework Help, iTutor). NULL on services that haven't been classified (Homebased, Virtual Medical Classroom, Extra Help, AP, College Level, AVID, EK12 services, Homebound subtypes).", domain: "core", format: "text", source: "user", queryable: true },
+  { field: "icon", column: "icon", label: "Icon", description: "Lucide icon name. UI-only; never select for reps.", domain: "core", format: "text", source: "user", queryable: false },
+  { field: "deliveryTypes", column: "delivery_types", label: "Delivery Types", description: "Postgres text[] of '1:1', 'SG' (small group), and/or 'WC' (whole class). Use ARRAY operators: '1:1' = ANY(delivery_types). Empty array on services that haven't been classified.", domain: "core", format: "text", source: "user", queryable: true },
+  { field: "challenge", column: "challenge", label: "Challenge", description: "Long-form description of the customer problem this service solves (rep-facing copy from the Resources tab). Useful when the rep asks 'what does <service> solve' or 'pitch X service'. NULL on services without enriched content yet.", domain: "core", format: "text", source: "user", queryable: true },
+  { field: "solution", column: "solution", label: "Solution", description: "Long-form description of how Fullmind delivers this service (rep-facing copy from the Resources tab). Pair with challenge. NULL until enriched.", domain: "core", format: "text", source: "user", queryable: true },
+  { field: "teacherOfRecord", column: "teacher_of_record", label: "Teacher of Record", description: "Enum: 'required' or 'optional'. Whether the service requires a school-side teacher of record. Required for credit-bearing; optional for most supplemental.", domain: "core", format: "text", source: "user", queryable: true },
+  { field: "hasLms", column: "has_lms", label: "LMS Included", description: "Whether the service uses Fullmind's LMS for lessons/assignments. TRUE for most credit-bearing and supplemental services; FALSE for Hybrid Staffing and iTutor (which use the school's own platform or no LMS).", domain: "core", format: "boolean", source: "user", queryable: true },
+  { field: "hasExitTickets", column: "has_exit_tickets", label: "Exit Tickets", description: "Whether the service includes end-of-session exit tickets.", domain: "core", format: "boolean", source: "user", queryable: true },
+  { field: "hasMiniLesson", column: "has_mini_lesson", label: "Mini Lesson", description: "Whether the service includes a mini-lesson per session.", domain: "core", format: "boolean", source: "user", queryable: true },
+  { field: "hasSwdProgress", column: "has_swd_progress", label: "SWD Progress Monitoring", description: "Whether the service includes IEP progress monitoring for students with disabilities. TRUE for Homebound, WCVI, and Resource Room; FALSE elsewhere.", domain: "core", format: "boolean", source: "user", queryable: true },
+  { field: "gradebooksIncluded", column: "gradebooks_included", label: "Gradebooks Included", description: "Whether grading happens in Fullmind's gradebooks. FALSE for Hybrid Staffing (uses school's platform — see gradebooks_note) and supplemental services that don't issue grades.", domain: "core", format: "boolean", source: "user", queryable: true },
+  { field: "gradebooksNote", column: "gradebooks_note", label: "Gradebooks Note", description: "Free-text explanation when gradebooks aren't included by default. Currently only set for Hybrid Staffing ('School's platform').", domain: "core", format: "text", source: "user", queryable: true },
+  { field: "parentServiceId", column: "parent_service_id", label: "Parent Service", description: "FK to services.id when this row is a subtype. Currently used by the Homebound subtypes (General/Medical/Suspension). NULL for top-level services. To list subtypes of a parent: WHERE parent_service_id = (SELECT id FROM services WHERE slug = '<parent-slug>'). To roll up subtype counts to the parent: COALESCE(parent_service_id, id) AS effective_service_id.", domain: "core", format: "integer", source: "user", queryable: true },
+];
+
+/** service_pricing — per-fiscal-year, per-delivery-mode rates for services. Empty in v1; populated as pricing migrates from PricingAndPackagingPage. */
+export const SERVICE_PRICING_COLUMNS: ColumnMetadata[] = [
+  { field: "id", column: "id", label: "ID", description: "Auto-increment primary key.", domain: "core", format: "integer", source: "user", queryable: true },
+  { field: "serviceId", column: "service_id", label: "Service", description: "FK to services.id. Always join through services for the human-readable name.", domain: "core", format: "integer", source: "user", queryable: true },
+  { field: "fiscalYear", column: "fiscal_year", label: "Fiscal Year", description: "Numeric FY (e.g., 2026 = FY26). Same convention as territory_plans.fiscal_year — NOT the 'YYYY-YY' string used on opportunities or 'FYNN' on district_financials. See SEMANTIC_CONTEXT.formatMismatches.fiscal_year.", domain: "core", format: "year", source: "user", queryable: true },
+  { field: "delivery", column: "delivery", label: "Delivery", description: "Enum: '1:1', '1:10', or '1:30'. Pricing tier for the delivery mode.", domain: "core", format: "text", source: "user", queryable: true },
+  { field: "rateCents", column: "rate_cents", label: "Rate (cents)", description: "Per-session/per-unit rate stored in cents to avoid float drift. Divide by 100 for dollars: rate_cents / 100.0 AS rate_dollars.", domain: "core", format: "integer", source: "user", queryable: true },
+  { field: "description", column: "description", label: "Description", description: "Free-text pricing-context blurb (e.g., 'Drop-in help for assignments brought to the session.').", domain: "core", format: "text", source: "user", queryable: true },
+  { field: "effectiveFrom", column: "effective_from", label: "Effective From", description: "When this rate became effective. Useful for historical pricing snapshots.", domain: "core", format: "date", source: "user", queryable: true },
+];
+
+/** service_aliases — maps free-form sessions.service_type and subscriptions.product_type strings to canonical services. THE join surface for service-level rollups. */
+export const SERVICE_ALIAS_COLUMNS: ColumnMetadata[] = [
+  { field: "alias", column: "alias", label: "Alias", description: "The raw string as it appears in sessions.service_type or subscriptions.product_type (e.g., 'Tutoring (Acceleration/Remediation)', 'virtualStaffing', 'Tier 1', 'Homebound - Medical'). Primary key.", domain: "core", format: "text", source: "user", queryable: true },
+  { field: "serviceId", column: "service_id", label: "Service", description: "FK to services.id when the alias maps to a catalog service. NULL when ignored=TRUE.", domain: "core", format: "integer", source: "user", queryable: true },
+  { field: "ignored", column: "ignored", label: "Ignored", description: "TRUE when the alias is intentionally not mapped to any service (billing artifacts like 'Fee', 'Credit', 'Placeholder Product', 'n/a', plus EK12 add-ons like 'Office Hours' that aren't catalog services). When rolling up sessions/subscriptions to services, filter ignored=FALSE.", domain: "core", format: "boolean", source: "user", queryable: true },
+  { field: "createdAt", column: "created_at", label: "Created At", description: "When the alias was first mapped.", domain: "core", format: "date", source: "user", queryable: true },
+  { field: "updatedAt", column: "updated_at", label: "Updated At", description: "Last time the mapping changed (auto-touched by trigger).", domain: "core", format: "date", source: "user", queryable: true },
 ];
 
 // ============================================================================
@@ -3438,11 +3480,35 @@ export const TABLE_REGISTRY: Record<string, TableMetadata> = {
   },
   services: {
     table: "services",
-    description: "Catalog of Fullmind service offerings that can be targeted for districts in a plan (via territory_plan_district_services).",
+    description:
+      "Canonical service catalog spanning native Fullmind services (Homebound, Tutoring, WCVI, etc.) and post-merger EK12 services (EK12 Tier 1, EK12 Diverse Learning, EK12 Enrichment, EK12 Supplemental). Also holds service subtypes (parent_service_id) — currently only Homebound has subtypes (General/Medical/Suspension). For 'what services do we offer' rep questions, ORDER BY sort_order. To roll session or EK12 subscription rows up to a canonical service, JOIN through service_aliases (alias → service_id), filtering out ignored=TRUE. See SEMANTIC_CONTEXT.conceptMappings.service_type_breakdown for the full pattern.",
     primaryKey: "id",
-    columns: [],
+    columns: SERVICE_COLUMNS,
     relationships: [
-      { toTable: "territory_plan_district_services", type: "one-to-many", joinSql: "territory_plan_district_services.service_id = services.id", description: "Junction to plan-districts" },
+      { toTable: "service_aliases", type: "one-to-many", joinSql: "service_aliases.service_id = services.id", description: "Aliases (raw session/subscription strings) that map to this service" },
+      { toTable: "service_pricing", type: "one-to-many", joinSql: "service_pricing.service_id = services.id", description: "Per-fiscal-year pricing tiers for this service" },
+      { toTable: "services", type: "many-to-one", joinSql: "services.parent_service_id = services.id", description: "Parent service (when this row is a subtype like Homebound - Medical)" },
+      { toTable: "territory_plan_district_services", type: "one-to-many", joinSql: "territory_plan_district_services.service_id = services.id", description: "Junction to plan-districts (return vs new targeting)" },
+    ],
+  },
+  service_pricing: {
+    table: "service_pricing",
+    description:
+      "Per-fiscal-year, per-delivery-mode rates for services. One row per (service, fiscal_year, delivery). rate_cents stores the price in cents (divide by 100 for dollars). Currently EMPTY in v1 — pricing still lives hardcoded in PricingAndPackagingPage; this table is the migration target. When seeded, becomes the canonical rate source for 'what does <service> cost' / 'price for <service> 1:30' rep questions.",
+    primaryKey: "id",
+    columns: SERVICE_PRICING_COLUMNS,
+    relationships: [
+      { toTable: "services", type: "many-to-one", joinSql: "service_pricing.service_id = services.id", description: "Service being priced" },
+    ],
+  },
+  service_aliases: {
+    table: "service_aliases",
+    description:
+      "Maps the free-form strings in sessions.service_type and subscriptions.product_type to canonical service catalog rows. THIS IS THE JOIN SURFACE for any service-level rollup of sessions or EK12 subscriptions — sessions.service_type alone has 80+ raw variants ('Tutoring (Acceleration/Remediation)', 'virtualStaffing', 'Homebound - Medical', etc.) that won't aggregate cleanly without this mapping. Always filter ignored=FALSE when rolling up; ignored rows cover billing artifacts (Fee, Credit, Placeholder Product, n/a) and EK12 add-ons that aren't catalog services (Office Hours, Teacher Collaboration). New aliases that haven't been mapped yet are surfaced via the unmapped_service_aliases admin view (not in this registry — admin tool only).",
+    primaryKey: "alias",
+    columns: SERVICE_ALIAS_COLUMNS,
+    relationships: [
+      { toTable: "services", type: "many-to-one", joinSql: "service_aliases.service_id = services.id", description: "Canonical service this alias maps to" },
     ],
   },
 };
@@ -3535,8 +3601,13 @@ export const SEMANTIC_CONTEXT: SemanticContext = {
     },
     service_type_breakdown: {
       dealLevel:
-        "For service-type breakdowns of revenue, the canonical shape depends on the modality: native Fullmind (session-based) → sessions.service_type / sessions.service_name with session_price × count(*) for revenue (or SUM(session_price)); EK12 subscriptions → subscriptions.product / product_type / sub_product / course_name with SUM(subscriptions.net_total). opportunities.service_types is a deal-level jsonb tag, not the canonical breakdown surface. For a combined cross-modality breakdown ('Algebra revenue overall'), UNION the two sources with a modality column and sum.",
-      note: "Neither DOA nor DF breaks revenue down by service type — the breakdown must be computed from sessions and/or subscriptions directly. When a rep asks 'revenue by service type' or 'how much Algebra did we book this year', route to sessions for session-based revenue and subscriptions for EK12 revenue, and combine if the question is modality-agnostic. Use DOA or DF to cross-check totals afterward (sum of breakdown should match DOA/DF total_revenue for the same scope, modulo small timing differences).",
+        "For service-level rollups of sessions or EK12 subscriptions, ALWAYS join through service_aliases — never group on raw sessions.service_type / subscriptions.product_type. The raw columns have 80+ variants ('Tutoring (Acceleration/Remediation)', 'virtualStaffing', 'Homebound - Medical', 'Tier 1', 'Diverse Learning', 'n/a', etc.) that won't aggregate cleanly. Canonical pattern for sessions: `JOIN service_aliases sa ON sa.alias = sessions.service_type AND sa.ignored = FALSE JOIN services svc ON svc.id = sa.service_id GROUP BY svc.name, svc.sort_order ORDER BY svc.sort_order`. Canonical pattern for subscriptions: same shape but `sa.alias = subscriptions.product_type`. For combined cross-modality ('total revenue per service across both sessions and EK12 subscriptions'), UNION ALL two CTEs (one per source) and SUM by service name. opportunities.service_types is a deal-level jsonb tag, not the canonical breakdown surface — use it only for 'which deals tag service X' style questions, not revenue breakdowns.",
+      note: "Neither DOA nor DF breaks revenue down by service. The breakdown must be computed from sessions and/or subscriptions through service_aliases. New session/subscription rows with brand-new alias strings won't appear in the rollup until the alias is mapped (admin Service Aliases tab handles this) — surface a small caveat when the question covers very recent data: 'unmapped aliases get bucketed out until an admin maps them'. Use DOA or DF totals to cross-check service-rollup sums (small timing drift expected). For Homebound questions, decide subtype-level vs parent: GROUP BY services.name keeps subtypes split (General / Medical / Suspension); to roll up to the parent, GROUP BY COALESCE(svc.parent_service_id, svc.id).",
+    },
+    services_catalog: {
+      aggregated:
+        "For 'what services do we offer' rep questions, list the services table directly. Default scope: all rows where parent_service_id IS NULL (top-level services only — subtypes confuse most rep questions unless explicitly asked). ORDER BY sort_order. Use name, instruction_type, and delivery_types for the rep-facing summary. Skip color/icon (UI-only). For 'core credit-bearing services' filter instruction_type = 'core_credit_bearing'; for 'supplemental services' filter instruction_type = 'supplemental'. EK12 services have name LIKE 'EK12 %' and instruction_type IS NULL.",
+      note: "When the rep asks about pricing alongside the catalog, JOIN service_pricing — but be aware service_pricing is currently empty (v1). When the rep asks about delivery breakdown ('which services support 1:30'), use ARRAY operator: '1:30' = ANY(delivery_types).",
     },
     competitor_revenue: {
       aggregated:


### PR DESCRIPTION
## Summary

- **Enriches the `services` catalog** from 9 lightly-populated rows to 23 rows with full content (instruction type, delivery, supports, teacher-of-record, challenge/solution copy from `OurServiceModelPage`). Adds iTutor, Homebased, Virtual Medical Classroom, Extra Help, AP, College Level, AVID, three Homebound subtypes, and four EK12 services (Tier 1, Diverse Learning, Enrichment, Supplemental).
- **Adds service hierarchy** (`parent_service_id`) so Homebound splits into General/Medical/Suspension subtypes while still rolling up.
- **Adds `service_aliases` mapping table** that resolves the 80+ raw variants in `sessions.service_type` and 11 in `subscriptions.product_type` to canonical catalog rows. Seeded from prod data (24 mapped + 8 intentionally ignored).
- **Adds `service_pricing` table** (empty for now — pricing still in `PricingAndPackagingPage`; this is the migration target).
- **Adds an admin "Service Aliases" tab** backed by an `unmapped_service_aliases` view, so new strings landing in synced sessions/subscriptions surface for one-click mapping instead of silently going un-rolled-up.
- **Teaches the Claude query tool** about all of this — full column metadata for the three new tables, rewritten `service_type_breakdown` concept that points at the alias-join pattern, new `services_catalog` concept, and updated hints on the source columns so Claude stops trying to GROUP BY raw `service_type`.

The 4 migrations are layered (each is a discrete review unit) but were all built in this session — no DB changes have been applied to prod yet.

## Why this matters

Pre-migration, ~$53M of revenue across sessions and EK12 subscriptions had no clean rollup story. The same conceptual service appeared as `Tutoring`, `Tutoring (Acceleration/Remediation)`, `tutoring`, etc. in the source data, and EK12 had a parallel taxonomy that didn't match Fullmind's. Reps couldn't ask service-level questions in the query tool without getting a fragmented or wrong answer. After this PR ships:
- Service-level rollups across both modalities resolve correctly.
- Drift is visible (admin tab) instead of silent.
- Five new question shapes are unlocked for the query tool (cross-sell candidates, subtype splits, catalog dead weight, EK12+native mixed customers, core vs supplemental pipeline mix).

## Test plan

- [x] `npx prisma format && npx prisma validate` clean
- [x] `npx prisma generate` succeeds
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run src/lib/__tests__/district-column-metadata.test.ts` — 10/10 passing (this test enforces that every Prisma model is either in TABLE_REGISTRY or excludedTables, and that all relationship targets resolve)
- [ ] Apply migrations locally and confirm seed data matches expected catalog (23 rows, 32 alias rows)
- [ ] Hit the admin Service Aliases tab, confirm empty state ("All service aliases are mapped") since the seed covers all known prod values
- [ ] Apply to prod via Supabase SQL editor in order: `20260504_enrich_services_catalog` → `20260505_add_service_pricing_and_aliases` → `20260506_service_hierarchy_and_alias_seed` → `20260507_add_ek12_services`, then insert 4 rows into `_prisma_migrations`

## Out of scope (follow-ups)

- Move `PricingAndPackagingPage` instructional pricing from hardcoded → `service_pricing` table reads
- Build a service-level revenue rollup view + UI surface (the table from the PR conversation that showed Hybrid Staffing at $13.4M etc.)
- Investigate the 4 EK12 data-quality rows surfaced during this work (3 "Placeholder Product" + 1 null-`product_type` row, all owned by Jenn Russart)
- Align `"Suspension Alternatives"` (plural) → `"Suspension Alternative"` in `PricingAndPackagingPage.tsx` to match the renamed catalog row

🤖 Generated with [Claude Code](https://claude.com/claude-code)