### PR TITLE
chore(import): pin School Lane Charter School (District) to NCES 4200030

### DIFF
--- a/scripts/salesforce-contact-leaid-overrides.json
+++ b/scripts/salesforce-contact-leaid-overrides.json
@@ -181,6 +181,7 @@
     "Community Colleges of Spokane|Washington": "M000200",
     "Bloom Academy Charter School|Texas": "4801466",
     "Bloom Academy Charter School (District)|Texas": "4801466",
-    "South Carolina Public Charter District|South Carolina": "4503901"
+    "South Carolina Public Charter District|South Carolina": "4503901",
+    "School Lane Charter School (District)|Pennsylvania": "4200030"
   }
 }


### PR DESCRIPTION
## Summary
- Adds `\"School Lane Charter School (District)|Pennsylvania\": \"4200030\"` to `scripts/salesforce-contact-leaid-overrides.json`.
- Prevents the Salesforce contact import from re-minting synthetic `M000044` after the duplicate was merged into the canonical PA NCES district `4200030`.

## Why
The synthetic `M000044` was minted because the contact-import matcher couldn't auto-link the SF account name "School Lane Charter School (District)" to the real NCES leaid. Without this override, the next contact import run would re-create the synthetic and we'd be back to a duplicate district pair.

## Test plan
- [x] `python3 -c "import json; json.load(open('scripts/salesforce-contact-leaid-overrides.json'))"` parses cleanly
- [ ] Next contact import run on staging shows School Lane resolving to `4200030` rather than minting `M000044`

🤖 Generated with [Claude Code](https://claude.com/claude-code)