### PR TITLE
feat(rfps): keep stale-posted RFPs when due date is in the future

### DIFF
--- a/src/features/rfps/lib/__tests__/sync.test.ts
+++ b/src/features/rfps/lib/__tests__/sync.test.ts
@@ -168,17 +168,44 @@ describe("syncRfps", () => {
     expect(rfpUpsert).toHaveBeenCalledTimes(1);
   });
 
-  it("passes postedSince to fetchOpportunities (~1 year ago)", async () => {
+  it("does not pass postedSince to fetchOpportunities (filtering is client-side so future-due RFPs survive)", async () => {
     fetchOpps.mockReturnValue(gen([]));
     rfpIngestRunFindFirst.mockResolvedValue(null);
 
-    const before = Date.now() - 366 * 24 * 60 * 60 * 1000;
     await syncRfps();
-    const after = Date.now() - 364 * 24 * 60 * 60 * 1000;
 
-    const postedSince = (fetchOpps.mock.calls[0][0] as { postedSince: Date }).postedSince;
-    expect(postedSince.getTime()).toBeGreaterThanOrEqual(before);
-    expect(postedSince.getTime()).toBeLessThanOrEqual(after);
+    expect(fetchOpps.mock.calls[0][0]).not.toHaveProperty("postedSince");
+  });
+
+  it("keeps a stale-posted RFP when its due date is still in the future", async () => {
+    const stalePostedDate = new Date(Date.now() - 400 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    const futureDueDate = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    fetchOpps.mockReturnValue(gen([
+      { ...minimalRecord("stale-future", 2, "Active Old", stalePostedDate), due_date: futureDueDate },
+    ]));
+    resolveAgency.mockResolvedValue({ leaid: "L", kind: "name_match" });
+    rfpIngestRunFindFirst.mockResolvedValue(null);
+
+    const summary = await syncRfps();
+
+    expect(summary.recordsSeen).toBe(1);
+    expect(summary.recordsSkippedStale).toBe(0);
+    expect(rfpUpsert).toHaveBeenCalledTimes(1);
+  });
+
+  it("still skips a stale-posted RFP when its due date is in the past", async () => {
+    const stalePostedDate = new Date(Date.now() - 400 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    const pastDueDate = new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    fetchOpps.mockReturnValue(gen([
+      { ...minimalRecord("stale-past", 2, "Closed Old", stalePostedDate), due_date: pastDueDate },
+    ]));
+    resolveAgency.mockResolvedValue({ leaid: "L", kind: "name_match" });
+    rfpIngestRunFindFirst.mockResolvedValue(null);
+
+    const summary = await syncRfps();
+
+    expect(summary.recordsSkippedStale).toBe(1);
+    expect(rfpUpsert).not.toHaveBeenCalled();
   });
 
   it("splits resolved counter into byOverride / byName", async () => {

--- a/src/features/rfps/lib/sync.ts
+++ b/src/features/rfps/lib/sync.ts
@@ -105,7 +105,10 @@ export async function syncRfps(): Promise<SyncSummary> {
 
   try {
     const buffer: HigherGovOpportunity[] = [];
-    for await (const r of fetchOpportunities({ since: watermark, postedSince })) buffer.push(r);
+    // No posted_date__gte at the API layer — we want RFPs that were posted
+    // long ago but are still actively soliciting (future due date). Filtering
+    // happens client-side below.
+    for await (const r of fetchOpportunities({ since: watermark })) buffer.push(r);
 
     const uniqueAgencies = new Map<number, { name: string; state: string }>();
     for (const r of buffer) {
@@ -117,11 +120,14 @@ export async function syncRfps(): Promise<SyncSummary> {
       agencyCache.set(key, await resolveAgency({ agencyKey: key, agencyName: name, stateAbbrev: state }));
     }
 
+    const now = new Date();
     for (const raw of buffer) {
       counters.recordsSeen++;
       try {
         const normalized = normalizeOpportunity(raw);
-        if (!normalized.postedDate || normalized.postedDate < postedSince) {
+        const postedTooOld = !normalized.postedDate || normalized.postedDate < postedSince;
+        const dueInFuture = normalized.dueDate ? normalized.dueDate >= now : false;
+        if (postedTooOld && !dueInFuture) {
           counters.recordsSkippedStale++;
           continue;
         }


### PR DESCRIPTION
## Summary
- The ingest was silently dropping RFPs posted more than 365 days ago, even when they were still actively soliciting (future due date). This hid long-running ISD supplemental contracts that originally awarded in 2024–2025 but have due dates in 2026/2027.
- Removed `posted_date__gte` from the HigherGov API call so older posts come through, and updated the client-side stale-skip filter to skip only when posted is older than 365 days **AND** there is no future due date.
- Surfaced empirically: a saved query for "Fullmind Relevant RFPs" was missing four open Texas City ISD supplementals (Special Education, After School Programs, Fine Arts, Staff Development) that were posted in 2024 but due in mid-2026.

## Test plan
- [x] `npx vitest run src/features/rfps/lib/__tests__/sync.test.ts` — all 12 tests pass
- [x] Existing stale-skip behavior preserved (records with no future due date and posted >365 days ago are still skipped)
- [x] New test: stale-posted + future due → kept
- [x] New test: stale-posted + past due → skipped
- [x] Existing `passes postedSince` test replaced with one asserting `postedSince` is NOT passed
- [x] Verified end-to-end against prod DB via local run (run #15): pulled in 4 previously-missed Texas City ISD RFPs, classifier picked up the new records, saved query now returns the expected RFPs

🤖 Generated with [Claude Code](https://claude.com/claude-code)