### PR TITLE
feat(leaderboard): exclude districts with any FY27 opp from Low Hanging Fruit

### DIFF
--- a/src/app/api/leaderboard/increase-targets/__tests__/route.test.ts
+++ b/src/app/api/leaderboard/increase-targets/__tests__/route.test.ts
@@ -143,7 +143,7 @@ describe("GET /api/leaderboard/increase-targets", () => {
     expect(data.totalRevenueAtRisk).toBe(75000);
   });
 
-  it("references fy27_done, fy27_pipe, fy27_plan, and revenue_trend CTEs in its SQL", async () => {
+  it("references fy27_done, fy27_pipe, fy27_plan, fy27_any_opp, and revenue_trend CTEs in its SQL", async () => {
     (prisma.$queryRaw as unknown as Mock).mockResolvedValueOnce([]);
 
     await GET();
@@ -157,8 +157,10 @@ describe("GET /api/leaderboard/increase-targets", () => {
     expect(sql).toContain("fy27_done");
     expect(sql).toContain("fy27_pipe");
     expect(sql).toContain("fy27_plan");
+    expect(sql).toContain("fy27_any_opp");
     expect(sql).toContain("revenue_trend");
     expect(sql).toContain("NOT IN (SELECT leaid FROM fy27_done");
+    expect(sql).toContain("NOT IN (SELECT leaid FROM fy27_any_opp");
     expect(sql).toContain("LEFT JOIN revenue_trend rt");
   });
 

--- a/src/app/api/leaderboard/increase-targets/route.ts
+++ b/src/app/api/leaderboard/increase-targets/route.ts
@@ -244,6 +244,16 @@ export async function GET() {
         JOIN opportunities o ON o.id = s.opportunity_id
         WHERE o.district_lea_id IS NOT NULL
         GROUP BY o.district_lea_id
+      ),
+      -- Any FY27 opp regardless of stage or amount.
+      -- Catches Closed Lost and zero-dollar Stage 0 opps that
+      -- district_financials' open_pipeline / closed_won_bookings miss.
+      fy27_any_opp AS (
+        SELECT DISTINCT district_lea_id AS leaid
+        FROM opportunities
+        WHERE school_yr = '2026-27'
+          AND district_lea_id IS NOT NULL
+          AND district_lea_id != '_NOMAP'
       )
       SELECT
         d.leaid, d.name, d.state_abbrev, d.enrollment, d.lmsid,
@@ -297,6 +307,7 @@ export async function GET() {
       LEFT JOIN top_products tp ON tp.leaid = eligible.leaid
       WHERE eligible.leaid NOT IN (SELECT leaid FROM fy27_done WHERE leaid IS NOT NULL)
         AND fy27_pipe.leaid IS NULL
+        AND eligible.leaid NOT IN (SELECT leaid FROM fy27_any_opp)
         -- Win-back categories also require no FY27 plan membership;
         -- Missing Renewal Opp stays visible even when in a plan (action flips to Open in LMS).
         AND (


### PR DESCRIPTION
## Summary
- Adds a `fy27_any_opp` CTE pulling DISTINCT `district_lea_id` from `opportunities` where `school_yr = '2026-27'`, then excludes those leaids in the WHERE clause.
- Catches Closed Lost and zero-dollar Stage 0 opps that the existing `district_financials`-based exclusions (`fy27_done`, `fy27_pipe`) miss because they read a Salesforce CSV that drops both.
- Existing `fy27_done` / `fy27_pipe` exclusions stay as belt-and-suspenders for any financials row that doesn't have a matching opp (manual finance adjustment, vendor split).

## Why
Bloom Charter (2× Closed Lost FY27 opps) and School Lane CS (1× Stage 0 \$0 FY27 opp) were both staying in the LHF queue despite reps having already engaged. Confirmed against prod data — both will now be filtered out.

## Test plan
- [x] `npm test -- src/app/api/leaderboard/increase-targets` (10/10 pass)
- [ ] Verify Bloom (`4801466`) and School Lane (`4200030`) no longer appear in LHF on the deployed preview
- [ ] Spot-check that districts with FY27 closed_won \$ (caught by both old and new exclusions) still drop off as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)