### PR TITLE
feat(map-plans): cut client over to MVT vector tiles + /list endpoint

### DIFF
--- a/src/features/map/components/MapV2Container.tsx
+++ b/src/features/map/components/MapV2Container.tsx
@@ -306,8 +306,11 @@ export default function MapV2Container({
   }, [activitiesGeoJSON, activitiesEnabled, mapReady, filterOverlayGeoJSON]);
 
   // Update vector tile URL when plan filters change.
+  // String concatenation (NOT `new URL(...)`) is required so the literal
+  // `{z}/{x}/{y}` placeholders survive into MapLibre's tile templater.
+  // The URL constructor percent-encodes `{` and `}` per the WHATWG spec.
   const plansTileUrl = useMemo(
-    () => new URL(buildMapPlansTileUrl(layerFilters.plans), window.location.origin).toString(),
+    () => `${window.location.origin}${buildMapPlansTileUrl(layerFilters.plans)}`,
     [layerFilters.plans],
   );
 
@@ -849,7 +852,7 @@ export default function MapV2Container({
       // Plan polygon source + layers (rendered below pin layers)
       map.current.addSource(PLANS_SOURCE, {
         type: "vector",
-        tiles: [new URL(buildMapPlansTileUrl(layerFilters.plans), window.location.origin).toString()],
+        tiles: [`${window.location.origin}${buildMapPlansTileUrl(layerFilters.plans)}`],
         minzoom: 0,
         maxzoom: 22,
       });

--- a/src/features/map/components/MapV2Container.tsx
+++ b/src/features/map/components/MapV2Container.tsx
@@ -14,7 +14,7 @@ import { useIsTouchDevice } from "@/features/map/hooks/use-is-touch-device";
 import { useProfile } from "@/lib/api";
 import { mapV2Ref, mapV2Refs, type MapRefKey } from "@/features/map/lib/ref";
 import { classifyTransition } from "@/features/map/lib/comparison";
-import { useSchoolGeoJSON, useMapContacts, useMapVacancies, useMapActivities, useMapPlans } from "@/features/map/lib/queries";
+import { useSchoolGeoJSON, useMapContacts, useMapVacancies, useMapActivities, useMapPlans, buildMapPlansTileUrl } from "@/features/map/lib/queries";
 import { useCrossFilter } from "@/features/map/lib/useCrossFilter";
 import {
   CONTACTS_SOURCE, VACANCIES_SOURCE, ACTIVITIES_SOURCE, PLANS_SOURCE,
@@ -242,7 +242,7 @@ export default function MapV2Container({
   );
 
   const plansEnabled = activeLayers.has("plans") && mapReady;
-  const { data: plansGeoJSON, isLoading: plansLoading } = useMapPlans(
+  const { data: plansRows, isLoading: plansLoading } = useMapPlans(
     layerFilters.plans, plansEnabled,
   );
 
@@ -260,7 +260,7 @@ export default function MapV2Container({
 
   // Cross-filter: constrains overlay rendering by plan focus, plan filters, and search results
   const { filterOverlayGeoJSON } = useCrossFilter({
-    plansGeoJSON,
+    plansGeoJSON: plansRows ?? null,
     contactsGeoJSON,
     vacanciesGeoJSON,
     activitiesGeoJSON,
@@ -305,17 +305,20 @@ export default function MapV2Container({
     }
   }, [activitiesGeoJSON, activitiesEnabled, mapReady, filterOverlayGeoJSON]);
 
-  // Push overlay plans data to map source
+  // Update vector tile URL when plan filters change.
+  const plansTileUrl = useMemo(
+    () => new URL(buildMapPlansTileUrl(layerFilters.plans), window.location.origin).toString(),
+    [layerFilters.plans],
+  );
+
   useEffect(() => {
     if (!map.current || !mapReady) return;
-    const source = map.current.getSource(PLANS_SOURCE) as maplibregl.GeoJSONSource | undefined;
+    const source = map.current.getSource(PLANS_SOURCE) as any;
     if (!source) return;
-    if (plansGeoJSON && plansEnabled) {
-      source.setData(plansGeoJSON);
-    } else {
-      source.setData({ type: "FeatureCollection", features: [] });
+    if (typeof source.setTiles === "function") {
+      source.setTiles([plansTileUrl]);
     }
-  }, [plansGeoJSON, plansEnabled, mapReady]);
+  }, [plansTileUrl, mapReady]);
 
   // Toggle overlay layer visibility based on activeLayers
   useEffect(() => {
@@ -844,7 +847,12 @@ export default function MapV2Container({
       // === OVERLAY LAYERS (map planning overlays) ===
 
       // Plan polygon source + layers (rendered below pin layers)
-      map.current.addSource(PLANS_SOURCE, createGeoJSONSource());
+      map.current.addSource(PLANS_SOURCE, {
+        type: "vector",
+        tiles: [new URL(buildMapPlansTileUrl(layerFilters.plans), window.location.origin).toString()],
+        minzoom: 0,
+        maxzoom: 22,
+      });
       for (const layer of getPlanLayers()) {
         map.current.addLayer(layer);
       }

--- a/src/features/map/components/MapV2Container.tsx
+++ b/src/features/map/components/MapV2Container.tsx
@@ -22,7 +22,7 @@ import {
   CONTACTS_CLUSTER_LAYER, VACANCIES_CLUSTER_LAYER, ACTIVITIES_CLUSTER_LAYER,
   PLANS_FILL_LAYER, PLANS_OUTLINE_LAYER,
   ALL_OVERLAY_POINT_LAYERS, ALL_OVERLAY_CLUSTER_LAYERS,
-  createClusteredSource, createGeoJSONSource,
+  createClusteredSource,
   getContactLayers, getVacancyLayers, getActivityLayers, getPlanLayers,
   layerIdToOverlayType, overlayTypeToPanel,
 } from "@/features/map/lib/pin-layers";

--- a/src/features/map/components/SearchResults/PlanCard.tsx
+++ b/src/features/map/components/SearchResults/PlanCard.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import type { Feature, Geometry } from "geojson";
+import type { PlanFeatureRow } from "@/features/map/lib/queries";
 
 interface PlanCardProps {
-  feature: Feature<Geometry>;
+  row: PlanFeatureRow;
   onClick?: () => void;
 }
 
@@ -18,14 +18,14 @@ function getStatusStyle(status: string | undefined) {
   return STATUS_COLORS[status.toLowerCase()] ?? STATUS_COLORS.draft;
 }
 
-export default function PlanCard({ feature, onClick }: PlanCardProps) {
-  const p = feature.properties ?? {};
+export default function PlanCard({ row, onClick }: PlanCardProps) {
+  const p = row;
   const planName = p.planName ?? "Untitled Plan";
   const planColor = p.planColor ?? "#7B6BA4";
   const planStatus = p.planStatus ?? "";
   const districtName = p.districtName ?? null;
-  const renewalTarget = p.renewalTarget ?? null;
-  const expansionTarget = p.expansionTarget ?? null;
+  const renewalTarget = p.renewalTarget;
+  const expansionTarget = p.expansionTarget;
 
   const statusStyle = getStatusStyle(planStatus);
 

--- a/src/features/map/components/SearchResults/PlansTab.tsx
+++ b/src/features/map/components/SearchResults/PlansTab.tsx
@@ -2,12 +2,12 @@
 
 import { useState, useMemo, useCallback } from "react";
 
-import type { FeatureCollection, Geometry, Feature } from "geojson";
+import type { PlanFeatureRow } from "@/features/map/lib/queries";
 import PlanCard from "./PlanCard";
 import PlanDetailModal from "./PlanDetailModal";
 
 interface PlansTabProps {
-  data: FeatureCollection<Geometry> | undefined;
+  data: PlanFeatureRow[] | undefined;
   isLoading: boolean;
 }
 
@@ -34,22 +34,19 @@ function SkeletonCards() {
 export default function PlansTab({ data, isLoading }: PlansTabProps) {
   const [selectedPlanId, setSelectedPlanId] = useState<string | null>(null);
 
-  // Plans can have multiple features per plan (one per district).
-  // Group by planId and show one card per unique plan.
-  const uniquePlans = useMemo(() => {
-    if (!data?.features?.length) return [];
-    const seen = new Map<string, Feature<Geometry>>();
-    for (const feature of data.features) {
-      const planId = feature.properties?.planId;
-      if (planId && !seen.has(planId)) {
-        seen.set(planId, feature);
+  // Group rows by planId; show one card per unique plan.
+  const uniquePlans = useMemo<PlanFeatureRow[]>(() => {
+    if (!data?.length) return [];
+    const seen = new Map<string, PlanFeatureRow>();
+    for (const row of data) {
+      if (row.planId && !seen.has(row.planId)) {
+        seen.set(row.planId, row);
       }
     }
     return [...seen.values()];
   }, [data]);
 
-  // Prev/Next navigation
-  const planIds = useMemo(() => uniquePlans.map((f) => f.properties?.planId as string), [uniquePlans]);
+  const planIds = useMemo(() => uniquePlans.map((r) => r.planId), [uniquePlans]);
   const currentIndex = selectedPlanId ? planIds.indexOf(selectedPlanId) : -1;
 
   const handlePrev = useCallback(() => {
@@ -76,11 +73,11 @@ export default function PlansTab({ data, isLoading }: PlansTabProps) {
   return (
     <>
       <div className="flex-1 overflow-y-auto p-3 space-y-2">
-        {uniquePlans.map((feature) => (
+        {uniquePlans.map((row) => (
           <PlanCard
-            key={feature.properties?.planId ?? feature.id}
-            feature={feature}
-            onClick={() => setSelectedPlanId(feature.properties?.planId)}
+            key={row.planId}
+            row={row}
+            onClick={() => setSelectedPlanId(row.planId)}
           />
         ))}
       </div>

--- a/src/features/map/components/SearchResults/PlansTabContainer.tsx
+++ b/src/features/map/components/SearchResults/PlansTabContainer.tsx
@@ -4,7 +4,6 @@ import { useEffect } from "react";
 import { useMapV2Store } from "@/features/map/lib/store";
 import { useMapPlans } from "@/features/map/lib/queries";
 import PlansTab from "./PlansTab";
-import type { FeatureCollection, Geometry } from "geojson";
 
 export default function PlansTabContainer() {
   const filters = useMapV2Store((s) => s.layerFilters.plans);
@@ -12,12 +11,11 @@ export default function PlansTabContainer() {
 
   const { data, isLoading } = useMapPlans(filters, true);
 
-  // Report raw GeoJSON to store for cross-filtering; clear on unmount
+  // Report rows to store for cross-filtering; clear on unmount.
   useEffect(() => {
     setOverlayGeoJSON("plans", data ?? null);
     return () => setOverlayGeoJSON("plans", null);
   }, [data, setOverlayGeoJSON]);
 
-  // PlansTab receives raw data (not cross-filtered) — plans are the cross-filter source
   return <PlansTab data={data} isLoading={isLoading} />;
 }

--- a/src/features/map/components/SearchResults/index.tsx
+++ b/src/features/map/components/SearchResults/index.tsx
@@ -461,9 +461,8 @@ export default function SearchResults() {
     counts.districts = total;
     if (activeLayers.has("plans") && overlayGeoJSON.plans) {
       const planIds = new Set<string>();
-      for (const f of overlayGeoJSON.plans.features) {
-        const pid = f.properties?.planId;
-        if (pid) planIds.add(pid);
+      for (const row of overlayGeoJSON.plans) {
+        if (row.planId) planIds.add(row.planId);
       }
       counts.plans = planIds.size;
     }

--- a/src/features/map/lib/__tests__/filter-utils.test.ts
+++ b/src/features/map/lib/__tests__/filter-utils.test.ts
@@ -92,3 +92,21 @@ describe("leaidSetKey", () => {
     expect(leaidSetKey(null)).toBe("");
   });
 });
+
+describe("extractLeaids — flat-array shape", () => {
+  it("extracts leaids from a flat array of plan-row objects", () => {
+    const rows = [
+      { leaid: "001", planId: "p1" },
+      { leaid: "002", planId: "p1" },
+      { leaid: "001", planId: "p2" }, // duplicate leaid across plans → still 2 unique
+      { leaid: undefined, planId: "p3" }, // missing leaid → ignored
+    ];
+    const result = extractLeaids(rows);
+    expect(result).toEqual(new Set(["001", "002"]));
+  });
+
+  it("returns an empty Set for null/undefined input", () => {
+    expect(extractLeaids(null)).toEqual(new Set());
+    expect(extractLeaids(undefined)).toEqual(new Set());
+  });
+});

--- a/src/features/map/lib/__tests__/pin-layers.test.ts
+++ b/src/features/map/lib/__tests__/pin-layers.test.ts
@@ -205,6 +205,15 @@ describe("getPlanLayers", () => {
   });
 });
 
+describe("getPlanLayers — vector source-layer", () => {
+  it("sets source-layer to 'plans' on both fill and outline specs", () => {
+    const layers = getPlanLayers();
+    for (const layer of layers) {
+      expect((layer as any)["source-layer"]).toBe("plans");
+    }
+  });
+});
+
 describe("layerIdToOverlayType", () => {
   it("maps contacts layer IDs to 'contacts'", () => {
     expect(layerIdToOverlayType(CONTACTS_POINT_LAYER)).toBe("contacts");

--- a/src/features/map/lib/__tests__/queries.test.ts
+++ b/src/features/map/lib/__tests__/queries.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { buildMapPlansTileUrl } from "../queries";
+
+describe("buildMapPlansTileUrl", () => {
+  it("returns the bare tile URL pattern when no filters are set", () => {
+    const url = buildMapPlansTileUrl({});
+    expect(url).toBe("/api/map/plans/{z}/{x}/{y}.mvt");
+  });
+
+  it("appends status filter as a comma-joined query param", () => {
+    const url = buildMapPlansTileUrl({ status: ["working", "planning"] });
+    expect(url).toBe("/api/map/plans/{z}/{x}/{y}.mvt?status=working%2Cplanning");
+  });
+
+  it("appends ownerIds, planIds, and fiscalYear", () => {
+    const url = buildMapPlansTileUrl({
+      ownerIds: ["u1", "u2"],
+      planIds: ["p1"],
+      fiscalYear: 2026,
+    });
+    expect(url).toContain("ownerIds=u1%2Cu2");
+    expect(url).toContain("planIds=p1");
+    expect(url).toContain("fiscalYear=2026");
+  });
+
+  it("omits empty arrays and undefined values", () => {
+    const url = buildMapPlansTileUrl({ status: [], ownerIds: undefined });
+    expect(url).toBe("/api/map/plans/{z}/{x}/{y}.mvt");
+  });
+});

--- a/src/features/map/lib/__tests__/queries.test.ts
+++ b/src/features/map/lib/__tests__/queries.test.ts
@@ -28,3 +28,14 @@ describe("buildMapPlansTileUrl", () => {
     expect(url).toBe("/api/map/plans/{z}/{x}/{y}.mvt");
   });
 });
+
+describe("buildMapPlansTileUrl + origin concatenation", () => {
+  it("preserves literal {z}/{x}/{y} placeholders when prefixed with an origin", () => {
+    const origin = "http://localhost:3005";
+    const url = `${origin}${buildMapPlansTileUrl({})}`;
+    expect(url).toBe("http://localhost:3005/api/map/plans/{z}/{x}/{y}.mvt");
+    // Sanity guard: ensure curly braces survived (they would be %7B / %7D if encoded).
+    expect(url).not.toContain("%7B");
+    expect(url).not.toContain("%7D");
+  });
+});

--- a/src/features/map/lib/filter-utils.ts
+++ b/src/features/map/lib/filter-utils.ts
@@ -37,14 +37,35 @@ export function isActivitiesFiltered(f: Partial<ActivityLayerFilter>): boolean {
   return !!(f.type?.length || f.status?.length || f.outcome?.length);
 }
 
-/** Extract unique leaid values from a GeoJSON FeatureCollection */
-export function extractLeaids(geojson: any): Set<string> {
+/**
+ * Extract unique leaids from either:
+ *   - a GeoJSON FeatureCollection (one feature per district)
+ *   - a flat array of plan-row objects ({ leaid, ... })
+ * Both shapes occur in this codebase: the contacts/vacancies/activities
+ * overlays still use FeatureCollection, while plans switched to a flat
+ * array after the MVT cutover.
+ */
+export function extractLeaids(input: any): Set<string> {
   const leaids = new Set<string>();
-  if (!geojson?.features) return leaids;
-  for (const f of geojson.features) {
-    const id = f.properties?.leaid;
-    if (id) leaids.add(id);
+  if (!input) return leaids;
+
+  // FeatureCollection shape
+  if (Array.isArray(input.features)) {
+    for (const f of input.features) {
+      const id = f.properties?.leaid;
+      if (id) leaids.add(id);
+    }
+    return leaids;
   }
+
+  // Flat array of plan rows
+  if (Array.isArray(input)) {
+    for (const row of input) {
+      if (row?.leaid) leaids.add(row.leaid);
+    }
+    return leaids;
+  }
+
   return leaids;
 }
 

--- a/src/features/map/lib/pin-layers.ts
+++ b/src/features/map/lib/pin-layers.ts
@@ -241,21 +241,21 @@ export function getActivityLayers(): LayerSpecification[] {
  */
 export function getPlanLayers(): LayerSpecification[] {
   return [
-    // Very subtle fill — just enough to hint at plan coverage without obscuring choropleth
     {
       id: PLANS_FILL_LAYER,
       type: "fill",
       source: PLANS_SOURCE,
+      "source-layer": "plans",
       paint: {
         "fill-color": ["coalesce", ["get", "planColor"], "#7B6BA4"],
         "fill-opacity": 0.08,
       },
     } satisfies LayerSpecification,
-    // Prominent outline for clear plan boundaries
     {
       id: PLANS_OUTLINE_LAYER,
       type: "line",
       source: PLANS_SOURCE,
+      "source-layer": "plans",
       paint: {
         "line-color": ["coalesce", ["get", "planColor"], "#7B6BA4"],
         "line-width": 2.5,

--- a/src/features/map/lib/queries.ts
+++ b/src/features/map/lib/queries.ts
@@ -318,6 +318,22 @@ export function useMapActivities(
 }
 
 /**
+ * A single (plan × district) row returned by `/api/map/plans/list` and shown
+ * in the PlansTab sidebar. Replaces the GeoJSON `Feature<Geometry>` shape that
+ * `useMapPlans` returned before the MVT cutover.
+ */
+export interface PlanFeatureRow {
+  planId: string;
+  planName: string;
+  planColor: string;
+  planStatus: string;
+  districtName: string;
+  leaid: string;
+  renewalTarget: number | null;
+  expansionTarget: number | null;
+}
+
+/**
  * Fetches plan district polygon GeoJSON.
  * Not bounds-limited — plans are loaded globally since there are relatively few.
  * Returns GeoJSON FeatureCollection with Polygon/MultiPolygon geometry.

--- a/src/features/map/lib/queries.ts
+++ b/src/features/map/lib/queries.ts
@@ -334,9 +334,26 @@ export interface PlanFeatureRow {
 }
 
 /**
- * Fetches plan district polygon GeoJSON.
- * Not bounds-limited — plans are loaded globally since there are relatively few.
- * Returns GeoJSON FeatureCollection with Polygon/MultiPolygon geometry.
+ * Stable URL pattern for the MapLibre vector source. Filters are baked into
+ * the query string so MapLibre can keep its tile cache stable across pans/zooms.
+ * The `{z}/{x}/{y}` placeholders are filled in by MapLibre at fetch time.
+ */
+export function buildMapPlansTileUrl(filters: PlanLayerFilter): string {
+  const params = new URLSearchParams();
+  if (filters.status?.length) params.set("status", filters.status.join(","));
+  if (filters.fiscalYear) params.set("fiscalYear", String(filters.fiscalYear));
+  if (filters.planIds?.length) params.set("planIds", filters.planIds.join(","));
+  if (filters.ownerIds?.length) params.set("ownerIds", filters.ownerIds.join(","));
+  const qs = params.toString();
+  return qs
+    ? `/api/map/plans/{z}/{x}/{y}.mvt?${qs}`
+    : `/api/map/plans/{z}/{x}/{y}.mvt`;
+}
+
+/**
+ * Fetches the lightweight plan-district list (no geometry) used by the
+ * PlansTab sidebar and the cross-filter. The map itself uses MVT vector
+ * tiles via `buildMapPlansTileUrl` — not this hook.
  */
 export function useMapPlans(
   filters: PlanLayerFilter,
@@ -353,7 +370,7 @@ export function useMapPlans(
   return useQuery({
     queryKey: ["mapPlans", queryString],
     queryFn: () =>
-      fetchJson<FeatureCollection<Geometry>>(`${API_BASE}/map/plans${queryString}`),
+      fetchJson<PlanFeatureRow[]>(`${API_BASE}/map/plans/list${queryString}`),
     enabled,
     staleTime: 2 * 60 * 1000,
     gcTime: 5 * 60 * 1000,

--- a/src/features/map/lib/store.ts
+++ b/src/features/map/lib/store.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
-import type { FeatureCollection, Point, Geometry } from "geojson";
+import type { FeatureCollection, Point } from "geojson";
+import type { PlanFeatureRow } from "./queries";
 import type { VendorId, SignalId, LocaleId, LayerType, ColorDimension } from "@/features/map/lib/layers";
 import type { AccountTypeValue } from "@/features/shared/types/account-types";
 import { DEFAULT_VENDOR_PALETTE, DEFAULT_SIGNAL_PALETTE, DEFAULT_CATEGORY_COLORS, DEFAULT_CATEGORY_OPACITIES, deriveVendorCategoryColors, deriveSignalCategoryColors, getVendorPalette, getSignalPalette } from "@/features/map/lib/palettes";
@@ -287,7 +288,7 @@ interface MapV2State {
     contacts: FeatureCollection<Point> | null;
     vacancies: FeatureCollection<Point> | null;
     activities: FeatureCollection<Point> | null;
-    plans: FeatureCollection<Geometry> | null;
+    plans: PlanFeatureRow[] | null;
   };
 
   // Unified layer control
@@ -447,7 +448,10 @@ interface MapV2Actions {
   setLayerFilter: <K extends keyof LayerFilters>(layer: K, filter: Partial<LayerFilters[K]>) => void;
   setDateRange: (layer: "vacancies" | "activities", range: Partial<DateRange>) => void;
   setMapBounds: (bounds: [number, number, number, number] | null) => void;
-  setOverlayGeoJSON: (layer: keyof MapV2State["overlayGeoJSON"], data: FeatureCollection | null) => void;
+  setOverlayGeoJSON: <K extends keyof MapV2State["overlayGeoJSON"]>(
+    layer: K,
+    data: MapV2State["overlayGeoJSON"][K],
+  ) => void;
 
   // Unified layer control
   setColorBy: (dimension: ColorDimension) => void;

--- a/src/features/map/lib/useCrossFilter.ts
+++ b/src/features/map/lib/useCrossFilter.ts
@@ -11,9 +11,10 @@ import {
   extractLeaids,
   leaidSetKey,
 } from "./filter-utils";
+import type { PlanFeatureRow } from "./queries";
 
 interface OverlayData {
-  plansGeoJSON: any;
+  plansGeoJSON: PlanFeatureRow[] | null;
   contactsGeoJSON: any;
   vacanciesGeoJSON: any;
   activitiesGeoJSON: any;


### PR DESCRIPTION
## Summary

- MapLibre plan layer now uses a vector source pointing at `/api/map/plans/{z}/{x}/{y}.mvt`. Filter changes call `source.setTiles(...)` rather than refetching the world; pan/zoom only fetches the tiles in view.
- `useMapPlans` now hits the lightweight `/api/map/plans/list` and returns `PlanFeatureRow[]`. PlansTab + cross-filter + tab counts all updated for the new shape.
- The legacy `/api/map/plans` GeoJSON endpoint is still in the codebase and is the one-line revert path if anything blows up — it's deleted in a follow-up PR after a soak.

## Spec / Plan

- `Docs/superpowers/specs/2026-05-01-map-plans-vector-tiles-design.md`
- `Docs/superpowers/plans/2026-05-04-map-plans-vector-tiles.md` (Tasks 9–17)

## Notable correctness fix

The plan's prescribed `new URL(buildMapPlansTileUrl(filters), window.location.origin).toString()` percent-encodes `{` / `}` per the WHATWG URL spec, which would silently break MapLibre's tile templater (`{z}` etc. is matched by literal regex). Fixed in commit `85791b9b` to use plain string concatenation; locked down with a regression test in `src/features/map/lib/__tests__/queries.test.ts` that asserts no `%7B` / `%7D` survive into the composed URL.

## Test plan

- [ ] Map: pan/zoom shows progressive tile load, no full-world freeze
- [ ] Network: tile responses are KB-scale; one JSON list call drives sidebar
- [ ] Filters: owner / status / fiscal-year all change tile URL and repaint
- [ ] Cross-filter: contacts / vacancies / activities respect the plan filter
- [ ] Empty filter combo: clean clear, no console errors
- [ ] `/api/map/plans` (legacy bare path) NOT called from the page

## Touch list

- `src/features/map/lib/queries.ts` — added `PlanFeatureRow`, exported `buildMapPlansTileUrl`, rewired `useMapPlans` to `/list`
- `src/features/map/lib/filter-utils.ts` — `extractLeaids` now accepts both GeoJSON and `PlanFeatureRow[]`
- `src/features/map/lib/store.ts` — `overlayGeoJSON.plans` retyped to `PlanFeatureRow[] | null`; `setOverlayGeoJSON` generic-keyed for per-layer discrimination
- `src/features/map/lib/useCrossFilter.ts` — `OverlayData.plansGeoJSON` retyped
- `src/features/map/lib/pin-layers.ts` — `getPlanLayers()` adds `'source-layer': 'plans'`
- `src/features/map/components/MapV2Container.tsx` — vector source registration, memoized `setTiles` effect, dropped unused `createGeoJSONSource` import
- `src/features/map/components/SearchResults/{PlansTabContainer,PlansTab,PlanCard,index}.tsx` — flat-array consumers
- `+__tests__/{filter-utils,queries,pin-layers}.test.ts` — TDD coverage for each contract change

🤖 Generated with [Claude Code](https://claude.com/claude-code)