### PR TITLE
fix(rfps): allow null stateAbbrev in agency resolver type signature

### DIFF
--- a/src/features/rfps/lib/district-resolver.ts
+++ b/src/features/rfps/lib/district-resolver.ts
@@ -62,7 +62,7 @@ export interface ResolveResult {
 export interface ResolveAgencyArgs {
   agencyKey: number;
   agencyName: string;
-  stateAbbrev: string;
+  stateAbbrev: string | null;
 }
 
 export async function resolveAgency({

--- a/src/features/rfps/lib/sync.ts
+++ b/src/features/rfps/lib/sync.ts
@@ -110,7 +110,7 @@ export async function syncRfps(): Promise<SyncSummary> {
     // happens client-side below.
     for await (const r of fetchOpportunities({ since: watermark })) buffer.push(r);
 
-    const uniqueAgencies = new Map<number, { name: string; state: string }>();
+    const uniqueAgencies = new Map<number, { name: string; state: string | null }>();
     for (const r of buffer) {
       if (!uniqueAgencies.has(r.agency.agency_key)) {
         uniqueAgencies.set(r.agency.agency_key, { name: r.agency.agency_name, state: r.pop_state });


### PR DESCRIPTION
## Summary
- Vercel build on `main` (commit `e4fce7e`) failed with TS2345 in `src/features/rfps/lib/sync.ts:116` — `r.pop_state` is `string | null` since the federal-scope NAT support landed (`4a579b6c`), but `resolveAgency` and the local `uniqueAgencies` map still required `string`.
- Relaxes both type signatures to `string | null`. Runtime is unchanged: `abbrevToFips` already accepts `null` and returns `null`, which yields the correct `unresolved` outcome for federal RFPs.

## Test plan
- [x] `npx tsc --noEmit` — no errors in production sources
- [ ] Vercel build on `main` succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)