### PR TITLE
feat(activities): replace Quarter with searchable Table view

### DIFF
--- a/Docs/superpowers/plans/2026-05-05-activities-table-view-plan.md
+++ b/Docs/superpowers/plans/2026-05-05-activities-table-view-plan.md
@@ -1,0 +1,226 @@
+# Implementation Plan: Activities Table View
+
+**Spec:** `docs/superpowers/specs/2026-05-05-activities-table-view-spec.md`
+**Backend context:** `docs/superpowers/specs/2026-05-05-activities-table-view-backend-context.md`
+**Branch:** `worktree-activities-table-view`
+
+## Phasing
+
+Three phases. Phase 1 = backend extensions + new bulk route (independent of UI).
+Phase 2 = filter-store + ViewToggle wiring (small, unblocks UI). Phase 3 = the
+table UI itself, broken into independent task groups so they can be parallelized.
+
+Commit after each task group. Tests are written **with** each task group, not
+saved for the end (per `feedback_regular_commits.md`).
+
+---
+
+## Phase 1 — Backend (independent of UI)
+
+### Task 1.1 — Extend `GET /api/activities`
+
+**Files:**
+- `src/app/api/activities/route.ts` — add `?contactIds=`, `?sortBy=`, `?sortDir=`. Extend `?search=` to OR against `notes` + `outcome` columns (currently title-only).
+- `src/features/shared/types/api-types.ts` — add `contactIds?: number[]`, `sortBy?: ActivitySortKey`, `sortDir?: "asc" \| "desc"` to `ActivitiesParams`. Define `ActivitySortKey = "date" \| "type" \| "title" \| "district" \| "owner" \| "status"`.
+- `src/features/activities/lib/queries.ts` — extend `buildActivitiesQueryString` to serialize the new params (stable key, alphabetical sort preserved).
+- Response shape (`ActivityListItem`) — add `districtName: string \| null`, `contactName: string \| null`, `ownerFullName: string \| null`, `outcomePreview: string \| null`. Compute these via Prisma `include` for first district + first contact + owner; truncate notes/outcome to first 80 chars.
+
+**Tests:** `src/app/api/activities/__tests__/route.test.ts`
+- `?search` matches notes
+- `?search` matches outcome
+- `?contactIds=1,2` filters
+- `?sortBy=title&sortDir=asc` orders correctly
+- response includes new fields
+
+### Task 1.2 — Extend `PATCH /api/activities/[id]`
+
+**Files:**
+- `src/app/api/activities/[id]/route.ts` — accept optional `createdByUserId` in PATCH body. Auth: caller must be admin OR be the current owner.
+- `src/features/activities/lib/queries.ts` `useUpdateActivity` mutation type — add `createdByUserId?: string`.
+- Optimistic cache patch in `onMutate` — add `createdByUserId` patch.
+
+**Tests:** extend `src/app/api/activities/[id]/__tests__/route.test.ts`
+- Owner can reassign to another user
+- Non-owner non-admin cannot reassign
+- Admin can reassign anyone's row
+
+### Task 1.3 — New `PATCH /api/activities/bulk`
+
+**Files:**
+- `src/app/api/activities/bulk/route.ts` (new) — `PATCH` handler. Body: `{ ids: string[], updates: { ownerId?: string, status?: ActivityStatus } }`. Cap 500 ids. Per-row auth check (own row OR admin). Skip rows where `source === "system"` (matches single-row PATCH behavior).
+- `src/features/activities/lib/queries.ts` — new `useBulkUpdateActivities` mutation with optimistic cache patching across the listed ids; invalidate `["activities"]` and each `["activity", id]` on settle.
+
+**Tests:** `src/app/api/activities/bulk/__tests__/route.test.ts`
+- 1 own row + 1 other-user row → 1 success, 1 forbidden in the response per-row result
+- > 500 ids → 400
+- Empty `updates` → 400
+- `ownerId` change persists for caller's rows
+- `status` change persists
+- Admin can update any row
+
+**Commit:** `feat(api): activities Table view backend extensions`
+
+---
+
+## Phase 2 — Store + ViewToggle wiring (small, blocks Phase 3)
+
+### Task 2.1 — Filter store: add Table view fields
+
+**Files:**
+- `src/features/activities/lib/filters-store.ts`:
+  - `CalendarView`: replace `quarter` references — actual type already has `"schedule" | "month" | "week" | "map"`. Add `"table"`. (No `quarter` value to remove from the type itself; only `Grain = "quarter"` exists, which we keep — it's just no longer reachable from the toggle.)
+  - `ActivitiesFilters`: add `contactIds: number[]`, `dateFrom: string \| null`, `dateTo: string \| null`.
+  - `EMPTY_FILTERS` updated.
+  - `ChromeState`: add `tableSorts: SortRule[]`, `tableVisibleColumns: string[]`, `tablePage: number`, `tablePageSize: number` plus their setters. (`SortRule` imported from `DataGrid/types.ts`.)
+  - `persist.partialize`: include the new table-state fields.
+  - `deriveActivitiesParams`: branch on a `view` argument — if `view === "table"`, drop the anchor+grain date computation and instead pass `startDateFrom: filters.dateFrom?.slice(0,10)` / `startDateTo: filters.dateTo?.slice(0,10)` only when set; pass `contactIds`, `sortBy`, `sortDir`, `limit`, `offset`. (Function takes a new optional `view` param so callers don't need refactoring.)
+
+**Tests:** `src/features/activities/lib/__tests__/filters-store.test.ts`
+- New fields default correctly
+- `deriveActivitiesParams({ view: "table" })` skips anchor+grain, uses dateFrom/dateTo
+- `deriveActivitiesParams({ view: "table" })` returns `limit/offset/sortBy/sortDir`
+- Old views still derive anchor+grain
+- Persist round-trip preserves the new table fields
+
+### Task 2.2 — ViewToggle: replace Quarter with Table
+
+**Files:**
+- `src/features/activities/components/page/ViewToggle.tsx`:
+  - Remove the `quarter` option.
+  - Add `{ id: "table", label: "Table", view: "table", grain: "week", Icon: Table }` (lucide `Table`) between `month` and `map`.
+  - `activeId` adds `if (view === "table") return "table"`.
+
+**Tests:** `src/features/activities/components/page/__tests__/ViewToggle.test.tsx`
+- Renders Table button
+- Quarter button is gone
+- Click Table → `onChange({ view: "table", grain: "week" })`
+
+**Commit:** `feat(activities): wire Table view into chrome + filter store`
+
+---
+
+## Phase 3 — Table UI
+
+Three task groups can run in parallel after Phase 2 lands.
+
+### Task 3.1 — Toolbar + DataGrid wiring (`ActivitiesTableView`)
+
+**Files:**
+- `src/features/activities/components/page/ActivitiesTableView.tsx` (new):
+  - Reads `useActivitiesChrome` for filters, sorts, page, pageSize, visibleColumns.
+  - Calls `useActivities(deriveActivitiesParams({ filters, anchorIso, grain, view: "table" }))`.
+  - Renders `<ActivitiesTableToolbar />`, `<DataGrid />` (with custom `cellRenderers` for the 4 editable columns), pagination footer, `<BulkActionBar />`.
+  - Selection state held locally (set of activity ids).
+  - Row click handler → `setOpenActivityId` from the parent shell (props).
+  - Drawer prev/next walks the **paginated** sorted result list.
+- `src/features/activities/components/page/table/ActivitiesTableToolbar.tsx` (new):
+  - Search input (debounced 250ms, writes to `filters.text`).
+  - `Reset` button (only when any filter active).
+  - `<ExportMenu />` and `<ColumnsPicker />`.
+- `src/features/activities/components/page/table/ColumnsPicker.tsx` (new):
+  - Multi-checkbox dropdown of the `ColumnDef[]`. Persists selection to `tableVisibleColumns` via store.
+- `src/features/activities/components/page/table/ExportMenu.tsx` (new):
+  - Dropdown: "Export selected" (disabled when none selected), "Export all filtered". Uses `rowsToCsv` + `downloadCsv` from `src/features/reports/lib/csv.ts`. Filename: `activities-{YYYY-MM-DD}.csv`.
+- `src/features/activities/components/page/table/columns.ts` (new):
+  - Defines `ColumnDef[]` for the 8 + extra columns. Wide bundle (8) marked `isDefault: true`. Each `key` matches an `ActivityListItem` field for sort/filter wiring.
+- `src/features/activities/components/page/ActivitiesPageShell.tsx`:
+  - Add `view === "table"` branch that renders `ActivitiesTableView` and **suppresses** `ActivitiesDateRange`, `ActivitiesFilterChips`, `UpcomingRail`. Keep header + scope toggle + drawer.
+
+**Tests:** `src/features/activities/components/page/__tests__/ActivitiesTableView.test.tsx`
+- Renders 8 default columns
+- Search input writes to filter store
+- Page change updates store
+- 200+ banner appears at threshold
+- Empty state (no filters): "No activities yet" + CTA
+- Empty state (filters active): "No matches" + Reset
+- Error state shows retry
+- Loading shows skeleton rows
+- Row click calls `onActivityClick`
+
+### Task 3.2 — Column-header filters + sort
+
+**Files:**
+- `src/features/activities/components/page/table/ActivitiesTableHeader.tsx` (new):
+  - Row of column-header buttons. Click label → cycle sort (asc → desc → off). Shift-click → multi-sort. Click `▾` icon → open `ColumnFilterPopover` with column key.
+  - Active-filter dot on filter trigger when that column has a value in `filters`.
+- `src/features/activities/components/page/table/ColumnFilterPopover.tsx` (new):
+  - Generic dispatcher that picks the body by `column.filterType` ("date" | "enum" | "text" | "relation").
+- Filter bodies (one file each in `src/features/activities/components/page/table/filters/`):
+  - `DateRangeFilter.tsx` — preset chips + custom range.
+  - `TypeFilter.tsx` — reuses `PopoverItem` + `ACTIVITY_CATEGORIES` accordion (extract a shared internal component if cleanly separable; otherwise inline).
+  - `OwnerFilter.tsx` — user list, "Me" pinned, search if >5.
+  - `StatusFilter.tsx` — `ACTIVITY_STATUS_CONFIG` swatches.
+  - `DistrictFilter.tsx` — search-as-you-type via `useDistricts({ search, limit: 25 })`.
+  - `ContactFilter.tsx` — search-as-you-type via `useSearchContacts(search)`.
+  - `TextFilter.tsx` — single text input, debounced.
+- All filter bodies write to `useActivitiesChrome.patchFilters`.
+
+**Tests:** `src/features/activities/components/page/table/__tests__/ActivitiesTableHeader.test.tsx`
+- Click date column → sort asc, click again → desc, third click → off
+- Shift-click adds to multi-sort
+- Filter trigger shows dot when filter active
+- Popover opens with correct body for each column type
+
+Plus one test per filter body (focus on writes-to-store behavior).
+
+### Task 3.3 — Editable cells + BulkActionBar
+
+**Files:**
+- `src/features/activities/components/page/table/cells/EditableDateCell.tsx` (new) — date+time popover. Calls `useUpdateActivity({ activityId, startDate })`.
+- `src/features/activities/components/page/table/cells/EditableTypeCell.tsx` (new) — type dropdown. Calls `useUpdateActivity({ activityId, type })`.
+- `src/features/activities/components/page/table/cells/EditableOwnerCell.tsx` (new) — user picker. Calls `useUpdateActivity({ activityId, createdByUserId })`. Disabled (read-only) for non-owner / non-admin callers (greyed avatar with tooltip "Only owner or admin can reassign").
+- `src/features/activities/components/page/table/cells/EditableStatusCell.tsx` (new) — status dropdown using `ACTIVITY_STATUS_CONFIG`. Calls `useUpdateActivity({ activityId, status })`.
+- `src/features/activities/components/page/table/BulkActionBar.tsx` (new):
+  - Sticky bottom; visible when `selectedIds.size > 0`.
+  - Buttons: Reassign owner ▾ (user picker), Change status ▾ (status picker), Export CSV (selected rows only via `rowsToCsv`), Clear selection.
+  - Calls `useBulkUpdateActivities`. Shows toast on success/failure with per-row counts.
+- All editable cells `stopPropagation` on click so the row doesn't open the drawer.
+
+**Tests:** Each cell gets a focused test (`__tests__/Editable{X}Cell.test.tsx`):
+- Click cell opens popover
+- Selecting a value calls `useUpdateActivity` with the right shape
+- `stopPropagation` verified (row click handler not fired)
+- Permission check on `EditableOwnerCell` (non-owner non-admin → disabled state)
+
+`BulkActionBar.test.tsx`:
+- Hidden with no selection
+- Reassign owner triggers `useBulkUpdateActivities`
+- Export selected calls `rowsToCsv` + `downloadCsv`
+- Clear empties selection
+
+**Commit per task group:**
+- 3.1: `feat(activities): table view shell, toolbar, columns, export`
+- 3.2: `feat(activities): column-header filters and sort`
+- 3.3: `feat(activities): inline-editable cells and bulk action bar`
+
+---
+
+## Test strategy
+
+- All tests Vitest + Testing Library + jsdom, co-located in `__tests__/`.
+- Mock `@/lib/supabase/server` (`getUser`, `isAdmin`) and `@/lib/prisma` per existing patterns from `src/app/api/activities/__tests__/route.test.ts`.
+- TanStack Query in tests uses a per-test `QueryClient` with `retry: false` and `gcTime: 0`.
+- Avoid `act()` warnings by awaiting `findByRole` over `getByRole` for popovers.
+- Visual regression handled by manual dev-server smoke after Phase 3 lands.
+
+## Risks / mitigation
+
+| Risk | Mitigation |
+|------|-----------|
+| Search across notes/outcome on a multi-thousand row table is slow | Phase 1 uses simple `ILIKE` OR; if slow in prod, follow up with tsvector + GIN migration (out of scope for v1) |
+| Bulk PATCH partial failures confuse users | Response returns `{ succeeded: string[], failed: { id, reason }[] }` per-row; toast summarizes both counts |
+| Inline edit + filter shifting the row out from under the cursor | `keepPreviousData` on `useActivities` + optimistic cache update means the row shows the new value immediately; row reorder happens on next refetch only |
+| User clicks editable cell expecting drawer | Hover states + small pencil icon on editable cells signal the difference; documented in design-review checklist |
+| `quarter` removed from toggle but old persisted state has `grain: "quarter"` | `ViewToggle.activeId` now defaults to `"month"` for `view === "month" && grain === "quarter"`; users see Month selected and the grain auto-corrects on next interaction |
+
+## Ordering / dependencies
+
+```
+Phase 1 (1.1, 1.2, 1.3) — independent, parallelizable
+       ↓
+Phase 2 (2.1 → 2.2)     — sequential, small
+       ↓
+Phase 3 (3.1, 3.2, 3.3) — parallelizable after 2.2
+```
+
+3.1 can land first (table renders read-only). 3.2 + 3.3 can land independently after.

--- a/Docs/superpowers/specs/2026-05-04-district-claims-design.md
+++ b/Docs/superpowers/specs/2026-05-04-district-claims-design.md
@@ -6,23 +6,27 @@
 
 ## Problem
 
-Districts today have a single editable `District.ownerId` field. Most existing values were assigned arbitrarily during data import; they don't reflect any real working relationship. The "Owner" UI surfaces (search-result card, district-edit modal, batch-edit) reinforce the wrong mental model: that a district has one designated rep.
+Districts today have a single editable `District.ownerId` field. Most existing values were assigned arbitrarily during a CRM-name backfill at login time; they don't reflect any real working relationship. The "Owner" UI surfaces reinforce the wrong mental model: that a district has one designated rep.
 
-In practice, multiple reps may legitimately have standing on a district — anyone with closed-won/lost history in the last 18 months, anyone with an open opportunity, anyone working a territory plan that includes the district. We want to model that reality and let reps explicitly *claim* districts they're actively pursuing.
+The same CRM-name backfill (`src/app/auth/callback/route.ts`) populates `sales_executive_id` on districts, schools, accounts, and unmatched_accounts, plus `territory_owner_id` on states. All of these share the same problem: they're stale identity guesses dressed up as ownership. We're cleaning all of them up in one pass.
+
+In practice, multiple reps may legitimately have standing on a district — anyone with closed-won/lost history in the last 18 months, anyone with an open opportunity, anyone working a territory plan that includes the district. We want to model that reality on districts, and stop pretending the other entities have meaningful "owners."
 
 ## Goals
 
-- Replace the single-owner field with a multi-claimant model.
+- Replace the single-owner field on **districts** with a multi-claimant model (derived + manual claims).
 - Compute most claims automatically ("derived claims") from existing data — opportunities, territory plans.
 - Let reps explicitly *claim* / *release* / *transfer* districts they're working on ("manual claims"), independent of derived basis.
 - Surface claimants on district UI so reps can see at a glance who has standing.
-- Preserve historical attribution during migration; let stale assignments age out naturally.
+- **Drop the entire CRM-name-backfill family** across the schema — the same login-time logic that planted `District.ownerId` also planted `District.salesExecutiveId`, `School.ownerId`, `State.territoryOwnerId`, `Account.salesExecutiveId`, and `unmatched_accounts.sales_executive_id`. All go.
+- Preserve historical district attribution during migration; let stale assignments age out naturally.
 
 ## Non-goals
 
-- Reworking `TerritoryPlan.ownerId`. Plans still have a single owner; that's a different concept.
-- Changing how `Opportunity.salesRepId` works.
-- Reworking `District.salesExecutiveId` (separate account-level field, out of scope).
+- Extending the claim model to schools, states, or accounts. They just lose their owner field with no replacement.
+- Reworking `TerritoryPlan.ownerId`. Plans still have a single user-set owner; that's a different concept.
+- Reworking `MapView.ownerId`. User's own map views; user-set, untouched.
+- Changing how `Opportunity.salesRepId` and `salesRepName` work — the rep on a deal is still the rep on a deal.
 - Notifications when someone else claims a district. (Future.)
 - Permissions / locking — claims are signals, not exclusive locks. Anyone can claim anything.
 
@@ -100,12 +104,22 @@ FROM district_manual_claims;
 
 API reads `district_claimants_v` and groups in app code by `(district_leaid, user_id)`, collapsing bases into a list per user.
 
-### Schema removed (in destructive migration B)
+### Schema removed (in destructive migration C)
 
-- `District.ownerId` (column + Prisma field).
-- `District.ownerUser` Prisma relation.
-- `districts.owner_id` index.
-- The `DistrictOwner` named-relation on `UserProfile`.
+All columns, their indexes, and their Prisma relations:
+
+- `District.ownerId` / `districts.owner_id` + `District.ownerUser` (`DistrictOwner` named-relation).
+- `District.salesExecutiveId` / `districts.sales_executive_id` + `District.salesExecutiveUser` (`DistrictSalesExec` named-relation).
+- `School.ownerId` / `schools.owner_id` + `School.ownerUser` (`SchoolOwner` named-relation).
+- `State.territoryOwnerId` / `states.territory_owner_id` + `State.territoryOwnerUser` named-relation.
+- `Account.salesExecutiveId` / `accounts.sales_executive_id` + relation.
+- `unmatched_accounts.sales_executive_id` + relation.
+
+The companion CRM string columns (`districts.owner`, `districts.sales_executive`, `schools.owner`, `states.territory_owner`, etc.) — leave as-is for now. They're populated by the existing CRM ETL and may have other consumers; out of scope to chase down. They become harmless string fields nobody reads.
+
+### Materialized view rebuild
+
+The `district_materialized_financials` materialized view (aliased `dmf` in the summary endpoints) currently includes `sales_executive_id`. The destructive migration must drop and recreate this view without that column. The summary endpoints (`src/app/api/districts/summary/route.ts`, `summary/compare/route.ts`, `leaids/route.ts`) lose the ability to filter financials by `sales_executive_id` — see API changes below for the replacement.
 
 ## API
 
@@ -147,11 +161,37 @@ Body: `{ toUserId: string }`. Atomic: deletes the authenticated user's claim, cr
 
 ### Existing endpoints — changes
 
+District endpoints:
+
 - `GET /api/districts/search` — drop `ownerUser` from the response payload. Add an inline `claimantSummary` field with `{ count: number, currentUserIsClaimant: boolean, topAvatars: Array<{ id, avatarUrl }> }` (≤3 avatars) so the search-card avatar stack can render without a separate per-result fetch.
-- `GET /api/districts/:leaid` — drop `ownerUser` and the `edits.owner` field from response.
+- `GET /api/districts/:leaid` — drop `ownerUser`, `salesExecutiveUser`, `salesExecutive`, and the `edits.owner` field from response.
 - `PATCH /api/districts/:leaid/edits` — drop `ownerId` from accepted body.
-- `POST /api/districts/batch-edits` — drop `ownerId` from the accepted body and from the validation that requires "at least one of ownerId or notes." Endpoint stays, now `notes`-only.
+- `POST /api/districts/batch-edits` — drop `ownerId` from the accepted body and from the "at least one of" validation. Endpoint stays, now `notes`-only.
+- `GET /api/districts` — drop the `salesExec` filter parameter. `where.salesExecutiveId` removed.
+- `GET /api/districts/summary`, `summary/compare`, `leaids` — the `owner` query param currently filters on `dmf.sales_executive_id`. Repurpose: `owner` now filters by *claimant* via a join through `district_claimants_v`. Same query param name, new semantics. (If keeping the param name causes confusion, rename to `claimedBy`; design assumes rename.)
 - District-list endpoint(s) accept a new `claimedBy=<userId>` filter that joins via `district_claimants_v`.
+
+Other endpoints (CRM-backfill cleanup):
+
+- `GET /api/states/[code]` — drop `territoryOwnerUser` and `territoryOwner` from response.
+- `PATCH /api/states/[code]` — drop `territoryOwnerId` from accepted body. The state edit form loses its owner select.
+- `GET /api/states/[code]/districts` — drop `salesExecutiveUser` and `salesExecutive` from each district row.
+- `GET /api/schools/[ncessch]`, `PATCH /api/schools/[ncessch]/edits` — drop `ownerUser` and `owner` from response and accepted body.
+- `POST /api/accounts` — drop `salesExecutiveId` from accepted body. Existing accounts keep working; new accounts can't be created with the field.
+- `GET /api/admin/unmatched-*` — drop the `sales_executive_id` filter parameter on the unmatched-accounts admin pages.
+- `GET /api/tiles/[z]/[x]/[y]` — drop `d.sales_executive_id` and `d.sales_executive_name` from the SELECT, and from tile-feature properties.
+
+### Auth callback (`src/app/auth/callback/route.ts`)
+
+The callback today runs one re-link by `salesRepEmail` (opportunities) plus a `Promise.all` wrapping five re-links by `crmName`. **Keep only the email-based opp re-link.** Delete the entire `Promise.all` block and the surrounding `crmName` profile fetch:
+
+- `UPDATE districts SET owner_id = ...`
+- `UPDATE districts SET sales_executive_id = ...`
+- `UPDATE states SET territory_owner_id = ...`
+- `UPDATE schools SET owner_id = ...`
+- `UPDATE unmatched_accounts SET sales_executive_id = ...`
+
+New users no longer get any CRM-name-derived ownership stitched together at login. Their connection to districts comes entirely from the claim system; their connection to opportunities still comes from the email-based salesRep re-link.
 
 ## UI
 
@@ -184,11 +224,37 @@ Remove the "Owner" select. The detail panel's Claims section replaces the editab
 
 New filter chip on the district list / map. Default state: **on** for the authenticated user (per CLAUDE.md "Filter bars default to current user"). One-click toggle to "All". Server side, the filter passes `claimedBy=<currentUserId>` to the list endpoint, which joins through `district_claimants_v`.
 
+### UI surfaces removed (CRM-backfill cleanup)
+
+District-level:
+
+- `src/features/districts/components/DistrictHeader.tsx:156-160` — "Sales Executive: <name>" row is deleted.
+- `src/features/map/components/SearchResults/DistrictExploreModal.tsx:285-286` — the "Owner" stat (currently bound to `salesExecutive`) is deleted.
+- `src/features/map/components/SearchBar/FullmindDropdown.tsx`, `DistrictsDropdown.tsx`, `FilterPills.tsx`, `SearchBar/index.tsx` — remove the `salesExecutive` and `owner` columns from the searchable filter set. The "Sales Exec" filter pill disappears.
+- `src/features/districts/lib/queries.ts` — drop `salesExecutive` from the params interface and from `searchParams` building. Drop `salesExecutiveId` from the edit-payload interface.
+- `src/features/shared/lib/queries.ts` — drop the `useSalesExecutives` query (`queryKey: ["salesExecutives"]`).
+- `src/features/shared/lib/app-store.ts` — drop the `salesExecutive` filter slice.
+- `src/features/shared/lib/filters.ts` — drop the `salesExecutive: "salesExecutiveId"` field-map entry.
+- `src/features/shared/types/api-types.ts` — drop `salesExecutive: PersonRef | null` from district-related response types (3 places) and `territoryOwner` from state types.
+- `src/lib/district-column-metadata.ts:2321` — drop the `territoryOwnerId` metadata entry (the column that backs it is gone).
+- `src/features/map/components/MapV2Container.tsx:1028` — drop the `salesExecutive: props?.sales_executive_name` mapping in the tile-feature handler.
+
+State-level:
+
+- The state detail panel's territory-owner edit field (anywhere `territoryOwnerId` is editable in the UI; trace from the `territoryOwner` types in `src/features/shared/types/api-types.ts:816` to its UI consumers).
+
+Account-level:
+
+- The "Sales Executive" filter on the unmatched-opps admin page (`src/app/admin/unmatched-opportunities/page.tsx` if it has one — verify during implementation; only the API filter is confirmed in trace).
+- The "Sales Executive" select on the create-account flow (consumer of `POST /api/accounts`).
+
 ### Surfaces NOT changing
 
-- `TerritoryPlan.ownerId` and the "Owner" label on `PlanDetailSidebar.tsx` — plan ownership is a separate concept.
+- `TerritoryPlan.ownerId` and the "Owner" label on `PlanDetailSidebar.tsx` — plan ownership is a separate concept, user-set, real.
 - `HomePanel`'s plan-owner filter — operates on plans, not districts.
-- `Opportunity.salesRepName` / `salesRepId` displayed in deal views — opp-level, not district-level.
+- `MapView.ownerId` — user's own map views, user-set.
+- `Opportunity.salesRepName` / `salesRepId` displayed in deal views — opp-level, not district-level. The email-based re-link in auth callback stays.
+- The CRM string columns themselves (`districts.owner`, `districts.sales_executive`, `schools.owner`, `states.territory_owner`, etc.). They're populated by the CRM ETL; we're not chasing down that pipeline. They become harmless fields nobody reads from app code.
 
 ## Migration
 
@@ -197,9 +263,13 @@ Three-phase. Each phase is a separate PR/deploy.
 ### Phase A — additive schema + backfill
 
 1. Migration creates `district_manual_claims` table, `district_derived_claims_v` view, and `district_claimants_v` view. No drops.
-2. Backfill script `scripts/backfill-district-manual-claims.ts`: for every district row with a non-null `ownerId`, insert into `district_manual_claims (district_leaid, user_id, claimed_at, last_activity_at)` with both timestamps set to `now()`. Skip if a row already exists for that `(leaid, user_id)`. Idempotent — can be re-run.
+2. Backfill script `scripts/backfill-district-manual-claims.ts`: for every district row, insert into `district_manual_claims (district_leaid, user_id, claimed_at, last_activity_at)` with both timestamps set to `now()` for **each** non-null `(leaid, user_id)` pair from these two sources:
+   - `(districts.leaid, districts.owner_id)` where `owner_id IS NOT NULL`
+   - `(districts.leaid, districts.sales_executive_id)` where `sales_executive_id IS NOT NULL`
 
-   Setting `last_activity_at = now()` starts the 6-month expiry clock fresh on backfill day. Random/wrong assignments will age out naturally if the rep never touches the district. Legitimate assignments will be kept alive by ongoing opps/plans/activities.
+   Skip if a row already exists for that `(leaid, user_id)` (UNIQUE constraint). Idempotent — can be re-run. If both `owner_id` and `sales_executive_id` point to the same user on a district, the second insert is a no-op.
+
+   Setting `last_activity_at = now()` starts the 6-month expiry clock fresh on backfill day. Random/wrong assignments age out naturally if the rep never touches the district. Legitimate assignments stay alive via ongoing opps/plans/activities.
 
 ### Phase B — audit (manual)
 
@@ -216,9 +286,15 @@ Sierra reviews `unsupported.csv` and chooses per row to keep, delete, or leave t
 
 Two PRs, in order:
 
-1. **App code PR** — implement the new claim API, the `<DistrictClaimants>` component, the search-card and detail-panel changes, the "Mine" filter chip, and remove all reads of `District.ownerUser` / `ownerId` in the codebase (API responses, UI components, search results, Prisma includes). Existing column stays in the database — application code just stops touching it. Deploy.
+1. **App code PR** — implement the new claim API, the `<DistrictClaimants>` component, the search-card and detail-panel changes, the "Mine" filter chip. Remove every read referenced in "Existing endpoints — changes" and "UI surfaces removed (CRM-backfill cleanup)" — the `ownerUser` / `salesExecutiveUser` / `territoryOwnerUser` Prisma includes, the related `salesExec` / `territoryOwnerId` query params, the filter pills, the header rows, the explore-modal stats, the `useSalesExecutives` query, the metadata entry, the auth-callback re-link blocks (4 of 5 deleted). Existing columns and the materialized view stay in the database — application code just stops touching them. Deploy.
 
-2. **Destructive migration PR** (after the app code is deployed and stable) — drop the `District.ownerUser` relation from `schema.prisma`, drop the `owner_id` column and its index, run `prisma migrate`. Splitting this off is cheap insurance: if any code path still referenced `ownerId`, we find out before the column is gone.
+2. **Destructive migration PR** (after the app code is deployed and stable) — single migration that:
+   1. Drops the `district_materialized_financials` view (or whatever its real name is — verify during implementation).
+   2. Drops the listed columns and indexes (`District.ownerId`, `District.salesExecutiveId`, `School.ownerId`, `State.territoryOwnerId`, `Account.salesExecutiveId`, `unmatched_accounts.sales_executive_id`).
+   3. Recreates `district_materialized_financials` from scratch without the `sales_executive_id` column.
+   4. Drops the corresponding Prisma relations from `schema.prisma` and runs `prisma migrate`.
+
+   Splitting this off from the app PR is cheap insurance: if any code path still referenced one of these columns, we find out before they're gone.
 
 ## Background jobs
 
@@ -273,9 +349,19 @@ Co-located under `__tests__/` next to source per project convention.
 - Detail panel shows Claim button when user is not a claimant; Release + Transfer when user is.
 - "Mine" filter chip default state matches current user.
 
+### Regression coverage for CRM-backfill cleanup
+
+- `GET /api/districts/:leaid` response no longer contains `ownerUser`, `salesExecutiveUser`, `salesExecutive`, or `edits.owner`.
+- `GET /api/states/[code]` response no longer contains `territoryOwnerUser` or `territoryOwner`.
+- `PATCH /api/districts/:leaid/edits` rejects (or ignores) an `ownerId` field; same for `PATCH /api/states/[code]` with `territoryOwnerId`.
+- `GET /api/districts?salesExec=...` no longer filters; the query param is silently ignored or returns 400 (pick one during implementation — lean toward "silently ignored" for forward compatibility).
+- `GET /api/districts/summary?owner=<userId>` filters by claimant, not by `sales_executive_id`. Verify with a fixture user who has a claim but no historical `sales_executive_id` and confirm the summary includes their districts.
+
 ## Open questions / future work
 
 - Notifications when someone claims, releases, or transfers a district you're connected to — defer.
 - Admin override to remove anyone's claim — defer until a real need surfaces.
 - Warning banner before expiry ("Your claim on X expires in 7 days") — defer.
-- Should `District.salesExecutiveId` be surfaced on the detail panel alongside claimants? Out of scope for this design.
+- Should states get their own claim model later? Today they have a single `territoryOwnerId` (which we're dropping). If state-level ownership turns out to matter for territory planning, consider a state_claims companion to district_claims in a later cycle.
+- Cleaning up the upstream CRM ETL that populates the now-orphan string columns (`districts.owner`, `sales_executive`, `territory_owner`, etc.) — out of scope; those columns become harmless string blobs.
+- Backfilling claim data into the `accounts` table (CMOs, ESAs, charter networks) — `Account.salesExecutiveId` is going away with no replacement on accounts. If account-level claims become a need, design separately.

--- a/Docs/superpowers/specs/2026-05-04-district-claims-design.md
+++ b/Docs/superpowers/specs/2026-05-04-district-claims-design.md
@@ -1,0 +1,281 @@
+# District Claims — Design
+
+**Status:** Draft
+**Author:** Sierra Arcega + Claude
+**Date:** 2026-05-04
+
+## Problem
+
+Districts today have a single editable `District.ownerId` field. Most existing values were assigned arbitrarily during data import; they don't reflect any real working relationship. The "Owner" UI surfaces (search-result card, district-edit modal, batch-edit) reinforce the wrong mental model: that a district has one designated rep.
+
+In practice, multiple reps may legitimately have standing on a district — anyone with closed-won/lost history in the last 18 months, anyone with an open opportunity, anyone working a territory plan that includes the district. We want to model that reality and let reps explicitly *claim* districts they're actively pursuing.
+
+## Goals
+
+- Replace the single-owner field with a multi-claimant model.
+- Compute most claims automatically ("derived claims") from existing data — opportunities, territory plans.
+- Let reps explicitly *claim* / *release* / *transfer* districts they're working on ("manual claims"), independent of derived basis.
+- Surface claimants on district UI so reps can see at a glance who has standing.
+- Preserve historical attribution during migration; let stale assignments age out naturally.
+
+## Non-goals
+
+- Reworking `TerritoryPlan.ownerId`. Plans still have a single owner; that's a different concept.
+- Changing how `Opportunity.salesRepId` works.
+- Reworking `District.salesExecutiveId` (separate account-level field, out of scope).
+- Notifications when someone else claims a district. (Future.)
+- Permissions / locking — claims are signals, not exclusive locks. Anyone can claim anything.
+
+## Concepts
+
+A **derived claim** is a `(district, user, basis)` tuple that follows automatically from other data. It is not stored — it's a SQL view.
+
+A **manual claim** is a user-authored row in a `district_manual_claims` table. A rep claims a district to signal "I'm actively working this." Multiple reps may hold manual claims on the same district simultaneously.
+
+A **claimant** is any user with at least one derived OR manual claim on a district.
+
+### Derivation rules
+
+A user has a derived claim on a district if **any** of these is true:
+
+1. They are `Opportunity.salesRepId` on an opp where `district_lea_id` matches and `stage IN ('Stage 0','Stage 1','Stage 2','Stage 3','Stage 4','Stage 5')`. (Open pipeline — no time filter.)
+2. They are `Opportunity.salesRepId` on an opp where `district_lea_id` matches and `stage IN ('Closed Won','Closed Lost')` and `close_date >= now() - interval '18 months'`.
+3. They are `TerritoryPlan.ownerId` on a plan that contains the district via `TerritoryPlanDistrict`.
+4. They are in `TerritoryPlanCollaborator` on a plan that contains the district via `TerritoryPlanDistrict`.
+
+Each rule emits a `basis` value: `open_pipeline`, `recently_closed`, `plan_owner`, `plan_collaborator`. A user with multiple matching rules has multiple bases on the same district; the UI collapses them onto a single user row with a chip per basis.
+
+### Manual-claim mechanics
+
+- **Claim** — a rep adds themselves as a claimant on a district. Idempotent.
+- **Release** — a rep removes their own claim. Cannot release someone else's.
+- **Transfer** — a rep hands their claim to another user in one atomic step. The current user's row is deleted; a new row is created for the target user with `claimed_at = now()`. Recipient consent is not required for v1.
+- **Expiry** — a manual claim is removed automatically when there has been no claim-extending activity from that rep on that district for 6 months. Activity = any of:
+  - rep is `salesRepId` on an opp at this district whose `created_at`, `close_date`, or latest `stage_history` entry falls within 6 months;
+  - rep is owner or collaborator on a plan that contains this district and the plan was created or updated within 6 months;
+  - rep has an `Activity` linked to this district via `ActivityDistrict` with `Activity.userId` = rep, within 6 months.
+
+  We materialize this as `last_activity_at` on the manual-claim row, refreshed nightly. Expiry runs daily and deletes claims with `last_activity_at < now() - interval '6 months'`. No advance warning to the rep in v1.
+
+## Data model
+
+### New table: `district_manual_claims`
+
+```sql
+CREATE TABLE district_manual_claims (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  district_leaid    varchar(7)  NOT NULL REFERENCES districts(leaid),
+  user_id           uuid        NOT NULL REFERENCES user_profiles(id),
+  claimed_at        timestamptz NOT NULL DEFAULT now(),
+  last_activity_at  timestamptz NOT NULL DEFAULT now(),
+  note              text,
+  UNIQUE (district_leaid, user_id)
+);
+CREATE INDEX district_manual_claims_user_idx       ON district_manual_claims(user_id);
+CREATE INDEX district_manual_claims_district_idx   ON district_manual_claims(district_leaid);
+CREATE INDEX district_manual_claims_last_activity  ON district_manual_claims(last_activity_at);
+```
+
+The `note` field is used for transfer audit trail (`transferred from <user>`); optional otherwise.
+
+### New view: `district_derived_claims_v`
+
+A read-only Postgres view emitting `(district_leaid, user_id, basis, since)` rows. Built as the union of:
+
+- `opportunities` rows where `district_lea_id IS NOT NULL AND sales_rep_id IS NOT NULL` and stage matches one of the open or recently-closed conditions; `basis` is `'open_pipeline'` or `'recently_closed'`; `since` is the opp's `close_date` for closed deals or `created_at` for open ones.
+- `territory_plan_districts` joined to `territory_plans` on plan owner; `basis = 'plan_owner'`; `since = added_at` of the district to the plan.
+- `territory_plan_districts` joined to `territory_plan_collaborators`; `basis = 'plan_collaborator'`; `since = added_at`.
+
+A `(district, user)` pair may produce multiple rows here (one per basis). The application collapses them at read time.
+
+### New view: `district_claimants_v`
+
+```sql
+SELECT district_leaid, user_id, basis, since, 'derived'::text AS kind
+FROM district_derived_claims_v
+UNION ALL
+SELECT district_leaid, user_id, 'manual_claim'::text AS basis, claimed_at AS since, 'manual'::text AS kind
+FROM district_manual_claims;
+```
+
+API reads `district_claimants_v` and groups in app code by `(district_leaid, user_id)`, collapsing bases into a list per user.
+
+### Schema removed (in destructive migration B)
+
+- `District.ownerId` (column + Prisma field).
+- `District.ownerUser` Prisma relation.
+- `districts.owner_id` index.
+- The `DistrictOwner` named-relation on `UserProfile`.
+
+## API
+
+### `GET /api/districts/:leaid/claimants`
+
+Returns:
+
+```ts
+{
+  claimants: Array<{
+    user: { id: string; fullName: string; avatarUrl: string | null };
+    kind: "derived" | "manual" | "both";  // "both" if user has both kinds
+    bases: Array<
+      | "open_pipeline"
+      | "recently_closed"
+      | "plan_owner"
+      | "plan_collaborator"
+      | "manual_claim"
+    >;
+    // Optional human-readable context for plan-based bases:
+    planContext?: Array<{ planId: string; planName: string; planColor: string }>;
+  }>;
+}
+```
+
+One row per user. Sorted: current user first, then by `since` desc within each kind.
+
+### `POST /api/districts/:leaid/claims`
+
+Creates a manual claim for the authenticated user. Idempotent — returns 200 with the existing row if already claimed. Sets `last_activity_at = now()`.
+
+### `DELETE /api/districts/:leaid/claims/me`
+
+Removes the authenticated user's manual claim. 404 if no row exists.
+
+### `POST /api/districts/:leaid/claims/transfer`
+
+Body: `{ toUserId: string }`. Atomic: deletes the authenticated user's claim, creates one for `toUserId`. 404 if the authenticated user has no existing claim. The new row's `note` is set to `transferred from <fromUser fullName>`.
+
+### Existing endpoints — changes
+
+- `GET /api/districts/search` — drop `ownerUser` from the response payload. Add an inline `claimantSummary` field with `{ count: number, currentUserIsClaimant: boolean, topAvatars: Array<{ id, avatarUrl }> }` (≤3 avatars) so the search-card avatar stack can render without a separate per-result fetch.
+- `GET /api/districts/:leaid` — drop `ownerUser` and the `edits.owner` field from response.
+- `PATCH /api/districts/:leaid/edits` — drop `ownerId` from accepted body.
+- `POST /api/districts/batch-edits` — drop `ownerId` from the accepted body and from the validation that requires "at least one of ownerId or notes." Endpoint stays, now `notes`-only.
+- District-list endpoint(s) accept a new `claimedBy=<userId>` filter that joins via `district_claimants_v`.
+
+## UI
+
+### `<DistrictClaimants>` component
+
+New component, rendered in two modes:
+
+- **Compact (search card):** avatar stack of up to 3 claimants (overlapping circles, plum border ring). `+N` pill if more. If the current user is among the claimants, their avatar gets a subtle ring highlight. Tooltip on hover lists names. If zero claimants, render nothing — absence carries the meaning, no "Unclaimed" tag.
+
+- **Detail (district panel):** a "Claims" section listing every claimant. Each row shows avatar, full name, and a stack of basis chips:
+  - `Open pipeline` — plum
+  - `Recently closed` — softer plum
+  - `Plan: <plan name>` — colored to the plan's color
+  - `Collaborator: <plan name>` — softer variant of plan color
+  - `Manual claim` — neutral
+
+  Below the list, action button(s) for the current user:
+  - If not currently a manual-claimant: `Claim this district` (primary).
+  - If currently a manual-claimant: `Release` and `Transfer…` (transfer opens a user picker modal).
+
+### Search card
+
+Replace the `district.ownerUser?.fullName` text line with `<DistrictClaimants compact ... />`. Keep the existing Customer/Prospect badge and the enrollment metric line.
+
+### District edit / batch-edit modal
+
+Remove the "Owner" select. The detail panel's Claims section replaces the editable owner — the user manages their relationship to the district there, not via an admin-style assignment.
+
+### "Mine" filter chip
+
+New filter chip on the district list / map. Default state: **on** for the authenticated user (per CLAUDE.md "Filter bars default to current user"). One-click toggle to "All". Server side, the filter passes `claimedBy=<currentUserId>` to the list endpoint, which joins through `district_claimants_v`.
+
+### Surfaces NOT changing
+
+- `TerritoryPlan.ownerId` and the "Owner" label on `PlanDetailSidebar.tsx` — plan ownership is a separate concept.
+- `HomePanel`'s plan-owner filter — operates on plans, not districts.
+- `Opportunity.salesRepName` / `salesRepId` displayed in deal views — opp-level, not district-level.
+
+## Migration
+
+Three-phase. Each phase is a separate PR/deploy.
+
+### Phase A — additive schema + backfill
+
+1. Migration creates `district_manual_claims` table, `district_derived_claims_v` view, and `district_claimants_v` view. No drops.
+2. Backfill script `scripts/backfill-district-manual-claims.ts`: for every district row with a non-null `ownerId`, insert into `district_manual_claims (district_leaid, user_id, claimed_at, last_activity_at)` with both timestamps set to `now()`. Skip if a row already exists for that `(leaid, user_id)`. Idempotent — can be re-run.
+
+   Setting `last_activity_at = now()` starts the 6-month expiry clock fresh on backfill day. Random/wrong assignments will age out naturally if the rep never touches the district. Legitimate assignments will be kept alive by ongoing opps/plans/activities.
+
+### Phase B — audit (manual)
+
+`scripts/audit-backfilled-claims.ts` produces two CSVs from the backfilled rows:
+
+- `covered.csv` — backfilled manual claims where the user *also* has a derived claim. (Redundant; the rep would have a claim anyway.)
+- `unsupported.csv` — backfilled manual claims where the user has no derived basis. (Suspect — likely random assignments.)
+
+Output columns: `district_leaid, district_name, user_id, user_full_name, derived_bases (semicolon-separated), claimed_at`.
+
+Sierra reviews `unsupported.csv` and chooses per row to keep, delete, or leave to natural expiry. No script action — the cleanup is done manually by editing rows in `district_manual_claims` (e.g., a one-off SQL delete by a list of `(leaid, user_id)` pairs).
+
+### Phase C — app code + destructive schema
+
+Two PRs, in order:
+
+1. **App code PR** — implement the new claim API, the `<DistrictClaimants>` component, the search-card and detail-panel changes, the "Mine" filter chip, and remove all reads of `District.ownerUser` / `ownerId` in the codebase (API responses, UI components, search results, Prisma includes). Existing column stays in the database — application code just stops touching it. Deploy.
+
+2. **Destructive migration PR** (after the app code is deployed and stable) — drop the `District.ownerUser` relation from `schema.prisma`, drop the `owner_id` column and its index, run `prisma migrate`. Splitting this off is cheap insurance: if any code path still referenced `ownerId`, we find out before the column is gone.
+
+## Background jobs
+
+Both run daily. Match the existing cron-route convention in this codebase (verify during implementation; the app already has cron-style routes elsewhere).
+
+### Activity-refresh job
+
+Recomputes `district_manual_claims.last_activity_at` for every row. For each `(district_leaid, user_id)` pair, set `last_activity_at` to the most recent of:
+
+- `Opportunity` rows where `sales_rep_id = user_id AND district_lea_id = district_leaid`: the max of `created_at`, `close_date`, and the latest `stage_history` entry's timestamp.
+- `TerritoryPlan` rows where (`owner_id = user_id` OR user is in `territory_plan_collaborators`) AND the plan contains the district: the plan's `updated_at`.
+- `Activity` rows linked via `ActivityDistrict` to this district where `Activity.userId = user_id`: the activity's `createdAt` (or whatever the canonical timestamp on `Activity` is — verify during implementation).
+
+If no activity is found, leave `last_activity_at` at its existing value (the expiry job will handle it).
+
+### Expiry job
+
+Deletes manual claims where `last_activity_at < now() - interval '6 months'`. Logs the count of deleted rows. No notifications.
+
+## Tests (Vitest)
+
+Co-located under `__tests__/` next to source per project convention.
+
+### Derivation view (`district_derived_claims_v`)
+
+- Opp in Stage 0 → claim row emitted with `basis = 'open_pipeline'`.
+- Opp in Stage 5 → same.
+- Opp in Closed Won, `close_date` 17 months ago → claim row with `basis = 'recently_closed'`.
+- Opp in Closed Won, `close_date` 19 months ago → no claim row.
+- Opp in Closed Lost, `close_date` 17 months ago → claim row.
+- Opp with `district_lea_id IS NULL` → no claim row.
+- Opp with `sales_rep_id IS NULL` → no claim row.
+- Plan owner with district in plan → claim row with `basis = 'plan_owner'`.
+- Plan collaborator with district in plan → claim row with `basis = 'plan_collaborator'`.
+
+### Manual-claim API
+
+- `POST /api/districts/:leaid/claims` creates a row; second call is idempotent (200, no duplicate).
+- `DELETE /api/districts/:leaid/claims/me` removes own row; 404 if none.
+- `DELETE` cannot remove another user's claim.
+- `POST /api/districts/:leaid/claims/transfer` is atomic: source row deleted, target row created with the correct `claimed_at` and `note`. 404 if caller has no claim.
+
+### Expiry cron
+
+- Manual claim with `last_activity_at = 5 months ago` → kept.
+- Manual claim with `last_activity_at = 7 months ago` → deleted.
+- Manual claim refreshed by activity-refresh job (rep added an activity yesterday) → kept.
+
+### UI tests
+
+- `<DistrictClaimants compact>` renders 0/1/3/5+ claimants correctly, current user gets ring.
+- Detail panel shows Claim button when user is not a claimant; Release + Transfer when user is.
+- "Mine" filter chip default state matches current user.
+
+## Open questions / future work
+
+- Notifications when someone claims, releases, or transfers a district you're connected to — defer.
+- Admin override to remove anyone's claim — defer until a real need surfaces.
+- Warning banner before expiry ("Your claim on X expires in 7 days") — defer.
+- Should `District.salesExecutiveId` be surfaced on the detail panel alongside claimants? Out of scope for this design.

--- a/Docs/superpowers/specs/2026-05-05-activities-table-view-backend-context.md
+++ b/Docs/superpowers/specs/2026-05-05-activities-table-view-backend-context.md
@@ -1,0 +1,674 @@
+# Activities Table View — Backend Context
+
+Discovery doc for the Activities page "Table" view that replaces the existing
+"Quarter" calendar option in `ViewToggle.tsx`. Captures the data model, API
+shape, hook surface, filter store, auth/scope, CSV utility, and bulk-update
+patterns the implementer needs to land the feature.
+
+Worktree path: `/Users/sierraarcega/territory-plan/.claude/worktrees/activities-table-view`.
+
+---
+
+## Activities Data Model
+
+The Activity model lives in `prisma/schema.prisma:581` as `model Activity`,
+mapped to the `activities` table. All relations are many-to-many through
+junction tables; there is **no direct FK from Activity to District/Contact** —
+the table view must join through `ActivityDistrict` / `ActivityContact`.
+
+### Activity (core fields)
+
+```
+id                  String    @default(uuid())   // PK
+type                String    @db.VarChar(30)    // ActivityType (see types.ts)
+title               String    @db.VarChar(255)
+notes               String?
+startDate           DateTime? @map("start_date")
+endDate             DateTime? @map("end_date")
+status              String    @default("planned")
+createdByUserId     String?   @map("created_by_user_id") @db.Uuid  // owner / rep
+createdAt           DateTime  @default(now())
+updatedAt           DateTime  @updatedAt
+
+// Calendar / sync provenance
+googleEventId       String?   @unique
+source              String    @default("manual")    // manual | calendar_sync | gmail_sync | slack_sync | system
+gmailMessageId      String?   @unique
+slackChannelId      String?
+slackMessageTs      String?
+integrationMeta     Json?
+
+// Mixmax campaign enrichment (sometimes shown in list rows)
+mixmaxSequenceName, mixmaxSequenceStep, mixmaxSequenceTotal,
+mixmaxStatus, mixmaxOpenCount, mixmaxClickCount
+
+// Outcome tracking (Wave 1 redesign)
+outcome             String?   // free-text
+outcomeType         String?   // legacy
+rating              Int?      // 1-5
+sentiment           String?   // positive | neutral | negative
+nextStep            String?
+followUpDate        DateTime?
+dealImpact          String    @default("none")   // none | progressed | won | lost
+outcomeDisposition  String?   // completed | no_show | rescheduled | cancelled
+
+// Location (promoted out of metadata)
+address             String?
+addressLat          Float?
+addressLng          Float?
+inPerson            Boolean?
+
+metadata            Json?
+```
+
+### Indexes already present on `activities`
+
+```
+@@index([createdByUserId])
+@@index([type])
+@@index([startDate])
+@@index([type, startDate])
+@@index([followUpDate])
+```
+
+There is **no full-text or trigram index on `title` / `notes`**. Existing
+search uses Prisma `contains` with `mode: "insensitive"`, which compiles to
+`ILIKE '%term%'` — sequential scan. See "Gaps + Risks" below.
+
+### Junctions (all M:N)
+
+```
+ActivityPlan         (activity_id, plan_id)
+ActivityDistrict     (activity_id, district_leaid, position, visitDate, visitEndDate, notes, warningDismissed)
+ActivityContact      (activity_id, contact_id)
+ActivityState        (activity_id, state_fips, isExplicit)
+ActivityOpportunity  (activity_id, opportunity_id)
+ActivityAttendee     (activity_id, user_id)
+ActivityRelation     (activity_id, related_activity_id, relationType)
+ActivityNote         (id, activity_id, author_id, body)         // threaded log
+ActivityAttachment   (Supabase Storage blob refs)
+ActivityExpense      (id, activity_id, description, amount, category, incurredOn)
+TaskActivity         (task → activity link)
+```
+
+### Related top-level models
+
+- `District` (PK `leaid` String; has `name`, `stateAbbrev`)
+- `Contact` (PK `id` Int; `leaid`, `name`, `title`, `email`, `phone`)
+- `UserProfile` (PK `id` Uuid; `email`, `fullName`, `avatarUrl`, `role`)
+
+### Activity Types & Statuses
+
+Defined in `src/features/activities/types.ts` (NOT Prisma enums — string
+columns with app-level validation):
+
+```
+ACTIVITY_CATEGORIES = {
+  events:             [conference, road_trip, dinner, happy_hour, school_site_visit, fun_and_games],
+  campaigns:          [mixmax_campaign],
+  meetings:           [discovery_call, program_check_in, proposal_review, renewal_conversation],
+  gift_drop:          [gift_drop],
+  sponsorships:       [booth_exhibit, conference_sponsor, meal_reception, charity_event],
+  thought_leadership: [webinar, speaking_engagement, professional_development, course],
+}
+
+VALID_ACTIVITY_STATUSES = [
+  planned, requested, planning, in_progress, wrapping_up, completed, cancelled
+]
+```
+
+`ALL_ACTIVITY_TYPES`, `ACTIVITY_TYPE_LABELS`, `ACTIVITY_STATUS_CONFIG`,
+`getCategoryForType()`, and `formatStatusLabel()` are exported from the same
+file and are reusable.
+
+---
+
+## Existing Activities API Routes
+
+Routes under `src/app/api/activities/`. The file `route.ts` is the list
+endpoint; `[id]/route.ts` is the detail. Sub-resource routes (notes, expenses,
+attachments, etc.) exist in nested folders but the table view should not need
+them directly — they're invoked via the drawer.
+
+### `GET /api/activities` — list (needed by table view)
+
+File: `src/app/api/activities/route.ts:22-324`
+
+Query params (all optional, multi-value via CSV `?key=a,b` or repeats):
+
+```
+search             string                  // ⚠ matches title only (see Gaps)
+type               string | string[]
+category           ActivityCategory | string[]
+status             string | string[]
+state              string | string[]       // 2-letter abbrev list (legacy aliases: stateAbbrev, stateCode)
+owner              string | string[]       // user UUIDs (multi-select)
+ownerId            string | "all"          // single-value path; "all" = team scope
+attendeeIds        string | string[]
+inPerson           "yes" | "no" | both
+territory          string | string[]       // territory plan names
+tags               string | string[]       // accepted but no-op (see route.ts:163)
+dealKinds          string | string[]       // accepted but no-op
+districtLeaid      string                  // single
+districtLeaids     string | string[]       // multi
+planId             string                  // when set, owner filter is ignored — shows all in plan
+needsPlanAssociation  bool
+hasUnlinkedDistricts  bool
+startDate          ISO date
+endDate            ISO date
+unscheduled        bool                    // null startDate
+source             string
+limit              number    default=100
+offset             number    default=0
+```
+
+Response (`ActivitiesResponse` in `src/features/shared/types/api-types.ts:592`):
+
+```
+{
+  activities: ActivityListItem[],   // see api-types.ts:569
+  total:      number,               // count after computed-flag filter
+  totalInDb:  number                // count matching base where (for pagination)
+}
+```
+
+`ActivityListItem` is a slim row (id, type, category, title, startDate,
+endDate, status, source, outcomeType, needsPlanAssociation,
+hasUnlinkedDistricts, planCount, districtCount, stateAbbrevs). It does **NOT
+contain district/contact names** or the owner's name — only counts/IDs.
+
+Server-side ordering: `orderBy: { startDate: { sort: "desc", nulls: "last" } }`
+(`route.ts:229`). Matches the table-view default.
+
+### `POST /api/activities` — create
+
+File: `src/app/api/activities/route.ts:327-652`. Not directly used by the
+table view, but reused by the existing `useCreateActivity` hook.
+
+### `GET /api/activities/[id]` — detail (needed for drawer prev/next)
+
+File: `src/app/api/activities/[id]/route.ts:18-236`. Returns the full
+`Activity` shape (`api-types.ts:514`) including all join data: plans,
+districts, contacts, states, expenses, attendees, opportunities, related
+activities, plus `createdByUser` (id/fullName/avatarUrl).
+
+### `PATCH /api/activities/[id]` — update
+
+File: `[id]/route.ts:239-538`. Accepts the full editable surface (type, title,
+status, dates, outcome fields, address, expenses, contacts, attendees,
+districts, opportunities). The table view's status/owner inline edits could
+hit this per-row, but that's N requests for N rows — see bulk patterns below.
+
+**Note:** the route currently has no path for changing `createdByUserId`
+(owner). Reassign-bulk needs a new path or a server-side handler that admits
+this field with the right permission check.
+
+### `DELETE /api/activities/[id]` — delete
+
+File: `[id]/route.ts:541-583`.
+
+### Sub-resource routes (drawer-only, listed for completeness)
+
+```
+/api/activities/[id]/plans                      POST, DELETE /[planId]
+/api/activities/[id]/districts                  POST, DELETE /[leaid]
+/api/activities/[id]/contacts                   (not seen in queries.ts; verify if needed)
+/api/activities/[id]/expenses                   POST, DELETE /[expenseId]
+/api/activities/[id]/notes                      POST, DELETE /[noteId]
+/api/activities/[id]/attachments                POST upload, DELETE, GET signed URL
+/api/activities/[id]/calendar-attendees         GET
+/api/activities/unlinked                        GET (separate route, source != manual, no district links)
+```
+
+### What the list route already supports for the table view
+
+✓ Search (title only) — `?search=`
+✓ Multi-type / multi-status / multi-owner / multi-state / multi-district
+✓ Date range — `?startDate=&endDate=`
+✓ Pagination — `?limit=&offset=` plus `totalInDb` for banners
+✓ Default sort by `startDate DESC`
+✓ Owner scope: `ownerId="all"` for team, current user otherwise
+✓ Attendee filter — `?attendeeIds=`
+
+### Gaps in the list route for the table view
+
+✗ Search does **not** cover notes / district name / contact name (see Gaps)
+✗ Contact filter — no `?contactIds=` parameter exists. Junction table
+  `ActivityContact` is queryable but not wired through the route.
+✗ Response omits district names, contact names, and owner name — the table UI
+  needs at least one display label per relation. Either extend the `select`
+  or accept that the table renders "3 districts / 2 contacts" badges and
+  defers names to the drawer.
+✗ `tags` and `dealKinds` accept the param but no-op.
+
+---
+
+## Existing TanStack Query Hooks
+
+File: `src/features/activities/lib/queries.ts`. Query keys are stable strings
+generated by `buildActivitiesQueryString()` (sorted, URL-encoded) — this is
+the pattern the table view should reuse.
+
+### Reusable as-is
+
+| Hook | Returns | Query key | Notes |
+|---|---|---|---|
+| `useActivities(params)` | `ActivitiesResponse` | `["activities", queryString]` | Reuse for the table list. Bumping `limit` to 50, paging via `offset`. `staleTime: 2min`. |
+| `useActivity(id)` | full `Activity` | `["activity", id]` | Drives the drawer when a row is clicked. Already has `placeholderData: keepPreviousData`. |
+| `usePrefetchActivity()` | `(id) => void` | — | Warm cache for adjacent rows on hover. |
+| `useUpdateActivity()` | mutation | invalidates `["activities"]` and `["activity", id]` | Optimistic update on scalar fields. Per-row inline edits use this. |
+| `useDeleteActivity()` | mutation | invalidates `["activities"]` | If table view supports row-level delete. |
+| `useProfile()` | current `UserProfile` | (in `src/features/shared/lib/queries.ts:168`) | Default owner scope. |
+
+### Need new hooks for table view
+
+| Need | Why | Suggested signature |
+|---|---|---|
+| `useBulkUpdateActivities()` | Reassign owner / change status across selected rows in one request | `mutationFn({ ids: string[], updates: { ownerId?, status? } })` → invalidates `["activities"]` |
+| `useExportActivitiesCsv()` (optional) | If we want server-rendered CSV (recommended only when result count > limit). Otherwise client-side via `rowsToCsv()`. | See "CSV export" below |
+
+### Mutation invalidation note
+
+Every existing mutation invalidates `["activities"]` (the prefix), so any
+future `useActivities` call automatically refetches. The table-view query key
+remains under that prefix as long as we use `useActivities(...)`.
+
+---
+
+## Existing Filter Logic (Zustand store)
+
+File: `src/features/activities/lib/filters-store.ts`. Persisted in
+`localStorage` under key `"cal"`, partialized to view/grain/savedViewId/
+railCollapsed (filters themselves are NOT persisted — they reset on reload,
+seeded by `useDefaultOwnerHydration()`).
+
+### `ActivitiesFilters` shape
+
+```ts
+{
+  categories:  ActivityCategory[];
+  types:       ActivityType[];
+  dealKinds:   DealKind[];          // accepted client-side, not server-applied
+  dealStages:  string[];
+  dealMin:     number;
+  dealMax:     number | null;
+  statuses:    string[];
+  owners:      string[];            // user IDs; empty = team scope
+  attendeeIds: string[];
+  districts:   string[];            // leaids
+  inPerson:    ("yes"|"no")[];
+  states:      string[];
+  territories: string[];            // plan IDs
+  tags:        string[];
+  text:        string;              // free-text search
+}
+```
+
+### `ChromeState` (calendar chrome)
+
+```ts
+view: "schedule" | "month" | "week" | "map";   // ← extend with "table"
+grain: "day" | "week" | "month" | "quarter";
+anchorIso: string;
+savedViewId: string | null;
+railCollapsed: boolean;
+syncState: "connected" | "stale" | "disconnected";
+filters: ActivitiesFilters;
+```
+
+### `deriveActivitiesParams({ filters, anchorIso, grain })`
+
+`filters-store.ts:189-218`. Translates store → API params. Uses single-value
+short-circuits when only one option is selected, otherwise the multi-value
+`owner` / `attendeeIds` / `districtLeaids` arrays. **It always sets
+`startDateFrom` and `startDateTo` derived from anchor+grain** — for a Table
+view that defaults to *all-time*, the implementer must:
+
+1. Add a new helper (e.g. `deriveTableActivitiesParams`) that omits the date
+   range when no explicit date range is set, OR
+2. Add a `dateMode: "all" | "range"` field to filters and branch in the
+   existing helper, OR
+3. Bypass the helper entirely for the table view and build params from
+   `filters` directly.
+
+### What's already covered for the table view
+
+✓ Text search — `filters.text` → `params.search`
+✓ Type / category / status (multi)
+✓ Owner — single short-circuits to `ownerId`; multi sends `owner[]`. Empty
+  list defaults to `ownerId: "all"`.
+✓ District — `filters.districts` → `params.districtLeaids`
+✓ Scope toggle (My / All) — handled by `ScopeToggle` (`page/ScopeToggle.tsx`)
+  which mutates `filters.owners` (`ActivitiesPageShell.tsx:116-119`).
+
+### What's missing for the table view
+
+✗ **Contact filter** — no `contacts: number[]` field in `ActivitiesFilters`.
+  Add it to the store + extend `deriveActivitiesParams` + extend the API.
+✗ **Date range that's not anchored to a calendar window.** Today's helper
+  always derives from anchor+grain. Table view needs free-form
+  `dateFrom` / `dateTo` (or "all time" sentinel).
+✗ **Sort** — currently fixed to `startDate DESC` server-side. If the table
+  needs user-controlled sort, add a `?sort=` parameter.
+
+### Recommendation: keep one store, add fields
+
+The table view should **not** fork its own filter state. Reasons:
+
+1. The scope toggle (My / All Fullmind) and the owner default-hydration are
+   already global — copy/paste invites bugs.
+2. Saved views (`saved-views.ts`) round-trip through this store; future
+   "saved table-view filters" will want to reuse them.
+3. CLAUDE.md's "stable query keys" rule already applies via
+   `buildActivitiesQueryString`.
+
+Add `contacts`, `dateFrom`, `dateTo`, `dateMode` to `ActivitiesFilters` and
+extend `deriveActivitiesParams` to honor them. The Quarter view goes away,
+so no migration of view persistence is needed beyond mapping the legacy
+`{ view: "month", grain: "quarter" }` to the new `view: "table"` (or just
+falling back to the new default when `grain === "quarter"`).
+
+---
+
+## Auth + Scope
+
+### Server-side
+
+Every activities route calls:
+
+```ts
+import { getUser } from "@/lib/supabase/server";
+const user = await getUser();
+if (!user) return 401;
+```
+
+`getUser()` (`src/lib/supabase/server.ts`) wraps Supabase SSR auth and
+respects the `impersonate_uid` cookie if the real user is admin. The
+returned user has `id` (UUID) and `isImpersonating: boolean`.
+
+`isAdmin(userId)` (same file, line 92) hits `prisma.userProfile` and checks
+`role === "admin"`. Used to allow viewing/editing other users' activities.
+
+### "My activities" vs "All Fullmind"
+
+Enforced **in the route, not by Postgres RLS** (see `route.ts:69-87`):
+
+```ts
+if (planId) {
+  where.plans = { some: { planId } };           // plan scope wins
+} else if (owners.length > 0) {
+  where.createdByUserId = { in: owners };       // multi-owner
+} else if (ownerId === "all") {
+  // no createdByUserId filter — team scope
+} else if (ownerId) {
+  where.createdByUserId = ownerId;              // specific user
+} else {
+  where.createdByUserId = user.id;              // default: my activities
+}
+```
+
+For PATCH/DELETE/[id] GET, the route checks `createdByUserId === user.id` OR
+linked to a plan (for view) OR `isAdmin(user.id)` (for edit). The bulk
+endpoint must apply the same rule **per row** — not a blanket pass.
+
+### `system` source filter
+
+Every list query forces `where.source = { not: "system" }` (`route.ts:70`)
+to hide system-generated activities. The bulk endpoint should keep this rule
+so we never reassign / restate a system row.
+
+---
+
+## CSV Export
+
+File: `src/features/reports/lib/csv.ts` — already production-quality, used by
+the Reports tab and the Low Hanging Fruit view. **Reuse, do not duplicate.**
+
+```ts
+// Shape:
+function rowsToCsv(columns: string[], rows: Array<Record<string, unknown>>): string
+function slugifyForFilename(s: string): string
+function downloadCsv(filename: string, csv: string): void
+```
+
+Cells are escaped for `,`, `"`, `\r`, `\n`. `Date` → ISO; objects →
+`JSON.stringify`. `downloadCsv` builds a `Blob`, creates an anchor, triggers
+download, and revokes the URL after the click. Tests live at
+`src/features/reports/lib/__tests__/csv.test.ts`.
+
+### Recommended call site for the Table view
+
+```ts
+import { rowsToCsv, slugifyForFilename, downloadCsv } from "@/features/reports/lib/csv";
+const csv = rowsToCsv(
+  ["title","type","status","startDate","owner","districts","contacts"],
+  selectedRows.map(toCsvRow),
+);
+downloadCsv(slugifyForFilename(`activities-${new Date().toISOString().slice(0,10)}`), csv);
+```
+
+The reps need *names*, not IDs (per user memory note "No ID strings in
+output"). The list endpoint returns counts/IDs only — for export we either:
+
+1. Hit `GET /api/activities/[id]` for each selected row to get names (slow
+   for 50+ rows), or
+2. Ask the bulk-export endpoint to return enriched rows (`POST
+   /api/activities/export`), or
+3. Extend the list endpoint to include district names + owner name when an
+   `?include=names` flag is set.
+
+Option 3 is cheapest; add it to the list route.
+
+---
+
+## Bulk Update Patterns
+
+### What exists in the codebase
+
+A search across `src/app/api/**` for `bulk` finds:
+
+- `POST /api/territory-plans/[id]/contacts/bulk-enrich` — kicks a Clay
+  enrichment for the plan's principals. Wrong shape for activities (it
+  scopes to a single plan and is a job-launcher, not a CRUD bulk).
+- `POST /api/vacancies/scan-bulk` — also a job-launcher.
+- `POST /api/territory-plans/[id]/expand-rollup` — internal.
+
+**There is no `PATCH /api/activities/bulk` or any other bulk-update CRUD
+endpoint for activities.** The implementer must build it.
+
+### Proposed endpoint: `PATCH /api/activities/bulk`
+
+```
+Request:  { ids: string[], updates: { ownerId?: string; status?: string } }
+Response: { updated: number, skipped: number, skippedIds: string[] }
+```
+
+Behavior:
+
+1. Authenticate via `getUser()` → 401 if missing.
+2. Validate `updates.status ∈ VALID_ACTIVITY_STATUSES` and `updates.ownerId`
+   is a known UUID (verify via `prisma.userProfile.findUnique`).
+3. Load the candidate rows: `prisma.activity.findMany({ where: { id: { in: ids } }, select: { id, createdByUserId, source } })`.
+4. For each row, verify the user can edit:
+   - row's `createdByUserId === user.id`, OR
+   - `await isAdmin(user.id)` (cache the result).
+   Skip rows that fail with their IDs returned in `skippedIds`.
+5. Skip rows where `source === "system"`.
+6. `prisma.activity.updateMany({ where: { id: { in: allowedIds } }, data: <updates> })`.
+   - For owner reassign, only admins should be allowed (rep can't reassign
+     a teammate's activity to a third user). Confirm with PM if rep can
+     reassign their own activities to anyone.
+7. Best-effort: trigger calendar updates for affected rows
+   (`updateActivityOnCalendar` per ID, fire-and-forget).
+8. Return counts.
+
+### Existing `PATCH /api/activities/[id]` does not accept `createdByUserId`
+
+Today `[id]/route.ts:267-273` destructures only the editable surface and
+omits `createdByUserId`. The bulk route is the **right place** to introduce
+owner-reassign rather than expanding the per-row PATCH (cleaner permission
+model, single audit log entry).
+
+### Bulk export endpoint (optional)
+
+If client-side CSV from selected rows is sufficient, skip this. If the user
+flow includes "export current filtered set (could be 1000+ rows)":
+
+```
+POST /api/activities/export
+Request:  ActivitiesParams + { columns: string[] }
+Response: text/csv stream
+```
+
+Reuses the same `where` builder as `GET /api/activities`. Server-side
+streaming so we don't OOM on 10k-row exports.
+
+---
+
+## Testing Patterns
+
+Framework: **Vitest + Testing Library + jsdom**. Configured in `vitest.config.ts`
+(default; not inspected). Co-located in `__tests__/`.
+
+### Example 1 — API route test
+
+`src/app/api/activities/__tests__/route.test.ts`
+
+Conventions:
+
+- Mocks `@/lib/supabase/server` → `getUser` (always called) + `isAdmin`.
+- Mocks `@/lib/prisma` with hand-rolled `vi.fn()` for each model touched
+  (e.g. `activity: { count, findMany, findUnique, create, update, delete }`,
+  `activityPlan: { findFirst }`, `territoryPlanDistrict: { findMany }`).
+- Mocks `@/features/calendar/lib/push` — fire-and-forget calendar sync hooks.
+- Helpers `makeListActivity()` / `makeDetailActivity()` build rows in the
+  shape Prisma returns from the matching include shape.
+- Builds `NextRequest` via:
+  ```ts
+  function makeRequest(url: string, init?: RequestInit) {
+    return new NextRequest(new URL(url, "http://localhost:3000"), init as never);
+  }
+  ```
+- Imports the route handler directly: `import { GET, POST } from "../route"`.
+- Cases cover 401, default scope, multi-value filters, planId, status,
+  category translation, etc.
+
+The bulk endpoint test should follow the same pattern: 401 case, ownership
+check (skip foreign rows for non-admin), system-source skip, status validation.
+
+### Example 2 — Store / hook test
+
+`src/features/activities/lib/__tests__/filters-store.test.ts`
+
+Conventions:
+
+- Mocks `@/features/shared/lib/queries` to stub `useProfile()`.
+- Wraps hooks in a `QueryClientProvider` factory (no network in jsdom).
+- Resets the Zustand store between tests via
+  `useActivitiesChrome.getState().resetFilters()`.
+- Asserts `getRangeForChrome` semantics by computing day spans rather than
+  literal ISO strings (timezone-portable).
+- Uses `renderHook`, `waitFor`, `act` from `@testing-library/react`.
+
+### Other useful patterns
+
+`src/app/api/territory-plans/[id]/contacts/bulk-enrich/__tests__/route.test.ts`
+covers a bulk-launch endpoint and demonstrates the auth guards / Prisma
+mocks for a multi-row write. Use it as a reference shape.
+
+---
+
+## Gaps + Risks
+
+### APIs to create
+
+1. **`PATCH /api/activities/bulk`** — new route. Owner reassign + status change
+   on a list of IDs. Permission rules per the table above (admin or own
+   row; never `system` source). See proposal above for shape.
+2. **(Optional) `POST /api/activities/export`** — only if we expect users to
+   export sets > 50 rows. Otherwise client-side CSV from the selected rows
+   is fine.
+
+### Existing APIs that need extension
+
+1. **`GET /api/activities` — `search` param.** Currently `where.title = { contains, mode: "insensitive" }`. The table view spec says search must cover
+   title + district name + contact name + notes. Options:
+   - Extend the `where` to an `OR` against `notes`, `districts.some.district.name`, `contacts.some.contact.name` — easiest, but four `ILIKE` joins on a non-indexed column scan is slow once activities exceed ~10k rows.
+   - Add a Postgres `tsvector` column populated by trigger (title + notes + district names + contact names) and a GIN index. Best long-term, but a migration. Out of scope for first ship if dataset is small (<5k rows today).
+   - Compromise: extend `OR` to title + notes initially, add district/contact name search as a second wave once we measure query time.
+2. **`GET /api/activities` — `contactIds` param.** Add `contactIds = readMulti(searchParams, "contactIds")` and `where.contacts = { some: { contactId: { in: idsAsInt } } }`. Mirror the existing `attendeeIds` / `districtLeaids` handling.
+3. **`GET /api/activities` — date range without a calendar anchor.** Already supported via `?startDate=&endDate=`. The store helper just needs to stop forcing them; the route is fine.
+4. **`GET /api/activities` — response enrichment for table display.** Add `?include=names` (or always include) to the list route to surface:
+   - first 1-2 district names (or just the first + count)
+   - first contact name
+   - owner's `fullName`
+   Without this, the table renders "3 districts" and "(unknown)" for the owner column unless the implementer fans out to per-row detail fetches.
+5. **`GET /api/activities` — sort param** (only if the table needs user sort beyond `startDate DESC`). Add `?sort=startDate|title|status|updatedAt&order=asc|desc`.
+
+### Schema changes
+
+None required for v1. If text-search performance becomes a problem, consider:
+
+- A migration adding `search_tsv tsvector` to `activities` with a GIN index
+  and a Postgres trigger to keep it populated from `title`, `notes`, plus
+  the latest district/contact names rolled in by the application layer (or
+  a materialized view of district/contact names by activity).
+
+The existing indexes (`createdByUserId`, `type`, `startDate`,
+`(type, startDate)`, `followUpDate`) already cover the dominant table-view
+filter combos. No new index needed for filtering itself.
+
+### Performance concerns
+
+1. **Text search seq-scan.** `ILIKE '%term%'` is O(N) on `activities`. If the
+   tenant has 50k+ rows, the search will hit ~hundreds of ms. Mitigation:
+   start with title-only (current behavior), measure, then add tsvector if
+   needed.
+2. **Computed flag filtering happens after the page is sliced.** The route
+   slices via `take/skip`, then drops rows that don't match
+   `needsPlanAssociation` / `hasUnlinkedDistricts`. So `total` (the post-slice
+   filtered count) ≠ `totalInDb`. The table-view banner trigger ("200+
+   filtered results") should read `totalInDb` for an accurate count, not
+   `total`.
+3. **Per-row detail fetch on bulk export** would cause N round-trips.
+   Server-side enrichment (the `?include=names` extension above) avoids it.
+4. **Drawer prefetch + table virtualization.** The page caps server returns
+   at `limit: 50` per CLAUDE.md, with "Show more" or scroll loading. Don't
+   blanket-prefetch every row — prefetch on hover only. Existing
+   `usePrefetchActivity` is the helper.
+5. **CSV export of large sets.** Client-side `rowsToCsv()` over a few hundred
+   rows is fine. Exporting filter sets in the thousands warrants
+   server-side streaming (see "Bulk export endpoint" above).
+6. **Bulk update deadlock risk.** `prisma.activity.updateMany` on a long ID
+   list is one statement, so no row-level deadlocks. But if the request
+   passes 1000+ IDs, validation/auth checks scale linearly and the round
+   trip can exceed 30s. Cap the request to e.g. 500 IDs and have the client
+   chunk if a user selects more.
+
+---
+
+## Summary
+
+The table view can ship by:
+
+1. Adding a `view: "table"` option to the chrome store and `ViewToggle`,
+   removing the `quarter` option.
+2. Extending `ActivitiesFilters` with `contacts: number[]`, plus optional
+   free-form date range fields, and updating `deriveActivitiesParams` to
+   omit the calendar-window dates when in table mode.
+3. Reusing `useActivities()`, `useActivity()`, `useUpdateActivity()`,
+   `useDeleteActivity()`, and `usePrefetchActivity()` as-is.
+4. Adding a `PATCH /api/activities/bulk` route for status/owner reassign
+   with the same auth rules as `[id] PATCH`.
+5. Extending the list route's `search` to include `notes` (and ideally
+   district + contact names) and adding `contactIds`. Optionally adding
+   `?include=names` for table-display enrichment.
+6. Reusing `rowsToCsv` / `downloadCsv` from `src/features/reports/lib/csv.ts`
+   for client-side CSV export of selected rows.
+7. Following the Vitest + Prisma-mock + Supabase-mock pattern in
+   `src/app/api/activities/__tests__/route.test.ts` for the new bulk route
+   and updated list route, plus the store-test pattern in
+   `src/features/activities/lib/__tests__/filters-store.test.ts` for any
+   helper changes.
+
+No schema migrations required for v1.

--- a/Docs/superpowers/specs/2026-05-05-activities-table-view-spec.md
+++ b/Docs/superpowers/specs/2026-05-05-activities-table-view-spec.md
@@ -1,0 +1,167 @@
+# Feature Spec: Activities Table View
+
+**Date:** 2026-05-05
+**Slug:** activities-table-view
+**Branch:** `worktree-activities-table-view`
+
+## Requirements
+
+Replace the **Quarter** option in the Activities page `ViewToggle` (top right, between
+Month and Map) with a new **Table** view that renders all activities as a paginated,
+sortable, filterable, partially-inline-editable data table.
+
+| Decision | Value |
+|----------|-------|
+| Primary use | Both fast lookup AND audit/triage equally |
+| Date scope | All time by default; date is a column filter |
+| Filter chrome | Hide existing chip bar in Table view; replace with column-header filters + a search bar |
+| Row click | Opens existing `ActivityDetailDrawer` |
+| Default columns | Date, Type, Title, District, Contact(s), Owner, Status, Outcome notes preview |
+| Bulk actions | Export CSV, reassign owner, change status |
+| Default sort | Date desc (most recent first) |
+| Inline editable cells | Date, Type, Owner, Status |
+| Pagination | Server-side; 50 rows/page; 200+ banner |
+
+## Visual Design
+
+### Approved approach
+
+**Direction A + inline editing.** Filter UI lives on the table itself
+(column-header popovers + a top search bar). The existing `ActivitiesFilterChips`
+bar is hidden in Table view. Clicking an editable cell opens an inline popover;
+clicking elsewhere on the row opens the existing `ActivityDetailDrawer`.
+
+### Key architectural decisions
+
+- **Filter state is shared** with calendar views via `useActivitiesChrome.filters`,
+  so switching Table → Schedule preserves what's selected. Two new fields:
+  `contactIds: number[]`, `dateFrom: string | null`, `dateTo: string | null`.
+- **`deriveActivitiesParams` branches on `view`**: when `view === "table"` it
+  uses `dateFrom/dateTo` (or no dates at all); otherwise it uses anchor+grain
+  as today.
+- **Row click vs cell click:** non-editable cells delegate the click up to the
+  row (drawer); editable cells `stopPropagation` and open their own popover.
+- **Inline editing reuses `useUpdateActivity`'s existing `onMutate`**, which
+  already does optimistic cache patching for `status`, `type`, `startDate`,
+  `endDate`. Owner reassignment is genuinely new and requires a new
+  `createdByUserId` field on the PATCH route plus auth check.
+- **Bulk mutations** go through a new `PATCH /api/activities/bulk` endpoint
+  with shape `{ ids: string[], updates: { ownerId?, status? } }`. Per-row auth
+  check (own row OR admin). Cap at 500 IDs per request.
+
+### Layout
+
+    +-------------------------------------------------------------------------------+
+    | Activities      [My / All Fullmind] · [Synced]   [Schedule|Week|Month|Table|Map] [+New]
+    +-------------------------------------------------------------------------------+
+    | [⌘K Search by title, notes, district, contact…]   [Reset] [Export▾] [Cols▾]   |
+    +-------------------------------------------------------------------------------+
+    | [✓] Date↓  Type▾  Title▾  District▾  Contact▾  Owner▾  Status▾  Outcome▾      |
+    +-------------------------------------------------------------------------------+
+    |  May 5   ROAD_TRIP  Trip to Syracuse   Syracuse C…  J. Patel  Me     Synced    "Visited principal — opened pilot…"
+    |  May 4   CONFERENCE Empowering Every…  —           A. Diaz   Me     Past due   "Walk-through booked next week…"
+    |  ...                                                                           |
+    +-------------------------------------------------------------------------------+
+    | Page 1 of 8 · 50 of 387 results · 200+ — narrow your filters for faster scrolling
+    +-------------------------------------------------------------------------------+
+    | [4 selected]   Reassign owner ▾   Change status ▾   Export CSV          Clear  |  (sticky bottom)
+    +-------------------------------------------------------------------------------+
+
+In Table view the date-range strip (`ActivitiesDateRange`) is also hidden,
+since "Date" is a column filter.
+
+## Component Plan
+
+### Existing components to reuse
+
+| Component | File | Use |
+|-----------|------|-----|
+| `DataGrid` | `src/features/shared/components/DataGrid/DataGrid.tsx` | Table renderer (handles selection, sort, expand, footer) |
+| `SelectAllBanner` | `src/features/shared/components/DataGrid/SelectAllBanner.tsx` | "Select all matching filters" banner |
+| `ActivityDetailDrawer` | `src/features/activities/components/page/ActivityDetailDrawer.tsx` | Row-click target |
+| `ActivityFormModal` | `src/features/activities/components/ActivityFormModal.tsx` | "+ New" CTA from empty state |
+| `useActivities` / `useActivity` / `useUpdateActivity` / `useDeleteActivity` / `usePrefetchActivity` | `src/features/activities/lib/queries.ts` | Data fetching |
+| `useActivitiesChrome` | `src/features/activities/lib/filters-store.ts` | Filter / view state |
+| `rowsToCsv` / `slugifyForFilename` / `downloadCsv` | `src/features/reports/lib/csv.ts` | Export |
+| `useDistricts`, `useUsers`, `useTags`, `useStates`, `useTerritoryPlans` | shared `lib/queries.ts` | Filter popover data |
+| `useSearchContacts` | `src/features/activities/lib/queries.ts` | Contact filter autocomplete |
+| `cn` | `src/features/shared/lib/cn.ts` | Class merging |
+| `ACTIVITY_STATUS_CONFIG` / `ACTIVITY_CATEGORIES` / `ACTIVITY_TYPE_LABELS` / `CATEGORY_LABELS` | `src/features/activities/types.ts` | Enum definitions and colors |
+| `useProfile` | `src/features/shared/lib/queries.ts` | Current user (default owner) |
+
+### New components to build
+
+| Component | Path | Responsibility |
+|-----------|------|----------------|
+| `ActivitiesTableView` | `src/features/activities/components/page/ActivitiesTableView.tsx` | Top-level container — toolbar + DataGrid + footer + bulk-action bar |
+| `ActivitiesTableToolbar` | `src/features/activities/components/page/table/ActivitiesTableToolbar.tsx` | Search input + Reset + Export menu + Columns picker |
+| `ActivitiesTableHeader` | `src/features/activities/components/page/table/ActivitiesTableHeader.tsx` | Column-header row with sort + filter trigger per column |
+| `ColumnFilterPopover` | `src/features/activities/components/page/table/ColumnFilterPopover.tsx` | Generic popover dispatcher — picks a typed body by column |
+| `DateRangeFilter` | `src/features/activities/components/page/table/filters/DateRangeFilter.tsx` | Anytime / Today / This week / Last 7 / Last 30 / Last 90 / Custom |
+| `TypeFilter` | `src/features/activities/components/page/table/filters/TypeFilter.tsx` | Category + type accordion (reuses existing `PopoverItem` style) |
+| `OwnerFilter` | `src/features/activities/components/page/table/filters/OwnerFilter.tsx` | User multi-select with "Me" pinned |
+| `StatusFilter` | `src/features/activities/components/page/table/filters/StatusFilter.tsx` | Status multi-select with color swatches |
+| `DistrictFilter` | `src/features/activities/components/page/table/filters/DistrictFilter.tsx` | Search-as-you-type multi-select |
+| `ContactFilter` | `src/features/activities/components/page/table/filters/ContactFilter.tsx` | Search-as-you-type multi-select |
+| `TextFilter` | `src/features/activities/components/page/table/filters/TextFilter.tsx` | Single text input (Title, Outcome) |
+| `EditableDateCell` | `src/features/activities/components/page/table/cells/EditableDateCell.tsx` | Inline date+time picker |
+| `EditableTypeCell` | `src/features/activities/components/page/table/cells/EditableTypeCell.tsx` | Type dropdown |
+| `EditableOwnerCell` | `src/features/activities/components/page/table/cells/EditableOwnerCell.tsx` | User picker |
+| `EditableStatusCell` | `src/features/activities/components/page/table/cells/EditableStatusCell.tsx` | Status pill dropdown |
+| `BulkActionBar` | `src/features/activities/components/page/table/BulkActionBar.tsx` | Sticky bottom bar — reassign owner, change status, export, clear |
+| `ExportMenu` | `src/features/activities/components/page/table/ExportMenu.tsx` | Selected vs All-filtered export |
+| `ColumnsPicker` | `src/features/activities/components/page/table/ColumnsPicker.tsx` | Visible-columns dropdown (DataGrid-compatible) |
+
+### Components to extend
+
+| Component | Change |
+|-----------|--------|
+| `ViewToggle` | Replace `quarter` option with `table`. New `CalendarView` value `"table"`. New icon (`Table` from lucide). |
+| `ActivitiesPageShell` | Add `view === "table"` branch that renders `ActivitiesTableView` and **suppresses** `ActivitiesDateRange`, `ActivitiesFilterChips`, `UpcomingRail`. Keep header + scope toggle + drawer. |
+| `filters-store.ts` `CalendarView` | `"schedule" \| "month" \| "week" \| "table" \| "map"` (drop `quarter`'s grain branch). |
+| `filters-store.ts` `ActivitiesFilters` | Add `contactIds: number[]`, `dateFrom: string \| null`, `dateTo: string \| null`. |
+| `deriveActivitiesParams` | Branch on `view === "table"`: ignore anchor+grain, send `startDateFrom: dateFrom`, `startDateTo: dateTo` only if set. Send `contactIds`, `sortBy`, `sortDir`, `limit: 50`, `offset: page * 50`. |
+| `GET /api/activities` (`route.ts`) | Extend `search` to OR against `notes` + `outcome` (currently title only). Accept `?contactIds=` array. Accept `?sortBy=date\|type\|title\|district\|owner\|status` + `?sortDir=asc\|desc`. |
+| `ActivitiesParams` (`api-types.ts`) | Add `contactIds?: number[]`, `sortBy?: SortKey`, `sortDir?: "asc" \| "desc"`. |
+| `ActivityListItem` response shape | Include first district name, first contact name, owner full name, outcome preview (first 80 chars of `outcome` or `notes`) for table rendering without per-row hydration. |
+| `useActivitiesChrome` `persist` partialize | Add `tableSorts`, `tableVisibleColumns`, `tablePage`, `tablePageSize` to persist table-specific UI state. |
+
+### New backend routes
+
+| Route | Method | Body / Params | Purpose |
+|-------|--------|---------------|---------|
+| `/api/activities/bulk` | `PATCH` | `{ ids: string[], updates: { ownerId?: string, status?: ActivityStatus } }` | Bulk reassign / status change. Per-row auth (own row OR admin). Cap 500 IDs. |
+| `/api/activities/[id]` | `PATCH` (extend) | Add `createdByUserId?: string` to body | Single-row owner reassign — used by `EditableOwnerCell`. |
+
+## Backend Design
+
+See: `docs/superpowers/specs/2026-05-05-activities-table-view-backend-context.md`
+
+### Summary
+
+- **No schema changes.** Existing indexes cover the new filter combos.
+- **Routes to extend**: `GET /api/activities` (search → notes/outcome, sortBy/sortDir, contactIds), `PATCH /api/activities/[id]` (allow owner reassign).
+- **Routes to add**: `PATCH /api/activities/bulk`.
+- **Response shape**: `ActivityListItem` gains `districtName: string | null`, `contactName: string | null`, `ownerFullName: string | null`, `outcomePreview: string | null` to avoid N+1 in the table renderer.
+- **Auth**: existing `getUser()` + `isAdmin()` from `src/lib/supabase/server.ts`. Bulk endpoint validates each id's ownership against the caller before applying.
+- **Performance**: Cap bulk IDs at 500. Server-side pagination + sort means the table never holds >50 rows in memory.
+
+## States
+
+- **Loading (initial)**: 8 skeleton rows × 8 cells. Toolbar buttons disabled.
+- **Loading (refetch on filter change)**: existing rows fade to 60%; spinner in toolbar. `keepPreviousData` so rows don't unmount.
+- **Empty (no filters)**: centered illustration + "No activities yet — log your first one." CTA opens `ActivityFormModal`.
+- **Empty (filters active)**: "No matches for these filters." `Reset filters` button.
+- **Error**: red-bordered card in tbody area: "Couldn't load activities." `[Retry]` button. Toolbar remains usable.
+- **Banner at ≥200 results**: yellow strip above footer: "200+ matching — narrow your filters for faster scrolling."
+- **Optimistic edit error**: cell reverts; toast at bottom-right: "Couldn't save change. Try again." (Reuses existing toast utility.)
+
+## Out of Scope
+
+- Saved table views (rely on existing saved-views infrastructure later — for v1, the table state is in `useActivitiesChrome.persist`).
+- Inline editing of Title, District, Contact, Outcome notes (these route to the drawer).
+- Mobile-optimized table layout (table view auto-redirects to Schedule on viewports < md).
+- Excel/XLSX export — CSV only for v1.
+- Cross-page select (`Select all matching filters` selects all matching, but bulk mutation cap is 500; UI shows "first 500 selected" if >500).
+- Tsvector / GIN index migration — defer until row count justifies it.
+- Removing the `Quarter` filter capability from saved calendar views — existing data with `grain: "quarter"` continues to render under Month view as before; only the **toggle button** is replaced.

--- a/src/app/api/activities/[id]/route.ts
+++ b/src/app/api/activities/[id]/route.ts
@@ -271,7 +271,19 @@ export async function PATCH(
       address, addressLat, addressLng, inPerson,
       metadata, attendeeUserIds, contactIds, expenses, rating, opportunityIds,
       districts: districtUpdates, // [{leaid, visitDate?, visitEndDate?}]
+      createdByUserId, // owner reassignment — auth gate above already restricts to current owner or admin
     } = body;
+
+    // Validate the new owner exists when reassigning ownership.
+    if (createdByUserId !== undefined && createdByUserId !== null) {
+      const newOwner = await prisma.userProfile.findUnique({
+        where: { id: createdByUserId },
+        select: { id: true },
+      });
+      if (!newOwner) {
+        return NextResponse.json({ error: "invalid_owner" }, { status: 400 });
+      }
+    }
 
     // Validate type if provided — allow keeping the existing type even if it's
     // a legacy value not in the current enum (e.g. customer_check_in)
@@ -402,6 +414,7 @@ export async function PATCH(
         }),
         ...(metadata !== undefined && { metadata: metadata }),
         ...(rating !== undefined && { rating: rating }),
+        ...(createdByUserId !== undefined && { createdByUserId }),
       },
     });
 

--- a/src/app/api/activities/__tests__/route.test.ts
+++ b/src/app/api/activities/__tests__/route.test.ts
@@ -23,7 +23,7 @@ vi.mock("@/lib/prisma", () => ({
     activityPlan: { findFirst: vi.fn() },
     district: { findMany: vi.fn() },
     territoryPlanDistrict: { findMany: vi.fn() },
-    userProfile: { findUnique: vi.fn() },
+    userProfile: { findUnique: vi.fn(), findMany: vi.fn().mockResolvedValue([]) },
   },
 }));
 
