### PR TITLE
fix(news): per-minute state cron, shrink rolling batch (unblock ingest)

### DIFF
--- a/src/app/api/cron/ingest-news-state/route.ts
+++ b/src/app/api/cron/ingest-news-state/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { ingestOneState } from "@/features/news/lib/ingest";
+import { US_STATES } from "@/features/news/lib/config";
+import { sweepOrphanedNewsRuns } from "@/features/news/lib/orphan-sweep";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+const CRON_SECRET = process.env.CRON_SECRET;
+
+/**
+ * GET /api/cron/ingest-news-state
+ *
+ * Per-minute slow drip of the 51 per-state Google News queries. Picks a state
+ * deterministically by epoch-minute index so all states cycle every ~51 min,
+ * regardless of when individual cron firings land. One RSS fetch per call,
+ * fits comfortably under any function timeout.
+ *
+ * Replaces the per-state fan-out that used to live in ingestDailyLayers — that
+ * version reliably blew the function timeout, so daily ingest never completed.
+ *
+ * Auth: CRON_SECRET via Bearer token or ?secret= query param.
+ */
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get("authorization");
+  const { searchParams } = new URL(request.url);
+  const secretParam = searchParams.get("secret");
+
+  if (CRON_SECRET && authHeader !== `Bearer ${CRON_SECRET}` && secretParam !== CRON_SECRET) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  await sweepOrphanedNewsRuns();
+
+  // Optional ?state=XX override for manual replays; otherwise rotate by minute.
+  const stateOverride = searchParams.get("state")?.toUpperCase();
+  const state = stateOverride
+    ? US_STATES.find((s) => s.abbrev === stateOverride)
+    : US_STATES[Math.floor(Date.now() / 60_000) % US_STATES.length];
+
+  if (!state) {
+    return NextResponse.json({ error: `unknown state ${stateOverride}` }, { status: 400 });
+  }
+
+  const run = await prisma.newsIngestRun.create({
+    data: { layer: "state", status: "running" },
+  });
+
+  try {
+    const ingestStats = await ingestOneState(state.name);
+
+    await prisma.newsIngestRun.update({
+      where: { id: run.id },
+      data: {
+        finishedAt: new Date(),
+        articlesNew: ingestStats.articlesNew,
+        articlesDup: ingestStats.articlesDup,
+        status: ingestStats.errors.length > 0 ? "error" : "ok",
+        error: ingestStats.errors.length > 0 ? ingestStats.errors.slice(0, 5).join("; ").slice(0, 2000) : null,
+      },
+    });
+
+    return NextResponse.json({
+      runId: run.id,
+      state: state.abbrev,
+      articlesNew: ingestStats.articlesNew,
+      articlesDup: ingestStats.articlesDup,
+      errors: ingestStats.errors.length,
+    });
+  } catch (err) {
+    await prisma.newsIngestRun.update({
+      where: { id: run.id },
+      data: {
+        finishedAt: new Date(),
+        status: "error",
+        error: String(err).slice(0, 2000),
+      },
+    });
+    return NextResponse.json({ error: String(err) }, { status: 500 });
+  }
+}

--- a/src/features/news/lib/config.ts
+++ b/src/features/news/lib/config.ts
@@ -111,5 +111,5 @@ export const TRACKING_PARAMS = new Set<string>([
   "igshid",
 ]);
 
-export const ROLLING_BATCH_SIZE = 100;
+export const ROLLING_BATCH_SIZE = 40;
 export const GOOGLE_NEWS_RSS_URL = "https://news.google.com/rss/search";

--- a/src/features/news/lib/ingest.ts
+++ b/src/features/news/lib/ingest.ts
@@ -4,7 +4,6 @@ import {
   BROAD_QUERIES,
   EDU_FEEDS,
   ROLLING_BATCH_SIZE,
-  US_STATES,
   perStateQuery,
 } from "./config";
 import { fetchGoogleNewsRss, fetchRssFeed, type RawArticle } from "./rss";
