### PR TITLE
fix(plans-filter): send 4-digit fiscal years to match DB column

### DIFF
--- a/src/features/map/components/SearchBar/PlansDropdown.tsx
+++ b/src/features/map/components/SearchBar/PlansDropdown.tsx
@@ -17,10 +17,10 @@ const STATUSES = [
 ];
 
 const FISCAL_YEARS = [
-  { value: 24, label: "FY24" },
-  { value: 25, label: "FY25" },
-  { value: 26, label: "FY26" },
-  { value: 27, label: "FY27" },
+  { value: 2024, label: "FY24" },
+  { value: 2025, label: "FY25" },
+  { value: 2026, label: "FY26" },
+  { value: 2027, label: "FY27" },
 ];
 
 export default function PlansDropdown({ onClose }: PlansDropdownProps) {

--- a/src/features/map/lib/__tests__/filter-utils.test.ts
+++ b/src/features/map/lib/__tests__/filter-utils.test.ts
@@ -26,7 +26,7 @@ describe("isPlansFiltered", () => {
     expect(isPlansFiltered({ status: ["working"] })).toBe(true);
   });
   it("returns true when fiscalYear set", () => {
-    expect(isPlansFiltered({ fiscalYear: 26 })).toBe(true);
+    expect(isPlansFiltered({ fiscalYear: 2026 })).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Specific-fiscal-year filters on the Plans layer were silently returning **zero plans** because `PlansDropdown` emits 2-digit values (`24/25/26/27`) while `territory_plans.fiscal_year` stores 4-digit years (`2024/2025/2026/2027`). The mismatch passes through both the legacy GeoJSON endpoint and the new MVT/list endpoints — all three were broken identically.

## Root cause

`src/features/map/components/SearchBar/PlansDropdown.tsx:19-24` declared:
\`\`\`ts
const FISCAL_YEARS = [
  { value: 24, label: \"FY24\" },
  // ...
];
\`\`\`

That \`value\` lands in \`layerFilters.plans.fiscalYear\` and gets serialized into the request URL via \`useMapPlans\`. All three plan endpoints \`parseInt\` it and run \`WHERE tp.fiscal_year = $N\` — which never matches because the DB stores \`2024+\`.

## Why this is the right place to fix it

Every other consumer of plan \`fiscalYear\` in the codebase already expects 4-digit:
- \`src/features/leaderboard/components/LhfPlanPicker.tsx:21\` — \`const TARGET_FY = 2027\`
- \`src/features/leaderboard/components/LhfBulkPlanPicker.tsx:59\` — same
- \`src/features/map/components/panels/HomePanel.tsx:40\` — \`useState(2027)\`
- \`src/features/map/components/panels/PlansListPanel.tsx\` — groups by raw \`p.fiscalYear\` from server (4-digit)

The dropdown was the lone outlier emitting 2-digit. Fixing it there is more localized than touching any of the three API routes.

## Discovery

Surfaced during smoke testing of PR #183 (the MVT cutover). Selecting \"FY26\" or \"FY27\" individually rendered zero plans; \"All Years\" rendered all plans. Same bug exists on \`main\` — this is a pre-existing latent issue PR #183 just made visible.

## Test plan

- [ ] Select FY24/FY25/FY26/FY27 individually in the Plans dropdown — each should narrow the visible plans, not return zero
- [ ] \"All Years\" still returns all plans (regression check)
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)