@@ -58,8 +58,17 @@ function makeListActivity(overrides: Record<string, unknown> = {}) {
     status: "planned",
     source: "manual",
     outcomeType: null,
+    notes: null,
+    outcome: null,
+    createdByUserId: "user-1",
     plans: [] as { planId: string }[],
-    districts: [] as { districtLeaid: string; warningDismissed: boolean }[],
+    districts: [] as {
+      districtLeaid: string;
+      warningDismissed: boolean;
+      position?: number;
+      district?: { name: string };
+    }[],
+    contacts: [] as { contact: { name: string } }[],
     states: [] as { state: { abbrev: string } }[],
     ...overrides,
   };
@@ -307,6 +316,118 @@ describe("GET /api/activities", () => {
     expect(res.status).toBe(500);
     const body = await res.json();
     expect(body.error).toBe("Failed to fetch activities");
+  });
+
+  it("search matches notes (broadened OR clause)", async () => {
+    mockGetUser.mockResolvedValue(TEST_USER);
+    mockPrisma.activity.count.mockResolvedValue(1);
+    mockPrisma.activity.findMany.mockResolvedValue([
+      makeListActivity({ notes: "discussed pilot" }),
+    ] as never);
+    mockPrisma.territoryPlanDistrict.findMany.mockResolvedValue([]);
+
+    const req = makeRequest("/api/activities?search=pilot");
+    await listActivities(req);
+
+    const where = mockPrisma.activity.findMany.mock.calls[0][0].where;
+    expect(where.OR).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ title: expect.objectContaining({ contains: "pilot" }) }),
+        expect.objectContaining({ notes: expect.objectContaining({ contains: "pilot" }) }),
+        expect.objectContaining({ outcome: expect.objectContaining({ contains: "pilot" }) }),
+      ])
+    );
+  });
+
+  it("?contactIds= filters by contact junction", async () => {
+    mockGetUser.mockResolvedValue(TEST_USER);
+    mockPrisma.activity.count.mockResolvedValue(0);
+    mockPrisma.activity.findMany.mockResolvedValue([]);
+    mockPrisma.territoryPlanDistrict.findMany.mockResolvedValue([]);
+
+    const req = makeRequest("/api/activities?contactIds=1,2");
+    await listActivities(req);
+
+    const where = mockPrisma.activity.findMany.mock.calls[0][0].where;
+    expect(where.contacts).toEqual({ some: { contactId: { in: [1, 2] } } });
+  });
+
+  it("?sortBy=title&sortDir=asc orders by title ascending", async () => {
+    mockGetUser.mockResolvedValue(TEST_USER);
+    mockPrisma.activity.count.mockResolvedValue(0);
+    mockPrisma.activity.findMany.mockResolvedValue([]);
+    mockPrisma.territoryPlanDistrict.findMany.mockResolvedValue([]);
+
+    const req = makeRequest("/api/activities?sortBy=title&sortDir=asc");
+    await listActivities(req);
+
+    const orderBy = mockPrisma.activity.findMany.mock.calls[0][0].orderBy;
+    expect(orderBy).toEqual([{ title: "asc" }]);
+  });
+
+  it("response includes denormalized Table-view fields", async () => {
+    mockGetUser.mockResolvedValue(TEST_USER);
+    mockPrisma.activity.count.mockResolvedValue(1);
+    mockPrisma.activity.findMany.mockResolvedValue([
+      makeListActivity({
+        notes: "Some notes",
+        outcome: null,
+        createdByUserId: "user-1",
+        districts: [
+          {
+            districtLeaid: "1234567",
+            warningDismissed: false,
+            position: 0,
+            district: { name: "Test District" },
+          },
+        ],
+        contacts: [{ contact: { name: "Jane Doe" } }],
+      }),
+    ] as never);
+    mockPrisma.territoryPlanDistrict.findMany.mockResolvedValue([]);
+    mockPrisma.userProfile.findMany.mockResolvedValue([
+      { id: "user-1", fullName: "Sierra A.", email: "sierra@test.com" },
+    ] as never);
+
+    const req = makeRequest("/api/activities");
+    const res = await listActivities(req);
+    const body = await res.json();
+
+    expect(body.activities[0].districtName).toBe("Test District");
+    expect(body.activities[0].contactName).toBe("Jane Doe");
+    expect(body.activities[0].ownerFullName).toBe("Sierra A.");
+    expect(body.activities[0].createdByUserId).toBe("user-1");
+  });
+
+  it("outcomePreview truncates at 80 chars with ellipsis", async () => {
+    mockGetUser.mockResolvedValue(TEST_USER);
+    const longText = "a".repeat(120);
+    mockPrisma.activity.count.mockResolvedValue(1);
+    mockPrisma.activity.findMany.mockResolvedValue([
+      makeListActivity({ outcome: longText, notes: null }),
+    ] as never);
+    mockPrisma.territoryPlanDistrict.findMany.mockResolvedValue([]);
+
+    const req = makeRequest("/api/activities");
+    const res = await listActivities(req);
+    const body = await res.json();
+
+    expect(body.activities[0].outcomePreview).toBe(`${"a".repeat(80)}…`);
+  });
+
+  it("outcomePreview falls back to notes when outcome is empty", async () => {
+    mockGetUser.mockResolvedValue(TEST_USER);
+    mockPrisma.activity.count.mockResolvedValue(1);
+    mockPrisma.activity.findMany.mockResolvedValue([
+      makeListActivity({ outcome: null, notes: "Short note" }),
+    ] as never);
+    mockPrisma.territoryPlanDistrict.findMany.mockResolvedValue([]);
+
+    const req = makeRequest("/api/activities");
+    const res = await listActivities(req);
+    const body = await res.json();
+
+    expect(body.activities[0].outcomePreview).toBe("Short note");
   });
 });
 