@@ -79,8 +78,13 @@ async function ingestFeed(
 }
 
 /**
- * Layer 1 + Layer 2: national edu RSS + broad Google News RSS + per-state queries.
+ * Layer 1 + Layer 2: national edu RSS + broad Google News RSS.
  * Intended to run nightly from /api/cron/ingest-news-daily.
+ *
+ * Per-state queries are NOT included here — they live in
+ * /api/cron/ingest-news-state which fans them out one-per-minute. Bundling all
+ * 51 states into the daily run blew the function timeout (every daily run was
+ * orphan-swept), so coverage moved to a slow drip.
  */
 export async function ingestDailyLayers(): Promise<IngestStats> {
   const t0 = Date.now();
@@ -111,24 +115,29 @@ export async function ingestDailyLayers(): Promise<IngestStats> {
     });
   }
 
-  // Layer 2b — per-state queries
-  for (const s of US_STATES) {
-    queue.add(async () => {
-      try {
-        const raws = await fetchGoogleNewsRss(perStateQuery(s.name));
-        await ingestFeed(raws, "google_news_query", stats);
-      } catch (err) {
-        stats.errors.push(`state "${s.abbrev}": ${String(err)}`);
-      }
-    });
-  }
-
   await queue.onIdle();
   const elapsedMs = Date.now() - t0;
   console.log(
     `[news.ingest.daily] articlesNew=${stats.articlesNew} articlesDup=${stats.articlesDup} ` +
     `errors=${stats.errors.length} ms=${elapsedMs}`
   );
+  return stats;
+}
+
+/**
+ * Layer 2b: single per-state Google News query. Intended to be called once per
+ * minute by /api/cron/ingest-news-state with a rotating state index, so all 51
+ * states are swept ~every 51 minutes. Cheap (1 fetch + dedup) so it fits well
+ * under any function timeout.
+ */
+export async function ingestOneState(stateName: string): Promise<IngestStats> {
+  const stats = emptyStats();
+  try {
+    const raws = await fetchGoogleNewsRss(perStateQuery(stateName));
+    await ingestFeed(raws, "google_news_query", stats);
+  } catch (err) {
+    stats.errors.push(`state "${stateName}": ${String(err)}`);
+  }
   return stats;
 }
 

--- a/vercel.json
+++ b/vercel.json
@@ -21,6 +21,10 @@
       "schedule": "*/15 * * * *"
     },
     {
+      "path": "/api/cron/ingest-news-state?secret=${CRON_SECRET}",
+      "schedule": "* * * * *"
+    },
+    {
       "path": "/api/cron/match-articles?secret=${CRON_SECRET}",
       "schedule": "5,20,35,50 * * * *"
     },


### PR DESCRIPTION
## Summary

Daily news ingest had been **100% failing for 10+ days** (every run orphan-swept after Vercel killed the function). Rolling ingest was at **~59% failure rate** since `ROLLING_BATCH_SIZE` was bumped 15→100 — confirmed via direct query of `news_ingest_runs`: every error in the table is the orphan-sweep sentinel string, no real exceptions. Both layers were budget-overshooting the function timeout.

- `ROLLING_BATCH_SIZE` 100 → 40 to bring p99 back under the function cap (76% of recent OK runs were already exceeding 300s; many hit 580s+).
- Drop the 51 per-state queries from `ingestDailyLayers`; daily now does just the 4 edu feeds + 10 broad queries (~14 fetches at concurrency 4, should finish in ~30-60s).
- New `/api/cron/ingest-news-state` route runs every minute, picks one state by `floor(epochMs/60_000) % 51`, supports `?state=XX` for replays, writes `layer="state"` rows for telemetry. Full state sweep ~every 51 minutes (~28×/day vs the old once-daily plan that never actually ran).

## Test plan

- [ ] Watch first few `/api/cron/ingest-news-state` invocations in Vercel logs after deploy — confirm 200s, sub-30s duration
- [ ] After 1 hour, query `SELECT layer, status, COUNT(*) FROM news_ingest_runs WHERE started_at > NOW() - INTERVAL '1 hour' GROUP BY 1, 2` — expect rolling failure rate < 10%, daily layer empty (next run is 9 UTC)
- [ ] After 24h, confirm daily run completed (status=ok, articles_new > 0)
- [ ] Confirm state cron rotates through all 51 states — query distinct state names from layer="state" rows over a few hours

🤖 Generated with [Claude Code](https://claude.com/claude-code)