--- a/src/app/api/activities/__tests__/route.test.ts
+++ b/src/app/api/activities/__tests__/route.test.ts
@@ -61,6 +61,8 @@ function makeListActivity(overrides: Record<string, unknown> = {}) {
     notes: null,
     outcome: null,
     createdByUserId: "user-1",
+    inPerson: null,
+    createdAt: new Date("2026-02-20T00:00:00Z"),
     plans: [] as { planId: string }[],
     districts: [] as {
       districtLeaid: string;

--- a/src/app/api/activities/__tests__/route.test.ts
+++ b/src/app/api/activities/__tests__/route.test.ts
@@ -914,6 +914,73 @@ describe("PATCH /api/activities/[id]", () => {
     expect(data.followUpDate).toBeNull();
     expect(data.outcomeDisposition).toBeNull();
   });
+
+  it("allows owner to reassign their own activity to another user", async () => {
+    mockGetUser.mockResolvedValue(TEST_USER);
+    mockPrisma.activity.findUnique.mockResolvedValue({
+      id: "activity-1",
+      createdByUserId: "user-1",
+    } as never);
+    mockPrisma.userProfile.findUnique.mockResolvedValue({ id: "user-2" } as never);
+    mockPrisma.activity.update.mockResolvedValue({
+      id: "activity-1",
+      title: "Reassigned",
+      createdByUserId: "user-2",
+      updatedAt: new Date("2026-02-23T12:00:00Z"),
+    } as never);
+
+    const req = makeRequest("/api/activities/activity-1", {
+      method: "PATCH",
+      body: JSON.stringify({ createdByUserId: "user-2" }),
+    });
+    const res = await PATCH(req, {
+      params: Promise.resolve({ id: "activity-1" }),
+    });
+
+    expect(res.status).toBe(200);
+    const data = mockPrisma.activity.update.mock.calls[0][0].data;
+    expect(data.createdByUserId).toBe("user-2");
+  });
+
+  it("returns 400 when reassigning to a non-existent user", async () => {
+    mockGetUser.mockResolvedValue(TEST_USER);
+    mockPrisma.activity.findUnique.mockResolvedValue({
+      id: "activity-1",
+      createdByUserId: "user-1",
+    } as never);
+    mockPrisma.userProfile.findUnique.mockResolvedValue(null as never);
+
+    const req = makeRequest("/api/activities/activity-1", {
+      method: "PATCH",
+      body: JSON.stringify({ createdByUserId: "ghost-user" }),
+    });
+    const res = await PATCH(req, {
+      params: Promise.resolve({ id: "activity-1" }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_owner");
+  });
+
+  it("returns 403 when non-owner non-admin attempts to reassign", async () => {
+    mockGetUser.mockResolvedValue(TEST_USER);
+    mockIsAdmin.mockResolvedValueOnce(false);
+    mockPrisma.activity.findUnique.mockResolvedValue({
+      id: "activity-1",
+      createdByUserId: "other-user",
+    } as never);
+
+    const req = makeRequest("/api/activities/activity-1", {
+      method: "PATCH",
+      body: JSON.stringify({ createdByUserId: "user-2" }),
+    });
+    const res = await PATCH(req, {
+      params: Promise.resolve({ id: "activity-1" }),
+    });
+
+    expect(res.status).toBe(403);
+  });
 });
 
 describe("DELETE /api/activities/[id]", () => {

--- a/src/app/api/activities/bulk/__tests__/route.test.ts
+++ b/src/app/api/activities/bulk/__tests__/route.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockGetUser = vi.fn();
+const mockIsAdmin = vi.fn().mockResolvedValue(false);
+vi.mock("@/lib/supabase/server", () => ({
+  getUser: (...args: unknown[]) => mockGetUser(...args),
+  isAdmin: (...args: unknown[]) => mockIsAdmin(...args),
+}));
+
+vi.mock("@/lib/prisma", () => ({
+  default: {
+    activity: {
+      findMany: vi.fn(),
+      updateMany: vi.fn(),
+    },
+    userProfile: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+import prisma from "@/lib/prisma";
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockPrisma = vi.mocked(prisma) as any;
+
+import { PATCH } from "../route";
+
+const TEST_USER = { id: "user-1", email: "test@example.com" };
+
+function makeRequest(body: unknown) {
+  return new NextRequest(new URL("/api/activities/bulk", "http://localhost:3000"), {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  } as never);
+}
+
+describe("PATCH /api/activities/bulk", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAdmin.mockResolvedValue(false);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetUser.mockResolvedValue(null);
+    const res = await PATCH(makeRequest({ ids: ["a"], updates: { status: "completed" } }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for empty ids", async () => {
+    mockGetUser.mockResolvedValue(TEST_USER);
+    const res = await PATCH(makeRequest({ ids: [], updates: { status: "completed" } }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for >500 ids", async () => {
+    mockGetUser.mockResolvedValue(TEST_USER);
+    const ids = Array.from({ length: 501 }, (_, i) => `a-${i}`);
+    const res = await PATCH(makeRequest({ ids, updates: { status: "completed" } }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("too_many_ids");
+    expect(body.max).toBe(500);
+  });
+
+  it("returns 400 when updates has no fields", async () => {
+    mockGetUser.mockResolvedValue(TEST_USER);
+    const res = await PATCH(makeRequest({ ids: ["a"], updates: {} }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("no_updates");
+  });
+
+  it("returns 400 when ownerId references a non-existent user", async () => {
+    mockGetUser.mockResolvedValue(TEST_USER);
+    mockPrisma.userProfile.findUnique.mockResolvedValue(null);
+    const res = await PATCH(makeRequest({ ids: ["a"], updates: { ownerId: "ghost" } }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_owner");
+  });
+
+  it("returns 400 for invalid status", async () => {
+    mockGetUser.mockResolvedValue(TEST_USER);
+    const res = await PATCH(makeRequest({ ids: ["a"], updates: { status: "not_a_status" } }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_status");
+  });
+
+  it("owner can update their own rows (status only)", async () => {
+    mockGetUser.mockResolvedValue(TEST_USER);
+    mockPrisma.activity.findMany.mockResolvedValue([
+      { id: "a-1", createdByUserId: "user-1", source: "manual" },
+      { id: "a-2", createdByUserId: "user-1", source: "manual" },
+    ]);
+    mockPrisma.activity.updateMany.mockResolvedValue({ count: 2 });
+
+    const res = await PATCH(
+      makeRequest({ ids: ["a-1", "a-2"], updates: { status: "completed" } })
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.succeeded).toEqual(["a-1", "a-2"]);
+    expect(body.failed).toEqual([]);
+    expect(mockPrisma.activity.updateMany).toHaveBeenCalledWith({
+      where: { id: { in: ["a-1", "a-2"] } },
+      data: { status: "completed" },
+    });
+  });
+
+  it("owner can reassign their own rows (owner only)", async () => {
+    mockGetUser.mockResolvedValue(TEST_USER);
+    mockPrisma.userProfile.findUnique.mockResolvedValue({ id: "user-2" });
+    mockPrisma.activity.findMany.mockResolvedValue([
+      { id: "a-1", createdByUserId: "user-1", source: "manual" },
+    ]);
+    mockPrisma.activity.updateMany.mockResolvedValue({ count: 1 });
+
+    const res = await PATCH(makeRequest({ ids: ["a-1"], updates: { ownerId: "user-2" } }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.succeeded).toEqual(["a-1"]);
+    expect(mockPrisma.activity.updateMany).toHaveBeenCalledWith({
+      where: { id: { in: ["a-1"] } },
+      data: { createdByUserId: "user-2" },
+    });
+  });
+
+  it("applies status and owner together in one call", async () => {
+    mockGetUser.mockResolvedValue(TEST_USER);
+    mockPrisma.userProfile.findUnique.mockResolvedValue({ id: "user-2" });
+    mockPrisma.activity.findMany.mockResolvedValue([
+      { id: "a-1", createdByUserId: "user-1", source: "manual" },
+    ]);
+    mockPrisma.activity.updateMany.mockResolvedValue({ count: 1 });
+
+    const res = await PATCH(
+      makeRequest({ ids: ["a-1"], updates: { ownerId: "user-2", status: "completed" } })
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockPrisma.activity.updateMany).toHaveBeenCalledWith({
+      where: { id: { in: ["a-1"] } },
+      data: { createdByUserId: "user-2", status: "completed" },
+    });
+  });
+
+  it("non-owner non-admin row returns failed:forbidden", async () => {
+    mockGetUser.mockResolvedValue(TEST_USER);
+    mockIsAdmin.mockResolvedValue(false);
+    mockPrisma.activity.findMany.mockResolvedValue([
+      { id: "a-1", createdByUserId: "user-1", source: "manual" },
+      { id: "a-2", createdByUserId: "someone-else", source: "manual" },
+    ]);
+    mockPrisma.activity.updateMany.mockResolvedValue({ count: 1 });
+
+    const res = await PATCH(
+      makeRequest({ ids: ["a-1", "a-2"], updates: { status: "completed" } })
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.succeeded).toEqual(["a-1"]);
+    expect(body.failed).toEqual([{ id: "a-2", reason: "forbidden" }]);
+  });
+
+  it("admin can update any row", async () => {
+    mockGetUser.mockResolvedValue(TEST_USER);
+    mockIsAdmin.mockResolvedValue(true);
+    mockPrisma.activity.findMany.mockResolvedValue([
+      { id: "a-1", createdByUserId: "someone-else", source: "manual" },
+    ]);
+    mockPrisma.activity.updateMany.mockResolvedValue({ count: 1 });
+
+    const res = await PATCH(makeRequest({ ids: ["a-1"], updates: { status: "completed" } }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.succeeded).toEqual(["a-1"]);
+    expect(body.failed).toEqual([]);
+  });
+
+  it("system-source row returns failed:system_skip", async () => {
+    mockGetUser.mockResolvedValue(TEST_USER);
+    mockPrisma.activity.findMany.mockResolvedValue([
+      { id: "a-1", createdByUserId: "user-1", source: "system" },
+    ]);
+    mockPrisma.activity.updateMany.mockResolvedValue({ count: 0 });
+
+    const res = await PATCH(makeRequest({ ids: ["a-1"], updates: { status: "completed" } }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.succeeded).toEqual([]);
+    expect(body.failed).toEqual([{ id: "a-1", reason: "system_skip" }]);
+    expect(mockPrisma.activity.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("non-existent id returns failed:not_found", async () => {
+    mockGetUser.mockResolvedValue(TEST_USER);
+    mockPrisma.activity.findMany.mockResolvedValue([]);
+
+    const res = await PATCH(makeRequest({ ids: ["ghost"], updates: { status: "completed" } }));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.succeeded).toEqual([]);
+    expect(body.failed).toEqual([{ id: "ghost", reason: "not_found" }]);
+    expect(mockPrisma.activity.updateMany).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/activities/bulk/route.ts
+++ b/src/app/api/activities/bulk/route.ts
@@ -1,0 +1,123 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+import { getUser, isAdmin } from "@/lib/supabase/server";
+import { VALID_ACTIVITY_STATUSES } from "@/features/activities/types";
+
+export const dynamic = "force-dynamic";
+
+const MAX_IDS = 500;
+
+type FailureReason = "not_found" | "forbidden" | "system_skip";
+
+interface BulkBody {
+  ids: unknown;
+  updates: unknown;
+}
+
+// PATCH /api/activities/bulk — apply the same owner/status update to many
+// activities in one round-trip. Powers the Table view's bulk action bar.
+//
+// Per-row authorization mirrors the single-row PATCH: the caller must be
+// admin OR the row's current owner. Rows that fail auth, are not found,
+// or originate from a system sync show up in the `failed` array with a
+// reason; the response is always 200 so partial successes are visible.
+export async function PATCH(request: NextRequest) {
+  const user = await getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: BulkBody;
+  try {
+    body = (await request.json()) as BulkBody;
+  } catch {
+    return NextResponse.json({ error: "invalid_body" }, { status: 400 });
+  }
+
+  // ---- Validate `ids` ----
+  if (!Array.isArray(body.ids) || body.ids.length === 0 || !body.ids.every((id) => typeof id === "string")) {
+    return NextResponse.json({ error: "invalid_ids" }, { status: 400 });
+  }
+  if (body.ids.length > MAX_IDS) {
+    return NextResponse.json({ error: "too_many_ids", max: MAX_IDS }, { status: 400 });
+  }
+  // Dedupe so the same id can't appear in succeeded AND failed.
+  const ids: string[] = [...new Set(body.ids as string[])];
+
+  // ---- Validate `updates` ----
+  if (!body.updates || typeof body.updates !== "object") {
+    return NextResponse.json({ error: "no_updates" }, { status: 400 });
+  }
+  const updates = body.updates as { ownerId?: unknown; status?: unknown };
+  const data: { createdByUserId?: string; status?: string } = {};
+
+  if (updates.ownerId !== undefined) {
+    if (typeof updates.ownerId !== "string" || updates.ownerId.length === 0) {
+      return NextResponse.json({ error: "invalid_owner" }, { status: 400 });
+    }
+    const newOwner = await prisma.userProfile.findUnique({
+      where: { id: updates.ownerId },
+      select: { id: true },
+    });
+    if (!newOwner) {
+      return NextResponse.json({ error: "invalid_owner" }, { status: 400 });
+    }
+    data.createdByUserId = updates.ownerId;
+  }
+
+  if (updates.status !== undefined) {
+    if (
+      typeof updates.status !== "string" ||
+      !(VALID_ACTIVITY_STATUSES as readonly string[]).includes(updates.status)
+    ) {
+      return NextResponse.json({ error: "invalid_status" }, { status: 400 });
+    }
+    data.status = updates.status;
+  }
+
+  if (Object.keys(data).length === 0) {
+    return NextResponse.json({ error: "no_updates" }, { status: 400 });
+  }
+
+  // ---- Per-row auth ----
+  const candidates = await prisma.activity.findMany({
+    where: { id: { in: ids } },
+    select: { id: true, createdByUserId: true, source: true },
+  });
+  const byId = new Map(candidates.map((c) => [c.id, c]));
+  const adminCaller = await isAdmin(user.id);
+
+  const succeeded: string[] = [];
+  const failed: { id: string; reason: FailureReason }[] = [];
+  const allowedIds: string[] = [];
+
+  for (const id of ids) {
+    const row = byId.get(id);
+    if (!row) {
+      failed.push({ id, reason: "not_found" });
+      continue;
+    }
+    if (row.source === "system") {
+      failed.push({ id, reason: "system_skip" });
+      continue;
+    }
+    // Match the [id] PATCH guard: rows with no owner are treated as the
+    // caller's own (legacy backfill).
+    const ownsIt = !row.createdByUserId || row.createdByUserId === user.id;
+    if (!ownsIt && !adminCaller) {
+      failed.push({ id, reason: "forbidden" });
+      continue;
+    }
+    allowedIds.push(id);
+  }
+
+  if (allowedIds.length > 0) {
+    await prisma.activity.updateMany({
+      where: { id: { in: allowedIds } },
+      data,
+    });
+    succeeded.push(...allowedIds);
+  }
+
+  return NextResponse.json({ succeeded, failed });
+}

--- a/src/app/api/activities/route.ts
+++ b/src/app/api/activities/route.ts
@@ -288,6 +288,8 @@ export async function GET(request: NextRequest) {
           notes: true,
           outcome: true,
           createdByUserId: true,
+          inPerson: true,
+          createdAt: true,
           plans: {
             select: { planId: true },
           },
@@ -410,6 +412,8 @@ export async function GET(request: NextRequest) {
           districtName: firstDistrict,
           contactName: firstContact,
           outcomePreview,
+          inPerson: activity.inPerson,
+          createdAt: activity.createdAt.toISOString(),
         };
       })
       .filter((a) => {

--- a/src/app/api/activities/route.ts
+++ b/src/app/api/activities/route.ts
@@ -48,6 +48,9 @@ export async function GET(request: NextRequest) {
     const dealKinds = readMulti(searchParams, "dealKinds");
     const districtLeaids = readMulti(searchParams, "districtLeaids");
     const attendeeIds = readMulti(searchParams, "attendeeIds");
+    const contactIds = readMulti(searchParams, "contactIds")
+      .map((s) => Number(s))
+      .filter((n) => Number.isFinite(n));
     const inPersonValues = readMulti(searchParams, "inPerson");
 
     const planId = searchParams.get("planId");
@@ -56,12 +59,23 @@ export async function GET(request: NextRequest) {
     const hasUnlinkedDistricts = searchParams.get("hasUnlinkedDistricts") === "true";
     const startDate = searchParams.get("startDate");
     const endDate = searchParams.get("endDate");
+    const startDateFrom = searchParams.get("startDateFrom");
+    const startDateTo = searchParams.get("startDateTo");
     const unscheduled = searchParams.get("unscheduled") === "true";
     const search = searchParams.get("search");
     const source = searchParams.get("source");
     const ownerId = searchParams.get("ownerId"); // specific user ID, "all", or null (defaults to current user)
     const limit = parseInt(searchParams.get("limit") || "100");
     const offset = parseInt(searchParams.get("offset") || "0");
+    // Table-view sort. The whitelist mirrors ActivitySortKey in the
+    // shared types — anything else falls through to the default (date desc).
+    const ALLOWED_SORT_KEYS = ["date", "type", "title", "district", "owner", "status"] as const;
+    type SortKey = typeof ALLOWED_SORT_KEYS[number];
+    const sortByRaw = searchParams.get("sortBy");
+    const sortBy: SortKey = (ALLOWED_SORT_KEYS as readonly string[]).includes(sortByRaw ?? "")
+      ? (sortByRaw as SortKey)
+      : "date";
+    const sortDir: "asc" | "desc" = searchParams.get("sortDir") === "asc" ? "asc" : "desc";
 
     // Build where clause
     // When filtering by planId, show ALL activities in that plan (not just the user's)
@@ -86,9 +100,19 @@ export async function GET(request: NextRequest) {
       where.createdByUserId = user.id;
     }
 
-    // Search by title
+    // Search across title, notes, and outcome (case-insensitive contains).
+    // OR'd into the where so a row matching ANY of the three fields appears.
     if (search) {
-      where.title = { contains: search, mode: "insensitive" };
+      where.OR = [
+        { title: { contains: search, mode: "insensitive" } },
+        { notes: { contains: search, mode: "insensitive" } },
+        { outcome: { contains: search, mode: "insensitive" } },
+      ];
+    }
+
+    // Filter by contact id list (Table view).
+    if (contactIds.length > 0) {
+      where.contacts = { some: { contactId: { in: contactIds } } };
     }
 
     // Filter by category (maps each category to its types). When both
@@ -188,6 +212,54 @@ export async function GET(request: NextRequest) {
         { endDate: { lte: new Date(endDate) } },
         { endDate: null, startDate: { not: null, lte: new Date(endDate) } },
       ];
+    } else if (startDateFrom || startDateTo) {
+      // Table view sends a free-form startDate range (either bound may be
+      // missing). Activities must have a startDate within the bounds.
+      const range: Prisma.DateTimeNullableFilter = { not: null };
+      if (startDateFrom) range.gte = new Date(startDateFrom);
+      if (startDateTo) {
+        // Inclusive end-of-day for the To bound so `2026-05-05` includes the
+        // full day in the user's timezone-relative view.
+        const to = new Date(startDateTo);
+        to.setHours(23, 59, 59, 999);
+        range.lte = to;
+      }
+      where.startDate = range;
+    }
+
+    // Resolve orderBy from sortBy/sortDir.
+    //
+    // - `district` falls back to title: Prisma can't natively orderBy on a
+    //   list relation's `name` field and our schema has no denormalized
+    //   first-district column. The header still reads "District" but the
+    //   rows order alphabetically by activity title under the hood.
+    // - `owner` falls back to `createdByUserId`: Activity carries the FK
+    //   scalar but has no `createdByUser` relation in the schema, so a
+    //   true name-sort would require a denormalized column or post-fetch
+    //   ordering. UUID-sort at least groups same-owner rows together.
+    let orderBy: Prisma.ActivityOrderByWithRelationInput | Prisma.ActivityOrderByWithRelationInput[];
+    switch (sortBy) {
+      case "type":
+        orderBy = [{ type: sortDir }, { startDate: { sort: "desc", nulls: "last" } }];
+        break;
+      case "title":
+        orderBy = [{ title: sortDir }];
+        break;
+      case "status":
+        orderBy = [{ status: sortDir }, { startDate: { sort: "desc", nulls: "last" } }];
+        break;
+      case "owner":
+        orderBy = [{ createdByUserId: sortDir }, { startDate: { sort: "desc", nulls: "last" } }];
+        break;
+      case "district":
+        orderBy = [{ title: sortDir }];
+        break;
+      case "date":
+      default:
+        orderBy = [
+          { startDate: { sort: sortDir, nulls: "last" } },
+          { createdAt: sortDir },
+        ];
     }
 
     const queryStart = Date.now();
@@ -210,7 +282,12 @@ export async function GET(request: NextRequest) {
           status: true,
           source: true,
           outcomeType: true,
-          // Only fetch the IDs and flags we need for list view, not full related objects
+          // Table-view denormalizations: notes/outcome power outcomePreview;
+          // first-district name + first-contact name + owner name avoid an
+          // N+1 in the row renderer. Older calendar views ignore these.
+          notes: true,
+          outcome: true,
+          createdByUserId: true,
           plans: {
             select: { planId: true },
           },
@@ -218,7 +295,14 @@ export async function GET(request: NextRequest) {
             select: {
               districtLeaid: true,
               warningDismissed: true,
+              position: true,
+              district: { select: { name: true } },
             },
+            orderBy: { position: "asc" },
+          },
+          contacts: {
+            select: { contact: { select: { name: true } } },
+            take: 1,
           },
           states: {
             select: {
@@ -226,7 +310,7 @@ export async function GET(request: NextRequest) {
             },
           },
         },
-        orderBy: { startDate: { sort: "desc", nulls: "last" } },
+        orderBy,
         take: limit,
         skip: offset,
       }),
@@ -258,6 +342,27 @@ export async function GET(request: NextRequest) {
       planDistrictMap.get(pd.planId)!.add(pd.districtLeaid);
     }
 
+    // Batch-fetch owner display names for the Table view's Owner column.
+    // Activity carries `createdByUserId` as a scalar (no relation), so we
+    // resolve names here in a single query rather than per-row.
+    const ownerIds = [
+      ...new Set(
+        activities
+          .map((a) => a.createdByUserId)
+          .filter((id): id is string => Boolean(id))
+      ),
+    ];
+    const ownerProfiles = ownerIds.length > 0
+      ? await prisma.userProfile.findMany({
+          where: { id: { in: ownerIds } },
+          select: { id: true, fullName: true, email: true },
+        })
+      : [];
+    const ownerNameById = new Map<string, string>();
+    for (const p of ownerProfiles) {
+      ownerNameById.set(p.id, p.fullName ?? p.email);
+    }
+
     // Transform and filter by computed flags
     const transformed = activities
       .map((activity) => {
@@ -271,6 +376,18 @@ export async function GET(request: NextRequest) {
             planDistrictMap.get(planId)?.has(ad.districtLeaid)
           );
         });
+
+        const firstDistrict = activity.districts[0]?.district?.name ?? null;
+        const firstContact = activity.contacts[0]?.contact?.name ?? null;
+        const ownerFullName = activity.createdByUserId
+          ? ownerNameById.get(activity.createdByUserId) ?? null
+          : null;
+        const previewSource = activity.outcome?.trim() || activity.notes?.trim() || null;
+        const outcomePreview = previewSource
+          ? previewSource.length > 80
+            ? `${previewSource.slice(0, 80)}…`
+            : previewSource
+          : null;
 
         return {
           id: activity.id,
@@ -287,6 +404,12 @@ export async function GET(request: NextRequest) {
           planCount: activity.plans.length,
           districtCount: activity.districts.length,
           stateAbbrevs: activity.states.map((s) => s.state.abbrev),
+          // Table-view denormalizations
+          createdByUserId: activity.createdByUserId,
+          ownerFullName,
+          districtName: firstDistrict,
+          contactName: firstContact,
+          outcomePreview,
         };
       })
       .filter((a) => {

--- a/src/features/activities/components/page/ActivitiesPageHeader.tsx
+++ b/src/features/activities/components/page/ActivitiesPageHeader.tsx
@@ -27,16 +27,20 @@ export default function ActivitiesPageHeader({
   const setView = useActivitiesChrome((s) => s.setView);
   const setGrain = useActivitiesChrome((s) => s.setGrain);
 
+  const isTableView = view === "table";
+
   return (
     <header className="bg-white border-b border-[#E2DEEC] px-6 py-3">
       <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-3">
         <div className="min-w-0">
           <h1 className="text-2xl font-bold text-[#403770] tracking-[-0.01em]">Activities</h1>
-          <p className="text-xs text-[#8A80A8] whitespace-nowrap">
-            Showing{" "}
-            <span className="font-medium text-[#6E6390]">{count.toLocaleString()}</span>{" "}
-            in this range
-          </p>
+          {!isTableView && (
+            <p className="text-xs text-[#8A80A8] whitespace-nowrap">
+              Showing{" "}
+              <span className="font-medium text-[#6E6390]">{count.toLocaleString()}</span>{" "}
+              in this range
+            </p>
+          )}
         </div>
 
         <div className="flex flex-wrap items-center gap-2">
@@ -61,9 +65,11 @@ export default function ActivitiesPageHeader({
         </div>
       </div>
 
-      <div className="mt-3 flex items-center">
-        <ActivitiesDateRange />
-      </div>
+      {!isTableView && (
+        <div className="mt-3 flex items-center">
+          <ActivitiesDateRange />
+        </div>
+      )}
     </header>
   );
 }

--- a/src/features/activities/components/page/ActivitiesPageShell.tsx
+++ b/src/features/activities/components/page/ActivitiesPageShell.tsx
@@ -51,15 +51,24 @@ export default function ActivitiesPageShell() {
   const [pendingModalOpen, setPendingModalOpen] = useState(false);
   useCommandBarHotkey(setCommandBarOpen);
 
+  const isTableView = view === "table";
+
   const params = useMemo(
     () => deriveActivitiesParams({ filters, anchorIso, grain }),
     [filters, anchorIso, grain]
   );
 
-  const { data, isLoading } = useActivities(params);
+  // Skip the calendar-window query in Table mode; the table owns its own
+  // pagination + sort and asks the API directly. Per CLAUDE.md "Conditional
+  // rendering over conditional fetching" — but here we're already mounting
+  // a single shell, so an `enabled` flag is the cleanest option.
+  const { data, isLoading } = useActivities(params, { enabled: !isTableView });
   const filtered = useMemo(
-    () => applyClientFilters(data?.activities ?? [], filters, getCategoryForType),
-    [data, filters]
+    () =>
+      isTableView
+        ? []
+        : applyClientFilters(data?.activities ?? [], filters, getCategoryForType),
+    [data, filters, isTableView]
   );
 
   // Upcoming-rail rolls 14 days forward from today regardless of the visible window.
@@ -73,10 +82,14 @@ export default function ActivitiesPageShell() {
       limit: 200,
     };
   }, [filters.owners]);
-  const { data: upcomingData } = useActivities(upcomingParams);
+  // Rail is hidden in Table view; skip the fetch too.
+  const { data: upcomingData } = useActivities(upcomingParams, { enabled: !isTableView });
   const upcomingFiltered = useMemo(
-    () => applyClientFilters(upcomingData?.activities ?? [], filters, getCategoryForType),
-    [upcomingData, filters]
+    () =>
+      isTableView
+        ? []
+        : applyClientFilters(upcomingData?.activities ?? [], filters, getCategoryForType),
+    [upcomingData, filters, isTableView]
   );
 
   // Scope is derived from filters.owners: solo-current-user → "mine", empty → "all".

--- a/src/features/activities/components/page/ActivitiesPageShell.tsx
+++ b/src/features/activities/components/page/ActivitiesPageShell.tsx
@@ -21,6 +21,7 @@ import WeekGridView from "./WeekGridView";
 import MapTimeView from "./MapTimeView";
 import UpcomingRail from "./UpcomingRail";
 import ActivityDetailDrawer from "./ActivityDetailDrawer";
+import ActivitiesTableView from "./table/ActivitiesTableView";
 import BackfillSetupModal from "@/features/calendar/components/backfill/BackfillSetupModal";
 import type { ActivityScope } from "./ScopeToggle";
 
@@ -127,8 +128,8 @@ export default function ActivitiesPageShell() {
         onScopeChange={onScopeChange}
         onReviewPending={() => setPendingModalOpen(true)}
       />
-      <SavedViewTabs currentUserId={profile?.id ?? null} />
-      <ActivitiesFilterChips onOpenCommandBar={() => setCommandBarOpen(true)} />
+      {view !== "table" && <SavedViewTabs currentUserId={profile?.id ?? null} />}
+      {view !== "table" && <ActivitiesFilterChips onOpenCommandBar={() => setCommandBarOpen(true)} />}
 
       <div className="flex-1 flex min-h-0">
         <div className="flex-1 min-w-0 flex flex-col overflow-hidden">
@@ -145,19 +146,27 @@ export default function ActivitiesPageShell() {
           {view === "week" && (
             <WeekGridView activities={filtered} onActivityClick={setOpenActivityId} />
           )}
+          {view === "table" && (
+            <ActivitiesTableView
+              onActivityClick={setOpenActivityId}
+              onNewActivity={() => setCreatingActivity(true)}
+            />
+          )}
           {view === "map" && (
             <MapTimeView activities={filtered} onActivityClick={setOpenActivityId} />
           )}
         </div>
 
-        <div className="hidden md:flex">
-          <UpcomingRail
-            activities={upcomingFiltered}
-            onActivityClick={setOpenActivityId}
-            scope={railScope}
-            onNewActivity={() => setCreatingActivity(true)}
-          />
-        </div>
+        {view !== "table" && (
+          <div className="hidden md:flex">
+            <UpcomingRail
+              activities={upcomingFiltered}
+              onActivityClick={setOpenActivityId}
+              scope={railScope}
+              onNewActivity={() => setCreatingActivity(true)}
+            />
+          </div>
+        )}
       </div>
 
       <ActivityDetailDrawer

--- a/src/features/activities/components/page/ViewToggle.tsx
+++ b/src/features/activities/components/page/ViewToggle.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { Calendar, CalendarDays, CalendarRange, ListChecks, Map } from "lucide-react";
+import { Calendar, CalendarDays, ListChecks, Map, Table as TableIcon } from "lucide-react";
 import type { CalendarView, Grain } from "@/features/activities/lib/filters-store";
 
 // One combined picker for view + grain. Each option pins both: clicking
-// "Quarter" puts you on the month-grid view paginating by quarter; clicking
-// "Schedule" puts you on the day-by-day list paginating by week. The lower
-// grain selector is gone — these five buttons are now the single source.
+// "Schedule" puts you on the day-by-day list paginating by week, etc. The
+// "Table" option swaps the calendar for a paginated, filterable activities
+// grid; date filtering moves into a column filter so anchor+grain are
+// irrelevant — we keep grain="week" so switching back to a calendar view
+// lands on a sensible default.
 interface ViewOption {
   id: string;
   label: string;
@@ -19,15 +21,18 @@ const OPTIONS: ViewOption[] = [
   { id: "schedule", label: "Schedule", view: "schedule", grain: "week", Icon: ListChecks },
   { id: "week", label: "Week", view: "week", grain: "week", Icon: CalendarDays },
   { id: "month", label: "Month", view: "month", grain: "month", Icon: Calendar },
-  { id: "quarter", label: "Quarter", view: "month", grain: "quarter", Icon: CalendarRange },
+  { id: "table", label: "Table", view: "table", grain: "week", Icon: TableIcon },
   { id: "map", label: "Map", view: "map", grain: "week", Icon: Map },
 ];
 
-function activeId(view: CalendarView, grain: Grain): string | null {
+function activeId(view: CalendarView, _grain: Grain): string | null {
   if (view === "schedule") return "schedule";
   if (view === "week") return "week";
+  if (view === "table") return "table";
   if (view === "map") return "map";
-  if (view === "month") return grain === "quarter" ? "quarter" : "month";
+  // Legacy state with grain="quarter" maps back to Month — the Quarter
+  // toggle was removed, but persisted store values may still carry it.
+  if (view === "month") return "month";
   return null;
 }
 

--- a/src/features/activities/components/page/table/ActivitiesTableHeader.tsx
+++ b/src/features/activities/components/page/table/ActivitiesTableHeader.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, ChevronUp, Filter } from "lucide-react";
+import {
+  useActivitiesChrome,
+  type ActivitySortKey,
+} from "@/features/activities/lib/filters-store";
+import type { ColumnDef } from "@/features/shared/components/DataGrid";
+import ColumnFilterPopover from "./ColumnFilterPopover";
+import { cn } from "@/features/shared/lib/cn";
+
+interface ActivitiesTableHeaderProps {
+  visibleColumnDefs: ColumnDef[];
+  selectAllChecked: boolean;
+  onTogglePageSelection: () => void;
+}
+
+const FILTERABLE_KEYS = new Set([
+  "date",
+  "type",
+  "title",
+  "district",
+  "contact",
+  "owner",
+  "status",
+  "outcome",
+  "createdAt",
+]);
+
+const SORT_KEY_BY_COLUMN: Record<string, ActivitySortKey> = {
+  date: "date",
+  type: "type",
+  title: "title",
+  district: "district",
+  owner: "owner",
+  status: "status",
+};
+
+// Activity column header row. Each column label is a sort button (cycles
+// asc → desc); a small ▾ icon next to it opens the column's filter popover.
+// The filter trigger gets a coral dot when that column has an active filter.
+export default function ActivitiesTableHeader({
+  visibleColumnDefs,
+  selectAllChecked,
+  onTogglePageSelection,
+}: ActivitiesTableHeaderProps) {
+  const sorts = useActivitiesChrome((s) => s.tableSorts);
+  const setTableSorts = useActivitiesChrome((s) => s.setTableSorts);
+  const filters = useActivitiesChrome((s) => s.filters);
+  const [openFilter, setOpenFilter] = useState<string | null>(null);
+
+  const primarySort = sorts[0];
+
+  function isSortable(key: string) {
+    const def = visibleColumnDefs.find((c) => c.key === key);
+    if (def?.sortable === false) return false;
+    return key in SORT_KEY_BY_COLUMN;
+  }
+
+  function clickSort(columnKey: string) {
+    if (!isSortable(columnKey)) return;
+    const sortKey = SORT_KEY_BY_COLUMN[columnKey];
+    // Cycle: not-sorted → asc → desc → not-sorted (default re-applies).
+    if (primarySort?.column === sortKey) {
+      if (primarySort.direction === "asc") {
+        setTableSorts([{ column: sortKey, direction: "desc" }]);
+      } else {
+        setTableSorts([{ column: "date", direction: "desc" }]); // back to default
+      }
+    } else {
+      setTableSorts([{ column: sortKey, direction: "asc" }]);
+    }
+  }
+
+  function isFiltered(columnKey: string): boolean {
+    switch (columnKey) {
+      case "date":
+        return Boolean(filters.dateFrom) || Boolean(filters.dateTo);
+      case "type":
+        return filters.categories.length > 0 || filters.types.length > 0;
+      case "owner":
+        return filters.owners.length > 0;
+      case "status":
+        return filters.statuses.length > 0;
+      case "district":
+        return filters.districts.length > 0;
+      case "contact":
+        return filters.contactIds.length > 0;
+      case "title":
+      case "outcome":
+        return Boolean(filters.text);
+      default:
+        return false;
+    }
+  }
+
+  return (
+    <thead className="sticky top-0 z-10 bg-[#F7F5FA] border-b border-[#E2DEEC]">
+      <tr>
+        <th className="w-8 px-3 py-2 text-left">
+          <input
+            type="checkbox"
+            aria-label="Select page"
+            checked={selectAllChecked}
+            onChange={onTogglePageSelection}
+            className="cursor-pointer accent-[#403770]"
+          />
+        </th>
+        {visibleColumnDefs.map((col) => {
+          const sortKey = SORT_KEY_BY_COLUMN[col.key];
+          const isActiveSort = sortKey && primarySort?.column === sortKey;
+          const filtered = isFiltered(col.key);
+          const filterable = FILTERABLE_KEYS.has(col.key);
+          return (
+            <th
+              key={col.key}
+              className="relative px-3 py-2 text-left whitespace-nowrap"
+              style={col.width ? { minWidth: col.width } : undefined}
+            >
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => clickSort(col.key)}
+                  disabled={!isSortable(col.key)}
+                  className={cn(
+                    "inline-flex items-center gap-1 text-[10px] font-extrabold uppercase tracking-[0.08em] text-[#544A78]",
+                    "disabled:cursor-default",
+                    isSortable(col.key) && "hover:text-[#403770]"
+                  )}
+                  aria-sort={
+                    isActiveSort
+                      ? primarySort.direction === "asc"
+                        ? "ascending"
+                        : "descending"
+                      : "none"
+                  }
+                >
+                  {col.label}
+                  {isActiveSort && (primarySort.direction === "asc"
+                    ? <ChevronUp className="w-3 h-3" />
+                    : <ChevronDown className="w-3 h-3" />)}
+                </button>
+                {filterable && (
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setOpenFilter(openFilter === col.key ? null : col.key);
+                    }}
+                    aria-label={`Filter ${col.label}`}
+                    aria-expanded={openFilter === col.key}
+                    className={cn(
+                      "relative inline-flex items-center justify-center w-4 h-4 rounded text-[#A69DC0] hover:text-[#403770] hover:bg-[#EFEDF5]",
+                      filtered && "text-[#F37167]"
+                    )}
+                  >
+                    <Filter className="w-3 h-3" />
+                    {filtered && (
+                      <span aria-hidden className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-[#F37167]" />
+                    )}
+                  </button>
+                )}
+              </div>
+              {openFilter === col.key && (
+                <ColumnFilterPopover
+                  columnKey={col.key}
+                  onClose={() => setOpenFilter(null)}
+                />
+              )}
+            </th>
+          );
+        })}
+      </tr>
+    </thead>
+  );
+}

--- a/src/features/activities/components/page/table/ActivitiesTableToolbar.tsx
+++ b/src/features/activities/components/page/table/ActivitiesTableToolbar.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Search, RotateCcw } from "lucide-react";
+import {
+  useActivitiesChrome,
+  EMPTY_FILTERS,
+  DEFAULT_TABLE_COLUMNS,
+  DEFAULT_TABLE_SORTS,
+} from "@/features/activities/lib/filters-store";
+import { useProfile } from "@/features/shared/lib/queries";
+import type { ActivityListItem } from "@/features/shared/types/api-types";
+import ColumnsPicker from "./ColumnsPicker";
+import ExportMenu from "./ExportMenu";
+
+interface ActivitiesTableToolbarProps {
+  selectedRows: ActivityListItem[];
+  filteredRows: ActivityListItem[];
+}
+
+// Top-of-table toolbar: full-width text search, reset button (only when any
+// filter is active), export menu, columns picker. The search input is
+// debounced 250ms before writing to filters.text — typing into the input
+// shouldn't fire a query on every keystroke.
+export default function ActivitiesTableToolbar({
+  selectedRows,
+  filteredRows,
+}: ActivitiesTableToolbarProps) {
+  const filters = useActivitiesChrome((s) => s.filters);
+  const patchFilters = useActivitiesChrome((s) => s.patchFilters);
+  const setTableSorts = useActivitiesChrome((s) => s.setTableSorts);
+  const setTableVisibleColumns = useActivitiesChrome((s) => s.setTableVisibleColumns);
+  const visibleColumns = useActivitiesChrome((s) => s.tableVisibleColumns);
+  const { data: profile } = useProfile();
+
+  const [search, setSearch] = useState(filters.text);
+  useEffect(() => {
+    const t = setTimeout(() => {
+      if (search.trim() !== filters.text) {
+        patchFilters({ text: search.trim() });
+      }
+    }, 250);
+    return () => clearTimeout(t);
+    // Intentionally not depending on filters.text — only the local input drives writes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [search, patchFilters]);
+
+  // Keep input in sync if some other UI clears the filter (e.g. Reset button).
+  useEffect(() => {
+    if (filters.text === "" && search !== "") setSearch("");
+  }, [filters.text, search]);
+
+  const hasActiveFilter =
+    filters.categories.length > 0 ||
+    filters.types.length > 0 ||
+    filters.statuses.length > 0 ||
+    filters.attendeeIds.length > 0 ||
+    filters.districts.length > 0 ||
+    filters.contactIds.length > 0 ||
+    filters.inPerson.length > 0 ||
+    filters.states.length > 0 ||
+    filters.territories.length > 0 ||
+    filters.tags.length > 0 ||
+    filters.dealKinds.length > 0 ||
+    Boolean(filters.text.trim()) ||
+    Boolean(filters.dateFrom) ||
+    Boolean(filters.dateTo) ||
+    // Default owner = my activities; treat anything beyond that as active.
+    (filters.owners.length !== 1 || (profile?.id ? filters.owners[0] !== profile.id : true));
+
+  function handleReset() {
+    setSearch("");
+    setTableSorts([...DEFAULT_TABLE_SORTS]);
+    setTableVisibleColumns([...DEFAULT_TABLE_COLUMNS]);
+    if (profile?.id) {
+      patchFilters({ ...EMPTY_FILTERS, owners: [profile.id] });
+    } else {
+      patchFilters({ ...EMPTY_FILTERS });
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-2 px-6 py-2.5 bg-white border-b border-[#E2DEEC]">
+      <div className="relative flex-1 max-w-2xl">
+        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-[#A69DC0]" />
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search by title, notes, district, contact…"
+          className="w-full h-8 pl-8 pr-2.5 text-xs text-[#403770] placeholder:text-[#A69DC0] bg-white border border-[#D4CFE2] rounded-lg focus:outline-none focus:ring-2 focus:ring-[#F37167] focus:border-transparent"
+        />
+      </div>
+      <div className="ml-auto flex items-center gap-2">
+        {hasActiveFilter && (
+          <button
+            type="button"
+            onClick={handleReset}
+            className="inline-flex items-center gap-1 h-8 px-2.5 text-[11px] font-bold uppercase tracking-[0.04em] text-[#544A78] bg-white border border-[#D4CFE2] rounded-lg hover:bg-[#F7F5FA] transition-colors fm-focus-ring"
+          >
+            <RotateCcw className="w-3 h-3" />
+            Reset
+          </button>
+        )}
+        <ExportMenu selectedRows={selectedRows} filteredRows={filteredRows} />
+        <ColumnsPicker
+          visibleColumns={visibleColumns}
+          onChange={setTableVisibleColumns}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/features/activities/components/page/table/ActivitiesTableToolbar.tsx
+++ b/src/features/activities/components/page/table/ActivitiesTableToolbar.tsx
@@ -34,6 +34,9 @@ export default function ActivitiesTableToolbar({
   const { data: profile } = useProfile();
 
   const [search, setSearch] = useState(filters.text);
+
+  // Local→store debounce. The local input is the source of truth while the
+  // user is typing; we flush to the Zustand store after 250ms of idle.
   useEffect(() => {
     const t = setTimeout(() => {
       if (search.trim() !== filters.text) {
@@ -45,10 +48,13 @@ export default function ActivitiesTableToolbar({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [search, patchFilters]);
 
-  // Keep input in sync if some other UI clears the filter (e.g. Reset button).
+  // Store→local sync. Only reacts to filters.text changing (e.g. Reset button,
+  // saved view). Critically NOT depending on `search` — if it did, every
+  // keystroke would race with the debounced flush above and wipe the input.
   useEffect(() => {
-    if (filters.text === "" && search !== "") setSearch("");
-  }, [filters.text, search]);
+    setSearch(filters.text);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filters.text]);
 
   const hasActiveFilter =
     filters.categories.length > 0 ||

--- a/src/features/activities/components/page/table/ActivitiesTableView.tsx
+++ b/src/features/activities/components/page/table/ActivitiesTableView.tsx
@@ -1,0 +1,356 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { ChevronLeft, ChevronRight, AlertTriangle, Inbox } from "lucide-react";
+import { useActivities } from "@/features/activities/lib/queries";
+import {
+  useActivitiesChrome,
+  deriveActivitiesParams,
+} from "@/features/activities/lib/filters-store";
+import {
+  ACTIVITY_TYPE_LABELS,
+  ACTIVITY_STATUS_CONFIG,
+  type ActivityType,
+  type ActivityStatus,
+} from "@/features/activities/types";
+import type { ActivityListItem } from "@/features/shared/types/api-types";
+import { cn } from "@/features/shared/lib/cn";
+import { ACTIVITIES_TABLE_COLUMNS, getColumnDef } from "./columns";
+import ActivitiesTableToolbar from "./ActivitiesTableToolbar";
+
+interface ActivitiesTableViewProps {
+  onActivityClick: (id: string) => void;
+  onNewActivity: () => void;
+}
+
+const NARROW_WIDTH_HINT_THRESHOLD = 200;
+
+// Render a typed value into a table cell. Text-fragment fall-throughs are
+// fine for now — when 3.3 lands, the editable columns swap their cell out
+// for an EditableXCell that handles its own click + popover.
+function renderCell(key: string, row: ActivityListItem) {
+  switch (key) {
+    case "date":
+      return row.startDate
+        ? new Date(row.startDate).toLocaleDateString(undefined, {
+            month: "short",
+            day: "numeric",
+            year: "numeric",
+          })
+        : <span className="text-[#A69DC0]">Unscheduled</span>;
+    case "type": {
+      const label = ACTIVITY_TYPE_LABELS[row.type as ActivityType] ?? row.type;
+      return <span className="text-[#544A78] uppercase tracking-wide text-[10px] font-semibold">{label}</span>;
+    }
+    case "title":
+      return <span className="font-medium text-[#403770]">{row.title}</span>;
+    case "district":
+      return row.districtName ?? <span className="text-[#A69DC0]">—</span>;
+    case "contact":
+      return row.contactName ?? <span className="text-[#A69DC0]">—</span>;
+    case "owner":
+      return row.ownerFullName ?? <span className="text-[#A69DC0]">—</span>;
+    case "status": {
+      const cfg = ACTIVITY_STATUS_CONFIG[row.status as ActivityStatus];
+      if (!cfg) return row.status;
+      return (
+        <span
+          className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold"
+          style={{ backgroundColor: cfg.bgColor, color: cfg.color }}
+        >
+          <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: cfg.color }} aria-hidden />
+          {cfg.label}
+        </span>
+      );
+    }
+    case "outcome":
+      return row.outcomePreview ? (
+        <span className="text-[#6E6390] truncate block">{row.outcomePreview}</span>
+      ) : (
+        <span className="text-[#A69DC0]">—</span>
+      );
+    case "states":
+      return (row.stateAbbrevs ?? []).join(", ") || <span className="text-[#A69DC0]">—</span>;
+    case "createdAt":
+      return <span className="text-[#A69DC0]">—</span>;
+    case "inPerson":
+      return <span className="text-[#A69DC0]">—</span>;
+    default:
+      return <span className="text-[#A69DC0]">—</span>;
+  }
+}
+
+// The Table view body. Owns local row-selection state; reads everything else
+// (filters, sort, pagination, visible columns) from useActivitiesChrome so
+// switching between calendar views preserves what the user picked.
+export default function ActivitiesTableView({
+  onActivityClick,
+  onNewActivity,
+}: ActivitiesTableViewProps) {
+  const filters = useActivitiesChrome((s) => s.filters);
+  const sorts = useActivitiesChrome((s) => s.tableSorts);
+  const visibleColumns = useActivitiesChrome((s) => s.tableVisibleColumns);
+  const page = useActivitiesChrome((s) => s.tablePage);
+  const pageSize = useActivitiesChrome((s) => s.tablePageSize);
+  const setTablePage = useActivitiesChrome((s) => s.setTablePage);
+
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  const params = useMemo(
+    () =>
+      deriveActivitiesParams({
+        filters,
+        anchorIso: new Date().toISOString(),
+        grain: "week",
+        view: "table",
+        page,
+        pageSize,
+        sorts,
+      }),
+    [filters, page, pageSize, sorts]
+  );
+
+  const { data, isLoading, isError, refetch } = useActivities(params);
+  const rows: ActivityListItem[] = data?.activities ?? [];
+  const total = data?.totalInDb ?? rows.length;
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+
+  const selectedRows = useMemo(
+    () => rows.filter((r) => selectedIds.has(r.id)),
+    [rows, selectedIds]
+  );
+
+  const visibleColumnDefs = visibleColumns
+    .map(getColumnDef)
+    .filter((c): c is NonNullable<typeof c> => Boolean(c));
+
+  const allOnPageSelected =
+    rows.length > 0 && rows.every((r) => selectedIds.has(r.id));
+
+  function togglePageSelection() {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (allOnPageSelected) {
+        rows.forEach((r) => next.delete(r.id));
+      } else {
+        rows.forEach((r) => next.add(r.id));
+      }
+      return next;
+    });
+  }
+
+  function toggleRow(id: string) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  return (
+    <div className="flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden">
+      <ActivitiesTableToolbar selectedRows={selectedRows} filteredRows={rows} />
+
+      {total >= NARROW_WIDTH_HINT_THRESHOLD && (
+        <div className="flex items-center gap-2 px-6 py-1.5 text-[11px] font-medium text-[#866720] bg-[#fffaf1] border-b border-[#ffd98d]">
+          <AlertTriangle className="w-3 h-3" aria-hidden />
+          200+ matching — narrow your filters for faster scrolling.
+        </div>
+      )}
+
+      <div className="flex-1 overflow-auto bg-white">
+        <table className="w-full text-xs">
+          <thead className="sticky top-0 z-10 bg-[#F7F5FA] border-b border-[#E2DEEC]">
+            <tr>
+              <th className="w-8 px-3 py-2 text-left">
+                <input
+                  type="checkbox"
+                  aria-label="Select page"
+                  checked={allOnPageSelected}
+                  onChange={togglePageSelection}
+                  className="cursor-pointer accent-[#403770]"
+                />
+              </th>
+              {visibleColumnDefs.map((col) => (
+                <th
+                  key={col.key}
+                  className="px-3 py-2 text-left text-[10px] font-extrabold uppercase tracking-[0.08em] text-[#544A78] whitespace-nowrap"
+                  style={col.width ? { minWidth: col.width } : undefined}
+                >
+                  {col.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-[#EFEDF5]">
+            {isLoading && rows.length === 0
+              ? Array.from({ length: 8 }).map((_, i) => (
+                  <tr key={`skel-${i}`} className="animate-pulse">
+                    <td className="px-3 py-3"><span className="block w-4 h-4 bg-[#EFEDF5] rounded" /></td>
+                    {visibleColumnDefs.map((col) => (
+                      <td key={col.key} className="px-3 py-3">
+                        <span className="block h-3 bg-[#EFEDF5] rounded" />
+                      </td>
+                    ))}
+                  </tr>
+                ))
+              : rows.map((row) => {
+                  const selected = selectedIds.has(row.id);
+                  return (
+                    <tr
+                      key={row.id}
+                      onClick={() => onActivityClick(row.id)}
+                      className={cn(
+                        "cursor-pointer transition-colors",
+                        selected ? "bg-[#EFEDF5]" : "hover:bg-[#F7F5FA]"
+                      )}
+                    >
+                      <td className="w-8 px-3 py-2.5" onClick={(e) => e.stopPropagation()}>
+                        <input
+                          type="checkbox"
+                          aria-label={`Select ${row.title}`}
+                          checked={selected}
+                          onChange={() => toggleRow(row.id)}
+                          className="cursor-pointer accent-[#403770]"
+                        />
+                      </td>
+                      {visibleColumnDefs.map((col) => (
+                        <td
+                          key={col.key}
+                          className="px-3 py-2.5 text-xs text-[#403770] whitespace-nowrap"
+                          style={col.width ? { maxWidth: col.width } : undefined}
+                        >
+                          {renderCell(col.key, row)}
+                        </td>
+                      ))}
+                    </tr>
+                  );
+                })}
+          </tbody>
+        </table>
+
+        {!isLoading && !isError && rows.length === 0 && (
+          <EmptyState
+            hasFilters={
+              filters.text.trim().length > 0 ||
+              filters.types.length > 0 ||
+              filters.statuses.length > 0 ||
+              filters.districts.length > 0 ||
+              filters.contactIds.length > 0 ||
+              Boolean(filters.dateFrom) ||
+              Boolean(filters.dateTo)
+            }
+            onNewActivity={onNewActivity}
+          />
+        )}
+
+        {isError && (
+          <div className="flex flex-col items-center justify-center py-16 px-6 text-center">
+            <AlertTriangle className="w-6 h-6 text-[#F37167] mb-2" aria-hidden />
+            <p className="text-sm text-[#544A78] mb-3">Couldn&apos;t load activities.</p>
+            <button
+              type="button"
+              onClick={() => refetch()}
+              className="px-3 py-1.5 text-xs font-medium text-white bg-[#403770] rounded-lg hover:bg-[#322a5a]"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+      </div>
+
+      <Pagination
+        page={page}
+        pageSize={pageSize}
+        total={total}
+        totalPages={totalPages}
+        rowCount={rows.length}
+        onPageChange={setTablePage}
+      />
+    </div>
+  );
+}
+
+function EmptyState({
+  hasFilters,
+  onNewActivity,
+}: {
+  hasFilters: boolean;
+  onNewActivity: () => void;
+}) {
+  if (hasFilters) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 px-6 text-center">
+        <Inbox className="w-6 h-6 text-[#A69DC0] mb-2" aria-hidden />
+        <p className="text-sm text-[#544A78] mb-1">No matches for these filters.</p>
+        <p className="text-xs text-[#8A80A8]">Clear filters from the toolbar to see everything.</p>
+      </div>
+    );
+  }
+  return (
+    <div className="flex flex-col items-center justify-center py-16 px-6 text-center">
+      <Inbox className="w-6 h-6 text-[#A69DC0] mb-2" aria-hidden />
+      <p className="text-sm text-[#544A78] mb-3">No activities yet — log your first one.</p>
+      <button
+        type="button"
+        onClick={onNewActivity}
+        className="px-3 py-1.5 text-xs font-medium text-white bg-[#403770] rounded-lg hover:bg-[#322a5a]"
+      >
+        New activity
+      </button>
+    </div>
+  );
+}
+
+function Pagination({
+  page,
+  pageSize,
+  total,
+  totalPages,
+  rowCount,
+  onPageChange,
+}: {
+  page: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+  rowCount: number;
+  onPageChange: (next: number) => void;
+}) {
+  const start = total === 0 ? 0 : page * pageSize + 1;
+  const end = page * pageSize + rowCount;
+  return (
+    <div className="flex items-center justify-between px-6 py-2 bg-[#F7F5FA] border-t border-[#E2DEEC] text-[11px] text-[#544A78]">
+      <span>
+        {total === 0 ? "No results" : `${start}–${end} of ${total}`}
+      </span>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => onPageChange(Math.max(0, page - 1))}
+          disabled={page === 0}
+          className="inline-flex items-center justify-center w-7 h-7 rounded-md border border-[#D4CFE2] text-[#544A78] bg-white hover:bg-[#EFEDF5] disabled:opacity-40 disabled:cursor-not-allowed"
+          aria-label="Previous page"
+        >
+          <ChevronLeft className="w-3.5 h-3.5" />
+        </button>
+        <span className="text-[11px] font-semibold text-[#544A78]">
+          Page {page + 1} of {totalPages}
+        </span>
+        <button
+          type="button"
+          onClick={() => onPageChange(Math.min(totalPages - 1, page + 1))}
+          disabled={page >= totalPages - 1}
+          className="inline-flex items-center justify-center w-7 h-7 rounded-md border border-[#D4CFE2] text-[#544A78] bg-white hover:bg-[#EFEDF5] disabled:opacity-40 disabled:cursor-not-allowed"
+          aria-label="Next page"
+        >
+          <ChevronRight className="w-3.5 h-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// Re-export the types so consumers can grab them from one place.
+export { ACTIVITIES_TABLE_COLUMNS };

--- a/src/features/activities/components/page/table/ActivitiesTableView.tsx
+++ b/src/features/activities/components/page/table/ActivitiesTableView.tsx
@@ -7,17 +7,17 @@ import {
   useActivitiesChrome,
   deriveActivitiesParams,
 } from "@/features/activities/lib/filters-store";
-import {
-  ACTIVITY_TYPE_LABELS,
-  ACTIVITY_STATUS_CONFIG,
-  type ActivityType,
-  type ActivityStatus,
-} from "@/features/activities/types";
+import type { ActivityType, ActivityStatus } from "@/features/activities/types";
 import type { ActivityListItem } from "@/features/shared/types/api-types";
 import { cn } from "@/features/shared/lib/cn";
 import { ACTIVITIES_TABLE_COLUMNS, getColumnDef } from "./columns";
 import ActivitiesTableToolbar from "./ActivitiesTableToolbar";
 import ActivitiesTableHeader from "./ActivitiesTableHeader";
+import BulkActionBar from "./BulkActionBar";
+import EditableDateCell from "./cells/EditableDateCell";
+import EditableTypeCell from "./cells/EditableTypeCell";
+import EditableStatusCell from "./cells/EditableStatusCell";
+import EditableOwnerCell from "./cells/EditableOwnerCell";
 
 interface ActivitiesTableViewProps {
   onActivityClick: (id: string) => void;
@@ -26,23 +26,15 @@ interface ActivitiesTableViewProps {
 
 const NARROW_WIDTH_HINT_THRESHOLD = 200;
 
-// Render a typed value into a table cell. Text-fragment fall-throughs are
-// fine for now — when 3.3 lands, the editable columns swap their cell out
-// for an EditableXCell that handles its own click + popover.
+// Map a column key to the right cell renderer. The four editable cells
+// stop their own click events so the row click → drawer fallback only
+// fires on the non-editable columns.
 function renderCell(key: string, row: ActivityListItem) {
   switch (key) {
     case "date":
-      return row.startDate
-        ? new Date(row.startDate).toLocaleDateString(undefined, {
-            month: "short",
-            day: "numeric",
-            year: "numeric",
-          })
-        : <span className="text-[#A69DC0]">Unscheduled</span>;
-    case "type": {
-      const label = ACTIVITY_TYPE_LABELS[row.type as ActivityType] ?? row.type;
-      return <span className="text-[#544A78] uppercase tracking-wide text-[10px] font-semibold">{label}</span>;
-    }
+      return <EditableDateCell activityId={row.id} startDate={row.startDate} />;
+    case "type":
+      return <EditableTypeCell activityId={row.id} type={row.type as ActivityType} />;
     case "title":
       return <span className="font-medium text-[#403770]">{row.title}</span>;
     case "district":
@@ -50,20 +42,15 @@ function renderCell(key: string, row: ActivityListItem) {
     case "contact":
       return row.contactName ?? <span className="text-[#A69DC0]">—</span>;
     case "owner":
-      return row.ownerFullName ?? <span className="text-[#A69DC0]">—</span>;
-    case "status": {
-      const cfg = ACTIVITY_STATUS_CONFIG[row.status as ActivityStatus];
-      if (!cfg) return row.status;
       return (
-        <span
-          className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold"
-          style={{ backgroundColor: cfg.bgColor, color: cfg.color }}
-        >
-          <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: cfg.color }} aria-hidden />
-          {cfg.label}
-        </span>
+        <EditableOwnerCell
+          activityId={row.id}
+          ownerId={row.createdByUserId ?? null}
+          ownerFullName={row.ownerFullName ?? null}
+        />
       );
-    }
+    case "status":
+      return <EditableStatusCell activityId={row.id} status={row.status as ActivityStatus} />;
     case "outcome":
       return row.outcomePreview ? (
         <span className="text-[#6E6390] truncate block">{row.outcomePreview}</span>
@@ -251,6 +238,11 @@ export default function ActivitiesTableView({
         totalPages={totalPages}
         rowCount={rows.length}
         onPageChange={setTablePage}
+      />
+
+      <BulkActionBar
+        selectedRows={selectedRows}
+        onClear={() => setSelectedIds(new Set())}
       />
     </div>
   );

--- a/src/features/activities/components/page/table/ActivitiesTableView.tsx
+++ b/src/features/activities/components/page/table/ActivitiesTableView.tsx
@@ -74,8 +74,12 @@ function renderCell(key: string, row: ActivityListItem) {
     case "states":
       return (row.stateAbbrevs ?? []).join(", ") || <span className="text-[#A69DC0]">—</span>;
     case "createdAt":
-      return <span className="text-[#A69DC0]">—</span>;
+      return row.createdAt
+        ? new Date(row.createdAt).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })
+        : <span className="text-[#A69DC0]">—</span>;
     case "inPerson":
+      if (row.inPerson === true) return <span className="text-[#403770]">In person</span>;
+      if (row.inPerson === false) return <span className="text-[#403770]">Virtual</span>;
       return <span className="text-[#A69DC0]">—</span>;
     default:
       return <span className="text-[#A69DC0]">—</span>;

--- a/src/features/activities/components/page/table/ActivitiesTableView.tsx
+++ b/src/features/activities/components/page/table/ActivitiesTableView.tsx
@@ -17,6 +17,7 @@ import type { ActivityListItem } from "@/features/shared/types/api-types";
 import { cn } from "@/features/shared/lib/cn";
 import { ACTIVITIES_TABLE_COLUMNS, getColumnDef } from "./columns";
 import ActivitiesTableToolbar from "./ActivitiesTableToolbar";
+import ActivitiesTableHeader from "./ActivitiesTableHeader";
 
 interface ActivitiesTableViewProps {
   onActivityClick: (id: string) => void;
@@ -161,28 +162,11 @@ export default function ActivitiesTableView({
 
       <div className="flex-1 overflow-auto bg-white">
         <table className="w-full text-xs">
-          <thead className="sticky top-0 z-10 bg-[#F7F5FA] border-b border-[#E2DEEC]">
-            <tr>
-              <th className="w-8 px-3 py-2 text-left">
-                <input
-                  type="checkbox"
-                  aria-label="Select page"
-                  checked={allOnPageSelected}
-                  onChange={togglePageSelection}
-                  className="cursor-pointer accent-[#403770]"
-                />
-              </th>
-              {visibleColumnDefs.map((col) => (
-                <th
-                  key={col.key}
-                  className="px-3 py-2 text-left text-[10px] font-extrabold uppercase tracking-[0.08em] text-[#544A78] whitespace-nowrap"
-                  style={col.width ? { minWidth: col.width } : undefined}
-                >
-                  {col.label}
-                </th>
-              ))}
-            </tr>
-          </thead>
+          <ActivitiesTableHeader
+            visibleColumnDefs={visibleColumnDefs}
+            selectAllChecked={allOnPageSelected}
+            onTogglePageSelection={togglePageSelection}
+          />
           <tbody className="divide-y divide-[#EFEDF5]">
             {isLoading && rows.length === 0
               ? Array.from({ length: 8 }).map((_, i) => (

--- a/src/features/activities/components/page/table/ActivitiesTableView.tsx
+++ b/src/features/activities/components/page/table/ActivitiesTableView.tsx
@@ -26,6 +26,20 @@ interface ActivitiesTableViewProps {
 
 const NARROW_WIDTH_HINT_THRESHOLD = 200;
 
+// String fallback for the cell's `title` tooltip. Used so truncated cells
+// reveal their full content on hover. Editable cells return `undefined` —
+// they handle their own truncation via the picker dropdown anyway.
+function renderCellAsTitle(key: string, row: ActivityListItem): string | undefined {
+  switch (key) {
+    case "title": return row.title;
+    case "district": return row.districtName ?? undefined;
+    case "contact": return row.contactName ?? undefined;
+    case "outcome": return row.outcomePreview ?? undefined;
+    case "states": return row.stateAbbrevs?.join(", ");
+    default: return undefined;
+  }
+}
+
 // Map a column key to the right cell renderer. The four editable cells
 // stop their own click events so the row click → drawer fallback only
 // fires on the non-editable columns.
@@ -148,7 +162,13 @@ export default function ActivitiesTableView({
       )}
 
       <div className="flex-1 overflow-auto bg-white">
-        <table className="w-full text-xs">
+        <table className="w-full text-xs table-fixed">
+          <colgroup>
+            <col style={{ width: 32 }} />
+            {visibleColumnDefs.map((col) => (
+              <col key={col.key} style={col.width ? { width: col.width } : undefined} />
+            ))}
+          </colgroup>
           <ActivitiesTableHeader
             visibleColumnDefs={visibleColumnDefs}
             selectAllChecked={allOnPageSelected}
@@ -189,10 +209,11 @@ export default function ActivitiesTableView({
                       {visibleColumnDefs.map((col) => (
                         <td
                           key={col.key}
-                          className="px-3 py-2.5 text-xs text-[#403770] whitespace-nowrap"
-                          style={col.width ? { maxWidth: col.width } : undefined}
+                          className="px-3 py-2.5 text-xs text-[#403770] overflow-hidden"
                         >
-                          {renderCell(col.key, row)}
+                          <div className="truncate" title={typeof renderCellAsTitle(col.key, row) === "string" ? renderCellAsTitle(col.key, row) : undefined}>
+                            {renderCell(col.key, row)}
+                          </div>
                         </td>
                       ))}
                     </tr>

--- a/src/features/activities/components/page/table/ActivitiesTableView.tsx
+++ b/src/features/activities/components/page/table/ActivitiesTableView.tsx
@@ -116,7 +116,7 @@ export default function ActivitiesTableView({
     [filters, page, pageSize, sorts]
   );
 
-  const { data, isLoading, isError, refetch } = useActivities(params);
+  const { data, isLoading, isFetching, isError, refetch } = useActivities(params);
   const rows: ActivityListItem[] = data?.activities ?? [];
   const total = data?.totalInDb ?? rows.length;
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
@@ -165,7 +165,7 @@ export default function ActivitiesTableView({
         </div>
       )}
 
-      <div className="flex-1 overflow-auto bg-white">
+      <div className={cn("flex-1 overflow-auto bg-white relative transition-opacity", isFetching && !isLoading && "opacity-70")}>
         <table className="w-full text-xs table-fixed">
           <colgroup>
             <col style={{ width: 32 }} />

--- a/src/features/activities/components/page/table/BulkActionBar.tsx
+++ b/src/features/activities/components/page/table/BulkActionBar.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useMemo, useState, useRef, useEffect } from "react";
+import { Download, ChevronDown, X } from "lucide-react";
+import { useBulkUpdateActivities } from "@/features/activities/lib/queries";
+import { useUsers, useProfile } from "@/features/shared/lib/queries";
+import {
+  ACTIVITY_STATUS_CONFIG,
+  VALID_ACTIVITY_STATUSES,
+  type ActivityStatus,
+} from "@/features/activities/types";
+import type { ActivityListItem } from "@/features/shared/types/api-types";
+import { rowsToCsv, downloadCsv } from "@/features/reports/lib/csv";
+import { cn } from "@/features/shared/lib/cn";
+
+interface BulkActionBarProps {
+  selectedRows: ActivityListItem[];
+  onClear: () => void;
+}
+
+// Sticky bottom action bar visible whenever ≥1 row is selected. Reassign
+// owner, change status, export selected, clear. Mutations go through
+// useBulkUpdateActivities — optimistic + per-row results; we surface the
+// failed-row count via a small inline toast above the bar.
+export default function BulkActionBar({ selectedRows, onClear }: BulkActionBarProps) {
+  const ids = useMemo(() => selectedRows.map((r) => r.id), [selectedRows]);
+  const bulk = useBulkUpdateActivities();
+  const [toast, setToast] = useState<string | null>(null);
+
+  if (ids.length === 0) return null;
+
+  function applyResult(succeeded: string[], failed: { id: string; reason: string }[]) {
+    if (failed.length === 0) {
+      setToast(`Updated ${succeeded.length} ${succeeded.length === 1 ? "activity" : "activities"}.`);
+    } else {
+      setToast(`${succeeded.length} updated, ${failed.length} skipped.`);
+    }
+    setTimeout(() => setToast(null), 4000);
+  }
+
+  function handleStatusChange(status: ActivityStatus) {
+    bulk.mutate(
+      { ids, updates: { status } },
+      {
+        onSuccess: (res) => {
+          applyResult(res.succeeded, res.failed);
+          if (res.succeeded.length === ids.length) onClear();
+        },
+        onError: () => setToast("Couldn't update — try again."),
+      }
+    );
+  }
+
+  function handleOwnerChange(ownerId: string) {
+    bulk.mutate(
+      { ids, updates: { ownerId } },
+      {
+        onSuccess: (res) => {
+          applyResult(res.succeeded, res.failed);
+          if (res.succeeded.length === ids.length) onClear();
+        },
+        onError: () => setToast("Couldn't update — try again."),
+      }
+    );
+  }
+
+  function handleExport() {
+    if (selectedRows.length === 0) return;
+    const csv = rowsToCsv(
+      ["Date", "Type", "Title", "District", "Contact", "Owner", "Status", "Outcome notes"],
+      selectedRows.map((r) => ({
+        Date: r.startDate ?? "",
+        Type: r.type,
+        Title: r.title,
+        District: r.districtName ?? "",
+        Contact: r.contactName ?? "",
+        Owner: r.ownerFullName ?? "",
+        Status: r.status,
+        "Outcome notes": r.outcomePreview ?? "",
+      }))
+    );
+    downloadCsv(`activities-${new Date().toISOString().slice(0, 10)}.csv`, csv);
+  }
+
+  return (
+    <div className="sticky bottom-0 left-0 right-0 z-20">
+      {toast && (
+        <div className="px-6 py-1.5 text-[11px] text-[#403770] bg-[#EFEDF5] border-t border-[#D4CFE2] text-center">
+          {toast}
+        </div>
+      )}
+      <div className="flex items-center gap-2 px-6 py-2 bg-[#403770] text-white shadow-[0_-2px_12px_rgba(64,55,112,0.2)]">
+        <span className="text-xs font-semibold">
+          {ids.length} selected
+        </span>
+        <span aria-hidden className="w-px h-4 bg-white/30" />
+        <OwnerPicker disabled={bulk.isPending} onPick={handleOwnerChange} />
+        <StatusPicker disabled={bulk.isPending} onPick={handleStatusChange} />
+        <button
+          type="button"
+          onClick={handleExport}
+          disabled={bulk.isPending}
+          className="inline-flex items-center gap-1 h-7 px-2.5 text-xs font-medium text-white border border-white/30 rounded-lg hover:bg-white/10 disabled:opacity-50"
+        >
+          <Download className="w-3 h-3" />
+          Export CSV
+        </button>
+        <button
+          type="button"
+          onClick={onClear}
+          className="ml-auto inline-flex items-center gap-1 h-7 px-2 text-[11px] font-bold uppercase tracking-[0.06em] text-white/70 hover:text-white"
+        >
+          <X className="w-3 h-3" />
+          Clear
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function OwnerPicker({ disabled, onPick }: { disabled: boolean; onPick: (ownerId: string) => void }) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const { data: users } = useUsers();
+  const { data: profile } = useProfile();
+
+  useEffect(() => {
+    if (!open) return;
+    function onDoc(e: MouseEvent) {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false);
+    }
+    function onKey(e: KeyboardEvent) { if (e.key === "Escape") setOpen(false); }
+    document.addEventListener("mousedown", onDoc);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDoc);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const sorted = useMemo(() => {
+    const list = users ?? [];
+    return [...list].sort((a, b) => {
+      if (profile?.id === a.id) return -1;
+      if (profile?.id === b.id) return 1;
+      return (a.fullName ?? a.email).localeCompare(b.fullName ?? b.email);
+    });
+  }, [users, profile?.id]);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => setOpen((v) => !v)}
+        className="inline-flex items-center gap-1 h-7 px-2.5 text-xs font-medium text-white border border-white/30 rounded-lg hover:bg-white/10 disabled:opacity-50"
+      >
+        Reassign owner
+        <ChevronDown className="w-3 h-3" />
+      </button>
+      {open && (
+        <div className="absolute left-0 bottom-full mb-1 z-30 w-56 max-h-64 overflow-y-auto bg-white border border-[#D4CFE2] rounded-xl shadow-lg p-1">
+          {sorted.map((u) => (
+            <button
+              key={u.id}
+              type="button"
+              onClick={() => { onPick(u.id); setOpen(false); }}
+              className={cn(
+                "w-full px-2 py-1.5 text-xs text-left rounded-md transition-colors text-[#403770] hover:bg-[#F7F5FA]"
+              )}
+            >
+              {profile?.id === u.id ? "Me" : u.fullName ?? u.email}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StatusPicker({ disabled, onPick }: { disabled: boolean; onPick: (status: ActivityStatus) => void }) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onDoc(e: MouseEvent) {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false);
+    }
+    function onKey(e: KeyboardEvent) { if (e.key === "Escape") setOpen(false); }
+    document.addEventListener("mousedown", onDoc);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDoc);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => setOpen((v) => !v)}
+        className="inline-flex items-center gap-1 h-7 px-2.5 text-xs font-medium text-white border border-white/30 rounded-lg hover:bg-white/10 disabled:opacity-50"
+      >
+        Change status
+        <ChevronDown className="w-3 h-3" />
+      </button>
+      {open && (
+        <div className="absolute left-0 bottom-full mb-1 z-30 w-44 bg-white border border-[#D4CFE2] rounded-xl shadow-lg p-1">
+          {VALID_ACTIVITY_STATUSES.map((s) => {
+            const c = ACTIVITY_STATUS_CONFIG[s];
+            return (
+              <button
+                key={s}
+                type="button"
+                onClick={() => { onPick(s); setOpen(false); }}
+                className="w-full flex items-center gap-2 px-2 py-1.5 text-xs text-left rounded-md text-[#403770] hover:bg-[#F7F5FA]"
+              >
+                <span className="w-2 h-2 rounded-full" style={{ backgroundColor: c.color }} aria-hidden />
+                {c.label}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/activities/components/page/table/ColumnFilterPopover.tsx
+++ b/src/features/activities/components/page/table/ColumnFilterPopover.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useActivitiesChrome } from "@/features/activities/lib/filters-store";
+import DateRangeFilter from "./filters/DateRangeFilter";
+import TypeFilter from "./filters/TypeFilter";
+import OwnerFilter from "./filters/OwnerFilter";
+import StatusFilter from "./filters/StatusFilter";
+import DistrictFilter from "./filters/DistrictFilter";
+import ContactFilter from "./filters/ContactFilter";
+import TextFilter from "./filters/TextFilter";
+
+interface ColumnFilterPopoverProps {
+  columnKey: string;
+  onClose: () => void;
+}
+
+// Generic filter dispatcher. Anchored relative to its trigger by the parent
+// header cell (which sets `relative` on its container). Click-outside +
+// Escape close. Each body owns its own Apply/Clear/Done — the popover just
+// wraps and positions.
+export default function ColumnFilterPopover({ columnKey, onClose }: ColumnFilterPopoverProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const filters = useActivitiesChrome((s) => s.filters);
+  const patchFilters = useActivitiesChrome((s) => s.patchFilters);
+
+  useEffect(() => {
+    function onDoc(e: MouseEvent) {
+      if (!ref.current?.contains(e.target as Node)) onClose();
+    }
+    function onKey(e: KeyboardEvent) { if (e.key === "Escape") onClose(); }
+    // Defer attaching the listener so the click that opened the popover
+    // doesn't immediately close it.
+    const t = setTimeout(() => {
+      document.addEventListener("mousedown", onDoc);
+      document.addEventListener("keydown", onKey);
+    }, 0);
+    return () => {
+      clearTimeout(t);
+      document.removeEventListener("mousedown", onDoc);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [onClose]);
+
+  function body() {
+    switch (columnKey) {
+      case "date":
+      case "createdAt":
+        return <DateRangeFilter onClose={onClose} />;
+      case "type":
+        return <TypeFilter onClose={onClose} />;
+      case "owner":
+        return <OwnerFilter onClose={onClose} />;
+      case "status":
+        return <StatusFilter onClose={onClose} />;
+      case "district":
+        return <DistrictFilter onClose={onClose} />;
+      case "contact":
+        return <ContactFilter onClose={onClose} />;
+      case "title":
+      case "outcome":
+        return (
+          <TextFilter
+            value={columnKey === "outcome" ? filters.text : filters.text}
+            placeholder={
+              columnKey === "outcome"
+                ? "Search notes & outcome…"
+                : "Search title…"
+            }
+            onChange={(next) => patchFilters({ text: next })}
+            onClose={onClose}
+          />
+        );
+      default:
+        return null;
+    }
+  }
+
+  return (
+    <div
+      ref={ref}
+      role="dialog"
+      className="absolute left-0 top-full mt-1 z-30 bg-white border border-[#D4CFE2] rounded-xl shadow-lg overflow-hidden"
+    >
+      {body()}
+    </div>
+  );
+}

--- a/src/features/activities/components/page/table/ColumnsPicker.tsx
+++ b/src/features/activities/components/page/table/ColumnsPicker.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { Columns3, Square, SquareCheck } from "lucide-react";
+import { ACTIVITIES_TABLE_COLUMNS, DEFAULT_COLUMN_KEYS } from "./columns";
+import { cn } from "@/features/shared/lib/cn";
+
+interface ColumnsPickerProps {
+  visibleColumns: string[];
+  onChange: (next: string[]) => void;
+}
+
+// Compact dropdown for toggling which Table columns are visible. Groups by
+// `group` field on each ColumnDef, with "Reset" restoring the default set.
+export default function ColumnsPicker({ visibleColumns, onChange }: ColumnsPickerProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onDoc(e: MouseEvent) {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false);
+    }
+    function onKey(e: KeyboardEvent) { if (e.key === "Escape") setOpen(false); }
+    document.addEventListener("mousedown", onDoc);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDoc);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const groups = ACTIVITIES_TABLE_COLUMNS.reduce<Record<string, typeof ACTIVITIES_TABLE_COLUMNS>>(
+    (acc, col) => {
+      (acc[col.group] ??= []).push(col);
+      return acc;
+    },
+    {}
+  );
+
+  function toggle(key: string) {
+    if (visibleColumns.includes(key)) {
+      // Don't allow removing the last column.
+      if (visibleColumns.length === 1) return;
+      onChange(visibleColumns.filter((k) => k !== key));
+    } else {
+      onChange([...visibleColumns, key]);
+    }
+  }
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="inline-flex items-center gap-1.5 h-8 px-2.5 text-xs font-medium text-[#544A78] bg-white border border-[#D4CFE2] rounded-lg hover:bg-[#F7F5FA] [transition-duration:120ms] transition-colors fm-focus-ring"
+      >
+        <Columns3 className="w-3.5 h-3.5" />
+        Columns
+      </button>
+      {open && (
+        <div className="absolute right-0 top-full mt-1 z-30 w-64 bg-white border border-[#D4CFE2] rounded-xl shadow-lg p-2">
+          {Object.entries(groups).map(([groupName, cols]) => (
+            <div key={groupName} className="mb-1.5">
+              <div className="px-2 pt-1 pb-0.5 text-[10px] font-extrabold uppercase tracking-[0.08em] text-[#8A80A8]">
+                {groupName}
+              </div>
+              {cols.map((col) => {
+                const active = visibleColumns.includes(col.key);
+                const Checkbox = active ? SquareCheck : Square;
+                return (
+                  <button
+                    key={col.key}
+                    type="button"
+                    onClick={() => toggle(col.key)}
+                    aria-pressed={active}
+                    className={cn(
+                      "w-full flex items-center gap-2 px-2 py-1.5 text-xs text-left rounded-md transition-colors",
+                      active ? "bg-[#F7F5FA] text-[#403770]" : "text-[#403770] hover:bg-[#F7F5FA]"
+                    )}
+                  >
+                    <Checkbox className={cn("w-3.5 h-3.5 flex-shrink-0", active ? "text-[#403770]" : "text-[#A69DC0]")} />
+                    {col.label}
+                  </button>
+                );
+              })}
+            </div>
+          ))}
+          <div className="flex items-center justify-between px-2 pt-2 mt-1 border-t border-[#EFEDF5]">
+            <button
+              type="button"
+              onClick={() => onChange([...DEFAULT_COLUMN_KEYS])}
+              className="text-[10px] font-bold uppercase tracking-[0.06em] text-[#544A78] hover:text-[#403770]"
+            >
+              Reset to default
+            </button>
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              className="text-[10px] font-bold uppercase tracking-[0.06em] text-[#8A80A8] hover:text-[#403770]"
+            >
+              Done
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/activities/components/page/table/ExportMenu.tsx
+++ b/src/features/activities/components/page/table/ExportMenu.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { Download, ChevronDown } from "lucide-react";
+import { rowsToCsv, downloadCsv } from "@/features/reports/lib/csv";
+import type { ActivityListItem } from "@/features/shared/types/api-types";
+import { ACTIVITY_TYPE_LABELS, ACTIVITY_STATUS_CONFIG, type ActivityStatus, type ActivityType } from "@/features/activities/types";
+import { cn } from "@/features/shared/lib/cn";
+
+interface ExportMenuProps {
+  selectedRows: ActivityListItem[];
+  filteredRows: ActivityListItem[];
+}
+
+const EXPORT_COLUMNS = [
+  "Date",
+  "Type",
+  "Title",
+  "District",
+  "Contact",
+  "Owner",
+  "Status",
+  "Outcome notes",
+];
+
+function rowToExportObject(row: ActivityListItem): Record<string, unknown> {
+  return {
+    Date: row.startDate ?? "",
+    Type: ACTIVITY_TYPE_LABELS[row.type as ActivityType] ?? row.type,
+    Title: row.title,
+    District: row.districtName ?? "",
+    Contact: row.contactName ?? "",
+    Owner: row.ownerFullName ?? "",
+    Status: ACTIVITY_STATUS_CONFIG[row.status as ActivityStatus]?.label ?? row.status,
+    "Outcome notes": row.outcomePreview ?? "",
+  };
+}
+
+export default function ExportMenu({ selectedRows, filteredRows }: ExportMenuProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onDoc(e: MouseEvent) {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false);
+    }
+    function onKey(e: KeyboardEvent) { if (e.key === "Escape") setOpen(false); }
+    document.addEventListener("mousedown", onDoc);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDoc);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  function exportRows(rows: ActivityListItem[]) {
+    if (rows.length === 0) return;
+    const data = rows.map(rowToExportObject);
+    const csv = rowsToCsv(EXPORT_COLUMNS, data);
+    const date = new Date().toISOString().slice(0, 10);
+    downloadCsv(`activities-${date}.csv`, csv);
+    setOpen(false);
+  }
+
+  const selectedCount = selectedRows.length;
+  const filteredCount = filteredRows.length;
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="inline-flex items-center gap-1.5 h-8 px-2.5 text-xs font-medium text-[#544A78] bg-white border border-[#D4CFE2] rounded-lg hover:bg-[#F7F5FA] [transition-duration:120ms] transition-colors fm-focus-ring"
+      >
+        <Download className="w-3.5 h-3.5" />
+        Export
+        <ChevronDown className="w-3 h-3 text-[#8A80A8]" />
+      </button>
+      {open && (
+        <div className="absolute right-0 top-full mt-1 z-30 w-56 bg-white border border-[#D4CFE2] rounded-xl shadow-lg p-1">
+          <button
+            type="button"
+            disabled={selectedCount === 0}
+            onClick={() => exportRows(selectedRows)}
+            className={cn(
+              "w-full text-left px-2.5 py-1.5 text-xs rounded-md",
+              selectedCount === 0
+                ? "text-[#A69DC0] cursor-not-allowed"
+                : "text-[#403770] hover:bg-[#F7F5FA]"
+            )}
+          >
+            Export selected
+            <span className="ml-1 text-[#8A80A8]">({selectedCount})</span>
+          </button>
+          <button
+            type="button"
+            disabled={filteredCount === 0}
+            onClick={() => exportRows(filteredRows)}
+            className={cn(
+              "w-full text-left px-2.5 py-1.5 text-xs rounded-md",
+              filteredCount === 0
+                ? "text-[#A69DC0] cursor-not-allowed"
+                : "text-[#403770] hover:bg-[#F7F5FA]"
+            )}
+          >
+            Export all filtered
+            <span className="ml-1 text-[#8A80A8]">({filteredCount})</span>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/activities/components/page/table/cells/EditableDateCell.tsx
+++ b/src/features/activities/components/page/table/cells/EditableDateCell.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { useUpdateActivity } from "@/features/activities/lib/queries";
+
+interface EditableDateCellProps {
+  activityId: string;
+  startDate: string | null;
+}
+
+// Click-to-edit start date. Renders the localized date inline; clicking
+// opens a single date input. We commit on blur or Enter, so the row's
+// drawer click never fires.
+export default function EditableDateCell({ activityId, startDate }: EditableDateCellProps) {
+  const [editing, setEditing] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const update = useUpdateActivity();
+
+  useEffect(() => {
+    if (!editing) return;
+    function onKey(e: KeyboardEvent) { if (e.key === "Escape") setEditing(false); }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [editing]);
+
+  function commit(value: string) {
+    if (!value) {
+      // Clear date.
+      update.mutate({ activityId, startDate: null });
+    } else {
+      const iso = new Date(`${value}T12:00:00`).toISOString();
+      update.mutate({ activityId, startDate: iso });
+    }
+    setEditing(false);
+  }
+
+  if (editing) {
+    return (
+      <div ref={ref} onClick={(e) => e.stopPropagation()} className="inline-block">
+        <input
+          autoFocus
+          type="date"
+          defaultValue={startDate ? startDate.slice(0, 10) : ""}
+          onBlur={(e) => commit(e.currentTarget.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") commit(e.currentTarget.value);
+          }}
+          className="px-1 py-0.5 text-xs text-[#403770] border border-[#C2BBD4] rounded-md focus:outline-none focus:ring-1 focus:ring-[#F37167]"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={(e) => { e.stopPropagation(); setEditing(true); }}
+      className="text-left px-1.5 py-0.5 rounded text-xs text-[#403770] hover:bg-[#EFEDF5]"
+    >
+      {startDate
+        ? new Date(startDate).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })
+        : <span className="text-[#A69DC0]">Unscheduled</span>}
+    </button>
+  );
+}

--- a/src/features/activities/components/page/table/cells/EditableOwnerCell.tsx
+++ b/src/features/activities/components/page/table/cells/EditableOwnerCell.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useState, useRef, useEffect, useMemo } from "react";
+import { useUpdateActivity } from "@/features/activities/lib/queries";
+import { useUsers, useProfile } from "@/features/shared/lib/queries";
+import { ChevronDown } from "lucide-react";
+import { cn } from "@/features/shared/lib/cn";
+
+interface EditableOwnerCellProps {
+  activityId: string;
+  ownerId: string | null;
+  ownerFullName: string | null;
+}
+
+// Inline owner picker. Reassign is gated server-side (caller must be admin
+// OR the row's current owner). We mirror that here: the cell is read-only
+// for non-owner non-admin viewers. We can't tell if the current user is
+// admin from here without an extra query, so we rely on the server's 403
+// to bounce unauthorized writes — and disable the cell for non-owners as
+// a UX hint. Admin reassignment still works (server allows it; user just
+// sees the read-only cell click open the picker).
+export default function EditableOwnerCell({ activityId, ownerId, ownerFullName }: EditableOwnerCellProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const update = useUpdateActivity();
+  const { data: profile } = useProfile();
+  const { data: users } = useUsers();
+
+  const isOwner = profile?.id != null && profile.id === ownerId;
+  // Treat null owner as "anyone can claim" to match the server's
+  // legacy-row leniency at /api/activities/[id]/route.ts:260.
+  const canEdit = isOwner || ownerId === null;
+
+  useEffect(() => {
+    if (!open) return;
+    function onDoc(e: MouseEvent) {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false);
+    }
+    function onKey(e: KeyboardEvent) { if (e.key === "Escape") setOpen(false); }
+    document.addEventListener("mousedown", onDoc);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDoc);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const sorted = useMemo(() => {
+    const list = users ?? [];
+    return [...list].sort((a, b) => {
+      if (profile?.id === a.id) return -1;
+      if (profile?.id === b.id) return 1;
+      return (a.fullName ?? a.email).localeCompare(b.fullName ?? b.email);
+    });
+  }, [users, profile?.id]);
+
+  const display = ownerFullName ?? <span className="text-[#A69DC0]">—</span>;
+
+  if (!canEdit) {
+    return (
+      <span title="Only owner or admin can reassign" className="text-[#403770]">
+        {display}
+      </span>
+    );
+  }
+
+  return (
+    <div ref={ref} className="relative inline-block" onClick={(e) => e.stopPropagation()}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs text-[#403770] hover:bg-[#EFEDF5]"
+      >
+        {display}
+        <ChevronDown className="w-2.5 h-2.5 opacity-60" />
+      </button>
+      {open && (
+        <div
+          role="dialog"
+          className="absolute left-0 top-full mt-1 z-30 w-56 max-h-72 overflow-y-auto bg-white border border-[#D4CFE2] rounded-xl shadow-lg p-1"
+        >
+          {sorted.map((u) => (
+            <button
+              key={u.id}
+              type="button"
+              onClick={() => {
+                update.mutate({ activityId, createdByUserId: u.id });
+                setOpen(false);
+              }}
+              className={cn(
+                "w-full px-2 py-1.5 text-xs text-left rounded-md transition-colors",
+                u.id === ownerId ? "bg-[#F7F5FA] font-semibold text-[#403770]" : "text-[#403770] hover:bg-[#F7F5FA]"
+              )}
+            >
+              {profile?.id === u.id ? "Me" : u.fullName ?? u.email}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/activities/components/page/table/cells/EditableStatusCell.tsx
+++ b/src/features/activities/components/page/table/cells/EditableStatusCell.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { useUpdateActivity } from "@/features/activities/lib/queries";
+import {
+  ACTIVITY_STATUS_CONFIG,
+  VALID_ACTIVITY_STATUSES,
+  type ActivityStatus,
+} from "@/features/activities/types";
+import { ChevronDown } from "lucide-react";
+import { cn } from "@/features/shared/lib/cn";
+
+interface EditableStatusCellProps {
+  activityId: string;
+  status: ActivityStatus;
+}
+
+// Inline status pill. Click opens a small dropdown of all valid statuses;
+// picking one fires useUpdateActivity (which optimistically patches the
+// cache) and closes.
+export default function EditableStatusCell({ activityId, status }: EditableStatusCellProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const update = useUpdateActivity();
+
+  useEffect(() => {
+    if (!open) return;
+    function onDoc(e: MouseEvent) {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false);
+    }
+    function onKey(e: KeyboardEvent) { if (e.key === "Escape") setOpen(false); }
+    document.addEventListener("mousedown", onDoc);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDoc);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const cfg = ACTIVITY_STATUS_CONFIG[status];
+
+  return (
+    <div ref={ref} className="relative inline-block" onClick={(e) => e.stopPropagation()}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold cursor-pointer hover:ring-1 hover:ring-[#D4CFE2] transition"
+        style={cfg ? { backgroundColor: cfg.bgColor, color: cfg.color } : undefined}
+      >
+        {cfg && (
+          <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: cfg.color }} aria-hidden />
+        )}
+        {cfg?.label ?? status}
+        <ChevronDown className="w-2.5 h-2.5 opacity-60" />
+      </button>
+      {open && (
+        <div
+          role="dialog"
+          className="absolute left-0 top-full mt-1 z-30 w-44 bg-white border border-[#D4CFE2] rounded-xl shadow-lg p-1"
+        >
+          {VALID_ACTIVITY_STATUSES.map((s) => {
+            const c = ACTIVITY_STATUS_CONFIG[s];
+            const active = s === status;
+            return (
+              <button
+                key={s}
+                type="button"
+                onClick={() => {
+                  update.mutate({ activityId, status: s });
+                  setOpen(false);
+                }}
+                className={cn(
+                  "w-full flex items-center gap-2 px-2 py-1.5 text-xs text-left rounded-md transition-colors",
+                  active ? "bg-[#F7F5FA] font-semibold text-[#403770]" : "text-[#403770] hover:bg-[#F7F5FA]"
+                )}
+              >
+                <span className="w-2 h-2 rounded-full" style={{ backgroundColor: c.color }} aria-hidden />
+                {c.label}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/activities/components/page/table/cells/EditableTypeCell.tsx
+++ b/src/features/activities/components/page/table/cells/EditableTypeCell.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { useUpdateActivity } from "@/features/activities/lib/queries";
+import {
+  ACTIVITY_CATEGORIES,
+  ACTIVITY_TYPE_LABELS,
+  CATEGORY_LABELS,
+  type ActivityCategory,
+  type ActivityType,
+} from "@/features/activities/types";
+import { ChevronDown } from "lucide-react";
+import { cn } from "@/features/shared/lib/cn";
+
+interface EditableTypeCellProps {
+  activityId: string;
+  type: ActivityType;
+}
+
+export default function EditableTypeCell({ activityId, type }: EditableTypeCellProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const update = useUpdateActivity();
+
+  useEffect(() => {
+    if (!open) return;
+    function onDoc(e: MouseEvent) {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false);
+    }
+    function onKey(e: KeyboardEvent) { if (e.key === "Escape") setOpen(false); }
+    document.addEventListener("mousedown", onDoc);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDoc);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative inline-block" onClick={(e) => e.stopPropagation()}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wide text-[#544A78] hover:bg-[#EFEDF5]"
+      >
+        {ACTIVITY_TYPE_LABELS[type] ?? type}
+        <ChevronDown className="w-2.5 h-2.5 opacity-60" />
+      </button>
+      {open && (
+        <div
+          role="dialog"
+          className="absolute left-0 top-full mt-1 z-30 w-60 max-h-72 overflow-y-auto bg-white border border-[#D4CFE2] rounded-xl shadow-lg p-1"
+        >
+          {(Object.keys(ACTIVITY_CATEGORIES) as ActivityCategory[]).map((c) => {
+            const childTypes = ACTIVITY_CATEGORIES[c] as readonly ActivityType[];
+            return (
+              <div key={c} className="mb-0.5">
+                <div className="px-2 pt-1 pb-0.5 text-[10px] font-extrabold uppercase tracking-[0.08em] text-[#8A80A8]">
+                  {CATEGORY_LABELS[c]}
+                </div>
+                {childTypes.map((t) => (
+                  <button
+                    key={t}
+                    type="button"
+                    onClick={() => {
+                      update.mutate({ activityId, type: t });
+                      setOpen(false);
+                    }}
+                    className={cn(
+                      "w-full px-2 py-1.5 text-xs text-left rounded-md transition-colors",
+                      t === type ? "bg-[#F7F5FA] font-semibold text-[#403770]" : "text-[#403770] hover:bg-[#F7F5FA]"
+                    )}
+                  >
+                    {ACTIVITY_TYPE_LABELS[t]}
+                  </button>
+                ))}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/activities/components/page/table/columns.ts
+++ b/src/features/activities/components/page/table/columns.ts
@@ -1,0 +1,27 @@
+import type { ColumnDef } from "@/features/shared/components/DataGrid";
+
+// Column metadata for the Activities Table view. The `key` corresponds
+// to a field on `ActivityListItem` (or a derived label, e.g. "owner"
+// reads `ownerFullName`). `isDefault: true` marks the Wide-bundle 8 from
+// the spec; the rest are picker-only.
+export const ACTIVITIES_TABLE_COLUMNS: ColumnDef[] = [
+  { key: "date",     label: "Date",     group: "Core",    isDefault: true,  filterType: "date",     width: 140 },
+  { key: "type",     label: "Type",     group: "Core",    isDefault: true,  filterType: "enum",     width: 160 },
+  { key: "title",    label: "Title",    group: "Core",    isDefault: true,  filterType: "text",     width: 260 },
+  { key: "district", label: "District", group: "Linked",  isDefault: true,  filterType: "relation", width: 200 },
+  { key: "contact",  label: "Contact",  group: "Linked",  isDefault: true,  filterType: "relation", width: 180, sortable: false },
+  { key: "owner",    label: "Owner",    group: "Core",    isDefault: true,  filterType: "relation", width: 140 },
+  { key: "status",   label: "Status",   group: "Core",    isDefault: true,  filterType: "enum",     width: 130 },
+  { key: "outcome",  label: "Outcome notes", group: "Core", isDefault: true, filterType: "text",   width: 320, sortable: false },
+  // Picker-only — hidden by default.
+  { key: "inPerson",   label: "In person",   group: "Other",  isDefault: false, filterType: "boolean" },
+  { key: "states",     label: "States",      group: "Other",  isDefault: false, filterType: "tags",     sortable: false },
+  { key: "createdAt",  label: "Created at",  group: "Audit",  isDefault: false, filterType: "date" },
+];
+
+export const COLUMN_KEYS = ACTIVITIES_TABLE_COLUMNS.map((c) => c.key);
+export const DEFAULT_COLUMN_KEYS = ACTIVITIES_TABLE_COLUMNS.filter((c) => c.isDefault).map((c) => c.key);
+
+export function getColumnDef(key: string): ColumnDef | undefined {
+  return ACTIVITIES_TABLE_COLUMNS.find((c) => c.key === key);
+}

--- a/src/features/activities/components/page/table/filters/ContactFilter.tsx
+++ b/src/features/activities/components/page/table/filters/ContactFilter.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Search, Square, SquareCheck } from "lucide-react";
+import { useActivitiesChrome } from "@/features/activities/lib/filters-store";
+import { useSearchContacts } from "@/features/activities/lib/queries";
+import { cn } from "@/features/shared/lib/cn";
+
+export default function ContactFilter({ onClose }: { onClose: () => void }) {
+  const filters = useActivitiesChrome((s) => s.filters);
+  const patchFilters = useActivitiesChrome((s) => s.patchFilters);
+  const [query, setQuery] = useState("");
+  const [debounced, setDebounced] = useState("");
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(query.trim()), 250);
+    return () => clearTimeout(t);
+  }, [query]);
+
+  const { data, isLoading } = useSearchContacts(debounced);
+
+  function toggle(id: number) {
+    const next = filters.contactIds.includes(id)
+      ? filters.contactIds.filter((v) => v !== id)
+      : [...filters.contactIds, id];
+    patchFilters({ contactIds: next });
+  }
+
+  return (
+    <div className="p-1 w-72 max-h-96 overflow-y-auto">
+      <div className="px-1 pt-1 pb-1.5">
+        <div className="relative">
+          <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-[#A69DC0]" />
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search contacts…"
+            className="w-full pl-7 pr-2 py-1.5 text-xs text-[#403770] placeholder:text-[#A69DC0] border border-[#C2BBD4] rounded-md focus:outline-none focus:ring-1 focus:ring-[#F37167]"
+          />
+        </div>
+      </div>
+      {isLoading ? (
+        <div className="px-3 py-2 text-[11px] text-[#A69DC0] italic">Loading…</div>
+      ) : (data?.contacts ?? []).length === 0 ? (
+        <div className="px-3 py-2 text-[11px] text-[#A69DC0] italic">
+          {debounced ? "No contacts match." : "Type to search…"}
+        </div>
+      ) : (
+        (data?.contacts ?? []).map((c) => {
+          const active = filters.contactIds.includes(c.id);
+          const Box = active ? SquareCheck : Square;
+          return (
+            <button
+              key={c.id}
+              type="button"
+              onClick={() => toggle(c.id)}
+              aria-pressed={active}
+              className={cn(
+                "w-full flex items-center gap-2 px-2 py-1.5 text-xs text-left rounded-md transition-colors",
+                active ? "bg-[#F7F5FA] text-[#403770]" : "text-[#403770] hover:bg-[#F7F5FA]"
+              )}
+            >
+              <Box className={cn("w-3.5 h-3.5 flex-shrink-0", active ? "text-[#403770]" : "text-[#A69DC0]")} />
+              <span className="flex-1 truncate">
+                {c.name}
+                {c.title && <span className="text-[10px] text-[#A69DC0] ml-1">{c.title}</span>}
+              </span>
+            </button>
+          );
+        })
+      )}
+      <div className="flex items-center justify-between border-t border-[#EFEDF5] mt-1 pt-1.5 px-1">
+        <button
+          type="button"
+          onClick={() => patchFilters({ contactIds: [] })}
+          className="px-2 py-1 text-[10px] font-bold uppercase tracking-[0.06em] text-[#8A80A8] hover:text-[#F37167]"
+        >
+          Clear
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          className="px-2 py-1 text-[10px] font-bold uppercase tracking-[0.06em] text-[#544A78] hover:text-[#403770]"
+        >
+          Done
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/activities/components/page/table/filters/DateRangeFilter.tsx
+++ b/src/features/activities/components/page/table/filters/DateRangeFilter.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useState } from "react";
+import { useActivitiesChrome } from "@/features/activities/lib/filters-store";
+import { cn } from "@/features/shared/lib/cn";
+
+const PRESETS = [
+  { id: "anytime", label: "Anytime" },
+  { id: "today", label: "Today" },
+  { id: "this-week", label: "This week" },
+  { id: "last-7", label: "Last 7 days" },
+  { id: "last-30", label: "Last 30 days" },
+  { id: "last-90", label: "Last 90 days" },
+] as const;
+
+type PresetId = typeof PRESETS[number]["id"];
+
+function presetRange(id: PresetId): { from: string | null; to: string | null } {
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  switch (id) {
+    case "anytime":
+      return { from: null, to: null };
+    case "today":
+      return { from: today.toISOString(), to: today.toISOString() };
+    case "this-week": {
+      const start = new Date(today);
+      start.setDate(start.getDate() - start.getDay());
+      const end = new Date(start);
+      end.setDate(end.getDate() + 6);
+      return { from: start.toISOString(), to: end.toISOString() };
+    }
+    case "last-7":
+    case "last-30":
+    case "last-90": {
+      const days = id === "last-7" ? 7 : id === "last-30" ? 30 : 90;
+      const start = new Date(today);
+      start.setDate(start.getDate() - days);
+      return { from: start.toISOString(), to: today.toISOString() };
+    }
+  }
+}
+
+export default function DateRangeFilter({ onClose }: { onClose: () => void }) {
+  const filters = useActivitiesChrome((s) => s.filters);
+  const patchFilters = useActivitiesChrome((s) => s.patchFilters);
+
+  const [customFrom, setCustomFrom] = useState(filters.dateFrom?.slice(0, 10) ?? "");
+  const [customTo, setCustomTo] = useState(filters.dateTo?.slice(0, 10) ?? "");
+
+  function applyPreset(id: PresetId) {
+    const { from, to } = presetRange(id);
+    patchFilters({ dateFrom: from, dateTo: to });
+    onClose();
+  }
+
+  function applyCustom() {
+    patchFilters({
+      dateFrom: customFrom ? new Date(customFrom).toISOString() : null,
+      dateTo: customTo ? new Date(customTo).toISOString() : null,
+    });
+    onClose();
+  }
+
+  return (
+    <div className="p-2 w-72">
+      <div className="grid grid-cols-2 gap-1 mb-2">
+        {PRESETS.map((p) => (
+          <button
+            key={p.id}
+            type="button"
+            onClick={() => applyPreset(p.id)}
+            className={cn(
+              "px-2 py-1.5 text-xs rounded-md text-left transition-colors",
+              "text-[#403770] hover:bg-[#F7F5FA]"
+            )}
+          >
+            {p.label}
+          </button>
+        ))}
+      </div>
+      <div className="border-t border-[#EFEDF5] pt-2">
+        <div className="text-[10px] font-extrabold uppercase tracking-[0.08em] text-[#8A80A8] mb-1.5">
+          Custom range
+        </div>
+        <div className="flex items-center gap-1.5">
+          <input
+            type="date"
+            value={customFrom}
+            onChange={(e) => setCustomFrom(e.target.value)}
+            className="flex-1 px-2 py-1 text-xs text-[#403770] border border-[#C2BBD4] rounded-md focus:outline-none focus:ring-1 focus:ring-[#F37167]"
+          />
+          <span className="text-[10px] text-[#8A80A8]">to</span>
+          <input
+            type="date"
+            value={customTo}
+            onChange={(e) => setCustomTo(e.target.value)}
+            className="flex-1 px-2 py-1 text-xs text-[#403770] border border-[#C2BBD4] rounded-md focus:outline-none focus:ring-1 focus:ring-[#F37167]"
+          />
+        </div>
+        <div className="flex items-center justify-end gap-1 mt-2">
+          <button
+            type="button"
+            onClick={() => { setCustomFrom(""); setCustomTo(""); patchFilters({ dateFrom: null, dateTo: null }); onClose(); }}
+            className="px-2 py-1 text-[10px] font-bold uppercase tracking-[0.06em] text-[#8A80A8] hover:text-[#F37167]"
+          >
+            Clear
+          </button>
+          <button
+            type="button"
+            onClick={applyCustom}
+            className="px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.06em] text-white bg-[#403770] rounded-md hover:bg-[#322a5a]"
+          >
+            Apply
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/activities/components/page/table/filters/DistrictFilter.tsx
+++ b/src/features/activities/components/page/table/filters/DistrictFilter.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Search, Square, SquareCheck } from "lucide-react";
+import { useActivitiesChrome } from "@/features/activities/lib/filters-store";
+import { useDistricts } from "@/features/districts/lib/queries";
+import { cn } from "@/features/shared/lib/cn";
+
+export default function DistrictFilter({ onClose }: { onClose: () => void }) {
+  const filters = useActivitiesChrome((s) => s.filters);
+  const patchFilters = useActivitiesChrome((s) => s.patchFilters);
+  const [query, setQuery] = useState("");
+  const [debounced, setDebounced] = useState("");
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(query.trim()), 250);
+    return () => clearTimeout(t);
+  }, [query]);
+
+  const { data, isLoading } = useDistricts({ search: debounced, limit: 25 });
+
+  function toggle(leaid: string) {
+    const next = filters.districts.includes(leaid)
+      ? filters.districts.filter((v) => v !== leaid)
+      : [...filters.districts, leaid];
+    patchFilters({ districts: next });
+  }
+
+  return (
+    <div className="p-1 w-72 max-h-96 overflow-y-auto">
+      <div className="px-1 pt-1 pb-1.5">
+        <div className="relative">
+          <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-[#A69DC0]" />
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search districts…"
+            className="w-full pl-7 pr-2 py-1.5 text-xs text-[#403770] placeholder:text-[#A69DC0] border border-[#C2BBD4] rounded-md focus:outline-none focus:ring-1 focus:ring-[#F37167]"
+          />
+        </div>
+      </div>
+      {isLoading ? (
+        <div className="px-3 py-2 text-[11px] text-[#A69DC0] italic">Loading…</div>
+      ) : (data?.districts ?? []).length === 0 ? (
+        <div className="px-3 py-2 text-[11px] text-[#A69DC0] italic">
+          {debounced ? "No districts match." : "Type to search…"}
+        </div>
+      ) : (
+        (data?.districts ?? []).map((d) => {
+          const active = filters.districts.includes(d.leaid);
+          const Box = active ? SquareCheck : Square;
+          return (
+            <button
+              key={d.leaid}
+              type="button"
+              onClick={() => toggle(d.leaid)}
+              aria-pressed={active}
+              className={cn(
+                "w-full flex items-center gap-2 px-2 py-1.5 text-xs text-left rounded-md transition-colors",
+                active ? "bg-[#F7F5FA] text-[#403770]" : "text-[#403770] hover:bg-[#F7F5FA]"
+              )}
+            >
+              <Box className={cn("w-3.5 h-3.5 flex-shrink-0", active ? "text-[#403770]" : "text-[#A69DC0]")} />
+              <span className="flex-1 truncate">{d.name}</span>
+              {d.stateAbbrev && <span className="text-[10px] text-[#A69DC0] flex-shrink-0">{d.stateAbbrev}</span>}
+            </button>
+          );
+        })
+      )}
+      <div className="flex items-center justify-between border-t border-[#EFEDF5] mt-1 pt-1.5 px-1">
+        <button
+          type="button"
+          onClick={() => patchFilters({ districts: [] })}
+          className="px-2 py-1 text-[10px] font-bold uppercase tracking-[0.06em] text-[#8A80A8] hover:text-[#F37167]"
+        >
+          Clear
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          className="px-2 py-1 text-[10px] font-bold uppercase tracking-[0.06em] text-[#544A78] hover:text-[#403770]"
+        >
+          Done
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/activities/components/page/table/filters/OwnerFilter.tsx
+++ b/src/features/activities/components/page/table/filters/OwnerFilter.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useMemo } from "react";
+import { useActivitiesChrome } from "@/features/activities/lib/filters-store";
+import { useUsers, useProfile } from "@/features/shared/lib/queries";
+import { Square, SquareCheck } from "lucide-react";
+import { cn } from "@/features/shared/lib/cn";
+
+export default function OwnerFilter({ onClose }: { onClose: () => void }) {
+  const filters = useActivitiesChrome((s) => s.filters);
+  const patchFilters = useActivitiesChrome((s) => s.patchFilters);
+  const { data: users } = useUsers();
+  const { data: profile } = useProfile();
+
+  const sorted = useMemo(() => {
+    const list = users ?? [];
+    return [...list].sort((a, b) => {
+      if (profile?.id === a.id) return -1;
+      if (profile?.id === b.id) return 1;
+      return (a.fullName ?? a.email).localeCompare(b.fullName ?? b.email);
+    });
+  }, [users, profile?.id]);
+
+  function toggle(id: string) {
+    const next = filters.owners.includes(id)
+      ? filters.owners.filter((v) => v !== id)
+      : [...filters.owners, id];
+    patchFilters({ owners: next });
+  }
+
+  return (
+    <div className="p-1 w-64 max-h-96 overflow-y-auto">
+      {sorted.map((u) => {
+        const active = filters.owners.includes(u.id);
+        const Box = active ? SquareCheck : Square;
+        return (
+          <button
+            key={u.id}
+            type="button"
+            onClick={() => toggle(u.id)}
+            aria-pressed={active}
+            className={cn(
+              "w-full flex items-center gap-2 px-2 py-1.5 text-xs text-left rounded-md transition-colors",
+              active ? "bg-[#F7F5FA] text-[#403770]" : "text-[#403770] hover:bg-[#F7F5FA]"
+            )}
+          >
+            <Box className={cn("w-3.5 h-3.5", active ? "text-[#403770]" : "text-[#A69DC0]")} />
+            {profile?.id === u.id ? "Me" : u.fullName ?? u.email}
+          </button>
+        );
+      })}
+      <div className="flex items-center justify-between border-t border-[#EFEDF5] mt-1 pt-1.5 px-1">
+        <button
+          type="button"
+          onClick={() => patchFilters({ owners: [] })}
+          className="px-2 py-1 text-[10px] font-bold uppercase tracking-[0.06em] text-[#8A80A8] hover:text-[#F37167]"
+        >
+          Clear
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          className="px-2 py-1 text-[10px] font-bold uppercase tracking-[0.06em] text-[#544A78] hover:text-[#403770]"
+        >
+          Done
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/activities/components/page/table/filters/StatusFilter.tsx
+++ b/src/features/activities/components/page/table/filters/StatusFilter.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useActivitiesChrome } from "@/features/activities/lib/filters-store";
+import { ACTIVITY_STATUS_CONFIG, VALID_ACTIVITY_STATUSES } from "@/features/activities/types";
+import { Square, SquareCheck } from "lucide-react";
+import { cn } from "@/features/shared/lib/cn";
+
+export default function StatusFilter({ onClose }: { onClose: () => void }) {
+  const filters = useActivitiesChrome((s) => s.filters);
+  const patchFilters = useActivitiesChrome((s) => s.patchFilters);
+
+  function toggle(value: string) {
+    const next = filters.statuses.includes(value)
+      ? filters.statuses.filter((v) => v !== value)
+      : [...filters.statuses, value];
+    patchFilters({ statuses: next });
+  }
+
+  return (
+    <div className="p-1 w-56">
+      {VALID_ACTIVITY_STATUSES.map((s) => {
+        const cfg = ACTIVITY_STATUS_CONFIG[s];
+        const active = filters.statuses.includes(s);
+        const Checkbox = active ? SquareCheck : Square;
+        return (
+          <button
+            key={s}
+            type="button"
+            onClick={() => toggle(s)}
+            aria-pressed={active}
+            className={cn(
+              "w-full flex items-center gap-2 px-2 py-1.5 text-xs text-left rounded-md transition-colors",
+              active ? "bg-[#F7F5FA] text-[#403770]" : "text-[#403770] hover:bg-[#F7F5FA]"
+            )}
+          >
+            <Checkbox className={cn("w-3.5 h-3.5", active ? "text-[#403770]" : "text-[#A69DC0]")} />
+            <span className="w-2 h-2 rounded-full" style={{ backgroundColor: cfg.color }} aria-hidden />
+            {cfg.label}
+          </button>
+        );
+      })}
+      <div className="flex items-center justify-between border-t border-[#EFEDF5] mt-1 pt-1.5 px-1">
+        <button
+          type="button"
+          onClick={() => patchFilters({ statuses: [] })}
+          className="px-2 py-1 text-[10px] font-bold uppercase tracking-[0.06em] text-[#8A80A8] hover:text-[#F37167]"
+        >
+          Clear
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          className="px-2 py-1 text-[10px] font-bold uppercase tracking-[0.06em] text-[#544A78] hover:text-[#403770]"
+        >
+          Done
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/activities/components/page/table/filters/TextFilter.tsx
+++ b/src/features/activities/components/page/table/filters/TextFilter.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface TextFilterProps {
+  value: string;
+  placeholder?: string;
+  onChange: (next: string) => void;
+  onClose: () => void;
+}
+
+// Per-column text filter — single input, applies on Enter / blur.
+export default function TextFilter({ value, placeholder, onChange, onClose }: TextFilterProps) {
+  const [draft, setDraft] = useState(value);
+  useEffect(() => setDraft(value), [value]);
+
+  function commit() {
+    if (draft.trim() !== value) onChange(draft.trim());
+    onClose();
+  }
+
+  return (
+    <div className="p-2 w-64">
+      <input
+        autoFocus
+        type="text"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") commit();
+          if (e.key === "Escape") onClose();
+        }}
+        placeholder={placeholder ?? "Contains…"}
+        className="w-full px-2.5 py-1.5 text-xs text-[#403770] placeholder:text-[#A69DC0] bg-white border border-[#C2BBD4] rounded-md focus:outline-none focus:ring-1 focus:ring-[#F37167]"
+      />
+      <div className="flex items-center justify-end mt-2 gap-1">
+        {value && (
+          <button
+            type="button"
+            onClick={() => { setDraft(""); onChange(""); onClose(); }}
+            className="px-2 py-1 text-[10px] font-bold uppercase tracking-[0.06em] text-[#8A80A8] hover:text-[#F37167]"
+          >
+            Clear
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={commit}
+          className="px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.06em] text-white bg-[#403770] rounded-md hover:bg-[#322a5a]"
+        >
+          Apply
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/activities/components/page/table/filters/TypeFilter.tsx
+++ b/src/features/activities/components/page/table/filters/TypeFilter.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useActivitiesChrome } from "@/features/activities/lib/filters-store";
+import {
+  ACTIVITY_CATEGORIES,
+  ACTIVITY_TYPE_LABELS,
+  CATEGORY_LABELS,
+  type ActivityCategory,
+  type ActivityType,
+} from "@/features/activities/types";
+import { Square, SquareCheck } from "lucide-react";
+import { cn } from "@/features/shared/lib/cn";
+
+export default function TypeFilter({ onClose }: { onClose: () => void }) {
+  const filters = useActivitiesChrome((s) => s.filters);
+  const patchFilters = useActivitiesChrome((s) => s.patchFilters);
+
+  function toggleCategory(c: ActivityCategory) {
+    const next = filters.categories.includes(c)
+      ? filters.categories.filter((v) => v !== c)
+      : [...filters.categories, c];
+    patchFilters({ categories: next });
+  }
+
+  function toggleType(t: ActivityType) {
+    const next = filters.types.includes(t)
+      ? filters.types.filter((v) => v !== t)
+      : [...filters.types, t];
+    patchFilters({ types: next });
+  }
+
+  return (
+    <div className="p-1 w-64 max-h-96 overflow-y-auto">
+      {(Object.keys(ACTIVITY_CATEGORIES) as ActivityCategory[]).map((c) => {
+        const childTypes = ACTIVITY_CATEGORIES[c] as readonly ActivityType[];
+        const catActive = filters.categories.includes(c);
+        const CatBox = catActive ? SquareCheck : Square;
+        return (
+          <div key={c} className="mb-0.5">
+            <button
+              type="button"
+              onClick={() => toggleCategory(c)}
+              className={cn(
+                "w-full flex items-center gap-2 px-2 py-1.5 text-xs font-semibold rounded-md transition-colors",
+                catActive ? "bg-[#F7F5FA] text-[#403770]" : "text-[#403770] hover:bg-[#F7F5FA]"
+              )}
+            >
+              <CatBox className={cn("w-3.5 h-3.5", catActive ? "text-[#403770]" : "text-[#A69DC0]")} />
+              {CATEGORY_LABELS[c]}
+            </button>
+            {childTypes.map((t) => {
+              const active = filters.types.includes(t);
+              const Box = active ? SquareCheck : Square;
+              return (
+                <button
+                  key={t}
+                  type="button"
+                  onClick={() => toggleType(t)}
+                  className={cn(
+                    "w-full flex items-center gap-2 pl-7 pr-2 py-1.5 text-xs text-left rounded-md transition-colors",
+                    active ? "bg-[#F7F5FA] text-[#403770]" : "text-[#403770] hover:bg-[#F7F5FA]"
+                  )}
+                >
+                  <Box className={cn("w-3.5 h-3.5", active ? "text-[#403770]" : "text-[#A69DC0]")} />
+                  {ACTIVITY_TYPE_LABELS[t]}
+                </button>
+              );
+            })}
+          </div>
+        );
+      })}
+      <div className="flex items-center justify-between border-t border-[#EFEDF5] mt-1 pt-1.5 px-1">
+        <button
+          type="button"
+          onClick={() => patchFilters({ categories: [], types: [] })}
+          className="px-2 py-1 text-[10px] font-bold uppercase tracking-[0.06em] text-[#8A80A8] hover:text-[#F37167]"
+        >
+          Clear
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          className="px-2 py-1 text-[10px] font-bold uppercase tracking-[0.06em] text-[#544A78] hover:text-[#403770]"
+        >
+          Done
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/activities/lib/filters-store.ts
+++ b/src/features/activities/lib/filters-store.ts
@@ -7,10 +7,14 @@ import type { ActivitiesParams } from "@/features/shared/types/api-types";
 import type { ActivityCategory, ActivityType } from "@/features/activities/types";
 import { useProfile } from "@/features/shared/lib/queries";
 
-export type CalendarView = "schedule" | "month" | "week" | "map";
+export type CalendarView = "schedule" | "month" | "week" | "table" | "map";
 export type Grain = "day" | "week" | "month" | "quarter";
 export type SyncState = "connected" | "stale" | "disconnected";
 export type DealKind = "won" | "lost" | "created" | "progressed" | "closing";
+
+export type ActivitySortKey = "date" | "type" | "title" | "district" | "owner" | "status";
+export type SortDir = "asc" | "desc";
+export interface TableSort { column: ActivitySortKey; direction: SortDir }
 
 export interface ActivitiesFilters {
   categories: ActivityCategory[];
@@ -23,11 +27,16 @@ export interface ActivitiesFilters {
   owners: string[]; // user IDs (created by); empty = team scope
   attendeeIds: string[]; // user IDs of attendees
   districts: string[]; // district leaids
+  contactIds: number[]; // contact IDs (Table view)
   inPerson: ("yes" | "no")[]; // empty = no filter; ["yes"] / ["no"] / both
   states: string[]; // state codes
   territories: string[]; // plan IDs
   tags: string[];
   text: string;
+  // Table-view-only date range; null = no bound. Calendar views ignore these
+  // and continue to compute the window from anchor + grain.
+  dateFrom: string | null;
+  dateTo: string | null;
 }
 
 export const EMPTY_FILTERS: ActivitiesFilters = {
@@ -41,12 +50,30 @@ export const EMPTY_FILTERS: ActivitiesFilters = {
   owners: [],
   attendeeIds: [],
   districts: [],
+  contactIds: [],
   inPerson: [],
   states: [],
   territories: [],
   tags: [],
   text: "",
+  dateFrom: null,
+  dateTo: null,
 };
+
+// Default Table column set (Wide bundle from spec). Order is left→right
+// in the rendered header. Hidden-by-default columns are added via the picker.
+export const DEFAULT_TABLE_COLUMNS = [
+  "date",
+  "type",
+  "title",
+  "district",
+  "contact",
+  "owner",
+  "status",
+  "outcome",
+] as const;
+export const DEFAULT_TABLE_SORTS: TableSort[] = [{ column: "date", direction: "desc" }];
+export const DEFAULT_TABLE_PAGE_SIZE = 50;
 
 interface ChromeState {
   view: CalendarView;
@@ -56,6 +83,11 @@ interface ChromeState {
   railCollapsed: boolean;
   syncState: SyncState;
   filters: ActivitiesFilters;
+  // Table-view UI state — persisted across sessions
+  tableSorts: TableSort[];
+  tableVisibleColumns: string[];
+  tablePage: number;
+  tablePageSize: number;
   // Setters
   setView: (v: CalendarView) => void;
   setGrain: (g: Grain) => void;
@@ -66,6 +98,10 @@ interface ChromeState {
   setFilters: (next: ActivitiesFilters | ((prev: ActivitiesFilters) => ActivitiesFilters)) => void;
   patchFilters: (patch: Partial<ActivitiesFilters>) => void;
   resetFilters: () => void;
+  setTableSorts: (sorts: TableSort[]) => void;
+  setTableVisibleColumns: (columns: string[]) => void;
+  setTablePage: (page: number) => void;
+  setTablePageSize: (size: number) => void;
 }
 
 export const useActivitiesChrome = create<ChromeState>()(
@@ -78,6 +114,10 @@ export const useActivitiesChrome = create<ChromeState>()(
       railCollapsed: false,
       syncState: "disconnected",
       filters: EMPTY_FILTERS,
+      tableSorts: DEFAULT_TABLE_SORTS,
+      tableVisibleColumns: [...DEFAULT_TABLE_COLUMNS],
+      tablePage: 0,
+      tablePageSize: DEFAULT_TABLE_PAGE_SIZE,
 
       setView: (view) => set({ view }),
       setGrain: (grain) => set({ grain }),
@@ -88,10 +128,15 @@ export const useActivitiesChrome = create<ChromeState>()(
       setFilters: (next) =>
         set((s) => ({
           filters: typeof next === "function" ? next(s.filters) : next,
+          tablePage: 0, // any filter change resets to first page
         })),
       patchFilters: (patch) =>
-        set((s) => ({ filters: { ...s.filters, ...patch } })),
-      resetFilters: () => set({ filters: EMPTY_FILTERS, savedViewId: null }),
+        set((s) => ({ filters: { ...s.filters, ...patch }, tablePage: 0 })),
+      resetFilters: () => set({ filters: EMPTY_FILTERS, savedViewId: null, tablePage: 0 }),
+      setTableSorts: (tableSorts) => set({ tableSorts, tablePage: 0 }),
+      setTableVisibleColumns: (tableVisibleColumns) => set({ tableVisibleColumns }),
+      setTablePage: (tablePage) => set({ tablePage }),
+      setTablePageSize: (tablePageSize) => set({ tablePageSize, tablePage: 0 }),
     }),
     {
       name: "cal", // -> cal in localStorage
@@ -101,6 +146,9 @@ export const useActivitiesChrome = create<ChromeState>()(
         grain: s.grain,
         savedViewId: s.savedViewId,
         railCollapsed: s.railCollapsed,
+        tableSorts: s.tableSorts,
+        tableVisibleColumns: s.tableVisibleColumns,
+        tablePageSize: s.tablePageSize,
       }),
     }
   )
@@ -186,17 +234,38 @@ export function getRangeForChrome(anchorIso: string, grain: Grain): { startIso: 
 
 // Build the useActivities() params from filters + chrome.
 // Multi-value filters that the API doesn't support yet are applied client-side.
+//
+// Calendar views (schedule/week/month/map) derive the date window from
+// anchor + grain. The Table view ignores anchor+grain and uses
+// filters.dateFrom/dateTo (which may be null = unbounded) plus
+// pagination + sort args.
 export function deriveActivitiesParams(args: {
   filters: ActivitiesFilters;
   anchorIso: string;
   grain: Grain;
+  view?: CalendarView;
+  page?: number;
+  pageSize?: number;
+  sorts?: TableSort[];
 }): ActivitiesParams {
-  const { startIso, endIso } = getRangeForChrome(args.anchorIso, args.grain);
-  const params: ActivitiesParams = {
-    startDateFrom: startIso.slice(0, 10),
-    startDateTo: endIso.slice(0, 10),
-    limit: 500,
-  };
+  const isTable = args.view === "table";
+  const params: ActivitiesParams = {};
+
+  if (isTable) {
+    if (args.filters.dateFrom) params.startDateFrom = args.filters.dateFrom.slice(0, 10);
+    if (args.filters.dateTo) params.startDateTo = args.filters.dateTo.slice(0, 10);
+    const pageSize = args.pageSize ?? DEFAULT_TABLE_PAGE_SIZE;
+    params.limit = pageSize;
+    if (args.page && args.page > 0) params.offset = args.page * pageSize;
+    const primarySort = args.sorts?.[0] ?? DEFAULT_TABLE_SORTS[0];
+    params.sortBy = primarySort.column;
+    params.sortDir = primarySort.direction;
+  } else {
+    const { startIso, endIso } = getRangeForChrome(args.anchorIso, args.grain);
+    params.startDateFrom = startIso.slice(0, 10);
+    params.startDateTo = endIso.slice(0, 10);
+    params.limit = 500;
+  }
 
   // Single-value short-circuits — API supports these directly.
   if (args.filters.categories.length === 1) params.category = args.filters.categories[0];
@@ -213,6 +282,7 @@ export function deriveActivitiesParams(args: {
   if (args.filters.attendeeIds.length > 0) params.attendeeIds = args.filters.attendeeIds;
   if (args.filters.districts.length > 0) params.districtLeaids = args.filters.districts;
   if (args.filters.inPerson.length > 0) params.inPerson = args.filters.inPerson;
+  if (args.filters.contactIds.length > 0) params.contactIds = args.filters.contactIds;
 
   return params;
 }

--- a/src/features/activities/lib/filters-store.ts
+++ b/src/features/activities/lib/filters-store.ts
@@ -267,9 +267,13 @@ export function deriveActivitiesParams(args: {
     params.limit = 500;
   }
 
-  // Single-value short-circuits — API supports these directly.
+  // Single-value short-circuits — API supports these directly. Multi-value
+  // categories ride the same `category` param as a CSV (route's readMulti
+  // parses it back into a list).
   if (args.filters.categories.length === 1) params.category = args.filters.categories[0];
+  else if (args.filters.categories.length > 1) params.category = args.filters.categories;
   if (args.filters.types.length === 1) params.type = args.filters.types[0];
+  else if (args.filters.types.length > 1) params.type = args.filters.types;
   if (args.filters.statuses.length === 1) params.status = args.filters.statuses[0] as ActivitiesParams["status"];
   if (args.filters.owners.length === 1) params.ownerId = args.filters.owners[0];
   if (args.filters.owners.length === 0) params.ownerId = "all";

--- a/src/features/activities/lib/queries.ts
+++ b/src/features/activities/lib/queries.ts
@@ -259,6 +259,66 @@ export function useUpdateActivity() {
   });
 }
 
+// Bulk-update mutation for the Table view's selection bar. Optimistically
+// patches every selected activity's cache entry, rolls back on error, then
+// invalidates so the server's authoritative shape replaces the local guess.
+//
+// Note that the server returns per-row results — `succeeded` and `failed` —
+// rather than 4xx for partial failures. Callers should check `failed.length`
+// and surface a toast when non-empty so reps know which rows didn't apply.
+export function useBulkUpdateActivities() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      ids,
+      updates,
+    }: {
+      ids: string[];
+      updates: { ownerId?: string; status?: ActivityStatus };
+    }) =>
+      fetchJson<{
+        succeeded: string[];
+        failed: { id: string; reason: "not_found" | "forbidden" | "system_skip" }[];
+      }>(`${API_BASE}/activities/bulk`, {
+        method: "PATCH",
+        body: JSON.stringify({ ids, updates }),
+      }),
+    onMutate: async ({ ids, updates }) => {
+      // Snapshot all the entries we're about to touch so we can roll back.
+      const snapshots = new Map<string, Activity | undefined>();
+      for (const id of ids) {
+        const key = ["activity", id] as const;
+        await queryClient.cancelQueries({ queryKey: key });
+        const previous = queryClient.getQueryData<Activity>(key);
+        snapshots.set(id, previous);
+        if (previous) {
+          queryClient.setQueryData<Activity>(key, {
+            ...previous,
+            ...(updates.ownerId !== undefined && { createdByUserId: updates.ownerId }),
+            ...(updates.status !== undefined && { status: updates.status }),
+          });
+        }
+      }
+      return { snapshots };
+    },
+    onError: (_err, _vars, context) => {
+      if (!context?.snapshots) return;
+      for (const [id, snapshot] of context.snapshots.entries()) {
+        if (snapshot) {
+          queryClient.setQueryData(["activity", id], snapshot);
+        }
+      }
+    },
+    onSettled: (_data, _err, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["activities"] });
+      for (const id of variables.ids) {
+        queryClient.invalidateQueries({ queryKey: ["activity", id] });
+      }
+    },
+  });
+}
+
 // Delete activity mutation
 export function useDeleteActivity() {
   const queryClient = useQueryClient();

--- a/src/features/activities/lib/queries.ts
+++ b/src/features/activities/lib/queries.ts
@@ -193,6 +193,7 @@ export function useUpdateActivity() {
       contactIds?: number[];
       expenses?: { description: string; amount: number }[];
       districts?: { leaid: string; visitDate?: string | null; visitEndDate?: string | null; position?: number; notes?: string | null }[];
+      createdByUserId?: string;
     }) =>
       fetchJson<Activity>(`${API_BASE}/activities/${activityId}`, {
         method: "PATCH",
@@ -231,6 +232,7 @@ export function useUpdateActivity() {
           ...(patch.inPerson !== undefined && { inPerson: patch.inPerson }),
           ...(patch.rating !== undefined && { rating: patch.rating }),
           ...(patch.metadata !== undefined && { metadata: patch.metadata }),
+          ...(patch.createdByUserId !== undefined && { createdByUserId: patch.createdByUserId }),
         });
       }
       return { previous, queryKey };

--- a/src/features/activities/lib/queries.ts
+++ b/src/features/activities/lib/queries.ts
@@ -51,6 +51,14 @@ export function buildActivitiesQueryString(params: ActivitiesParams): string {
   if (districtLeaids) sp.set("districtLeaids", districtLeaids);
   const attendeeIds = csvParam(params.attendeeIds);
   if (attendeeIds) sp.set("attendeeIds", attendeeIds);
+  const contactIds = csvParam(
+    params.contactIds == null
+      ? undefined
+      : Array.isArray(params.contactIds)
+        ? params.contactIds.map((v) => String(v))
+        : String(params.contactIds)
+  );
+  if (contactIds) sp.set("contactIds", contactIds);
   const inPerson = csvParam(params.inPerson);
   if (inPerson) sp.set("inPerson", inPerson);
 
@@ -66,6 +74,8 @@ export function buildActivitiesQueryString(params: ActivitiesParams): string {
   if (params.search) sp.set("search", params.search);
   if (params.limit) sp.set("limit", params.limit.toString());
   if (params.offset) sp.set("offset", params.offset.toString());
+  if (params.sortBy) sp.set("sortBy", params.sortBy);
+  if (params.sortDir) sp.set("sortDir", params.sortDir);
 
   // Sort entries so e.g. {a,b} and {b,a} produce the same string and the
   // same TanStack key. URLSearchParams preserves insertion order otherwise.

--- a/src/features/activities/lib/queries.ts
+++ b/src/features/activities/lib/queries.ts
@@ -94,6 +94,11 @@ export function useActivities(params: ActivitiesParams = {}, options?: { enabled
     queryFn: () => fetchJson<ActivitiesResponse>(url),
     staleTime: 2 * 60 * 1000, // 2 minutes
     enabled: options?.enabled,
+    // Keep the prior result visible while a new filter/sort/page request
+    // is in flight. Without this, the Table view flashes to a skeleton on
+    // every checkbox toggle, which feels unresponsive even though the
+    // request itself is fast (~800ms).
+    placeholderData: keepPreviousData,
   });
 }
 

--- a/src/features/shared/types/api-types.ts
+++ b/src/features/shared/types/api-types.ts
@@ -581,6 +581,14 @@ export interface ActivityListItem {
   planCount: number;
   districtCount: number;
   stateAbbrevs: string[];
+  // Owner / display-name denormalization for the Table view. The list
+  // route populates these from a Prisma `include`; older calendar views
+  // ignore them and read names per-row from their own includes.
+  createdByUserId?: string | null;
+  ownerFullName?: string | null;
+  districtName?: string | null;
+  contactName?: string | null;
+  outcomePreview?: string | null;
   // Mixmax enrichment fields (populated by Mixmax sync)
   mixmaxSequenceName?: string | null;
   mixmaxSequenceStep?: number | null;
@@ -622,6 +630,8 @@ export interface ActivitiesParams {
   owner?: string | string[];
   // Filter to activities that include these user IDs as attendees.
   attendeeIds?: string | string[];
+  // Multi-contact filter — Table view writes the user-picked contacts here.
+  contactIds?: number[] | string[];
   // "yes" → only in-person; "no" → only virtual; both → exclude unset.
   inPerson?: string | string[];
   territory?: string | string[];
@@ -630,6 +640,9 @@ export interface ActivitiesParams {
   search?: string;
   limit?: number;
   offset?: number;
+  // Server-side sort. Default on the route is date desc.
+  sortBy?: "date" | "type" | "title" | "district" | "owner" | "status";
+  sortDir?: "asc" | "desc";
 }
 
 // ===== Deal data layer (Wave 1) =====

--- a/src/features/shared/types/api-types.ts
+++ b/src/features/shared/types/api-types.ts
@@ -589,6 +589,8 @@ export interface ActivityListItem {
   districtName?: string | null;
   contactName?: string | null;
   outcomePreview?: string | null;
+  inPerson?: boolean | null;
+  createdAt?: string;
   // Mixmax enrichment fields (populated by Mixmax sync)
   mixmaxSequenceName?: string | null;
   mixmaxSequenceStep?: number | null;

--- a/src/features/shared/types/api-types.ts
+++ b/src/features/shared/types/api-types.ts
@@ -600,6 +600,9 @@ export interface ActivityListItem {
 export interface ActivitiesResponse {
   activities: ActivityListItem[];
   total: number;
+  // Total matching the base filters before computed-flag filtering. Used by
+  // the Table view's pagination footer + 200+ banner.
+  totalInDb?: number;
 }
 
 // ActivitiesParams is the client-side filter shape sent to GET /api/activities.


### PR DESCRIPTION
## Summary

Replaces the **Quarter** option in the Activities `ViewToggle` with a new **Table** view: a paginated, server-filtered, partially inline-editable activities grid with bulk actions and CSV export.

- Backend: extends `GET /api/activities` with `?contactIds=`, `?sortBy=`, `?sortDir=`, broadens `?search=` to OR across title/notes/outcome, augments the response with first-district name, first-contact name, owner full name, outcome preview, in-person, created-at. Adds `PATCH /api/activities/[id] { createdByUserId }` for owner reassign and a new `PATCH /api/activities/bulk` for batch owner/status updates with per-row auth + system-skip.
- Frontend: new column-header-driven table at `src/features/activities/components/page/table/`. Toolbar (search + reset + export + columns picker), per-column filter popovers (Date / Type / Owner / Status / District / Contact / text), inline-editable Date / Type / Owner / Status cells, sticky bulk-action bar (reassign owner, change status, export CSV). Filter state shared with calendar views via `useActivitiesChrome` so switching between toggle modes preserves selections.
- 22 new server-side tests (3 reassign + 6 GET extension + 13 bulk). All 127 existing tests still pass.

Spec: `docs/superpowers/specs/2026-05-05-activities-table-view-spec.md`
Plan: `docs/superpowers/plans/2026-05-05-activities-table-view-plan.md`

## Test plan

- [ ] Toggle to **Table** view from any other tab; ViewToggle order is Schedule / Week / Month / Table / Map
- [ ] Default columns (Date / Type / Title / District / Contact / Owner / Status / Outcome notes) render with real data; long values truncate with "…" and a hover tooltip shows the full text
- [ ] Toolbar search debounces 250ms; types into the input without dropping characters; hits `?search=` on the request and matches title, notes, OR outcome
- [ ] Click a column label → sort cycles asc → desc → default. Coral dot appears on a column's filter icon when that filter is active
- [ ] Open the **Type** filter popover, pick a category (e.g. Meetings) and an extra type from another category → request fires with `?category=meetings&type=...`; rows filter accordingly
- [ ] Open **Status**, **Owner**, **District**, **Contact** filters → each writes to the store and triggers a fetch with the matching param
- [ ] Click the **Date** column filter → preset chips (Today / This week / Last 7/30/90) and a custom range; selecting either updates `dateFrom/dateTo` and the rows
- [ ] Click an **editable cell** (Date / Type / Owner / Status) → inline picker opens; selecting a value mutates the activity, optimistic update is visible immediately, drawer does NOT open
- [ ] Click any non-editable cell → existing `ActivityDetailDrawer` opens with the right activity
- [ ] Select rows via the leftmost checkbox → sticky bottom bar appears: Reassign owner, Change status, Export CSV, Clear. Bulk action shows a toast with succeeded/failed counts
- [ ] Pagination footer shows "X–Y of N" and prev/next chevrons; 200+ results triggers the warning banner above the footer
- [ ] **Columns** picker toggles which columns show (Reset to default works, can't remove the last column); selection is persisted across reloads
- [ ] **Export** menu offers Selected (when ≥1 row picked) and All filtered; CSV downloads with the right filename
- [ ] Reset button clears search + every filter and restores the default-owner-is-me preset
- [ ] Header in Table view does NOT show the calendar count subtitle or the date strip; chip bar + saved-view tabs + upcoming rail are hidden too
- [ ] Switching Table → Schedule preserves filter selections (categories, statuses, owners) where they apply

## Known follow-ups

- No frontend test coverage for the new components in this PR (server-side tests only). Plan called for ~12 frontend test files; those should land in a follow-up before any major refactor.
- Owner sort falls back to `createdByUserId` (UUID alphabetical) because `Activity` has no `createdByUser` Prisma relation; district sort falls back to title for the same reason. A denormalized first-district / owner-name column would unblock proper sorts.
- Bulk endpoint skips calendar push fan-out for now — at 500-row scale that would be 500 fire-and-forget tasks. Queue if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)