### PR TITLE
feat(lhf): amber required state on target field in Add to Plan pickers

### DIFF
--- a/Docs/superpowers/plans/2026-05-06-lhf-banner-collapsible.md
+++ b/Docs/superpowers/plans/2026-05-06-lhf-banner-collapsible.md
@@ -1,0 +1,199 @@
+# LHF Banner Collapsible Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Low Hanging Fruit summary banner collapsible — a chevron-up button hides it to a slim "Instructions" row; chevron-down restores it; state persists for the browser session via sessionStorage.
+
+**Architecture:** Single file change to `LowHangingFruitView.tsx`. Add `bannerCollapsed` state (initialised from sessionStorage), a `toggleBanner` handler, and replace the static banner `<div>` with a conditional that renders either the full banner (+ chevron-up) or a slim collapsed row (+ chevron-down). Tests are added to the existing test file.
+
+**Tech Stack:** React 19, Tailwind CSS 4, Lucide React icons, Vitest + Testing Library.
+
+---
+
+### Task 1: Add collapsible banner to `LowHangingFruitView`
+
+**Files:**
+- Modify: `src/features/leaderboard/components/LowHangingFruitView.tsx`
+- Test: `src/features/leaderboard/components/__tests__/LowHangingFruitView.test.tsx`
+
+Work in the worktree at `/Users/astonfurious/The Laboratory/territory-plan-mobile-scroll-fix`.
+
+- [ ] **Step 1: Add failing tests**
+
+Open `src/features/leaderboard/components/__tests__/LowHangingFruitView.test.tsx` and add `fireEvent` and `beforeEach` imports, then append the new describe block **after** the existing `describe("LowHangingFruitView", ...)` block:
+
+```tsx
+// Add fireEvent to existing import
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+```
+
+Then add at the bottom of the file:
+
+```tsx
+describe("LowHangingFruitView — summary banner collapse", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("shows the banner and a hide button by default", () => {
+    renderView();
+    expect(screen.getByLabelText("Hide instructions")).toBeInTheDocument();
+    expect(screen.getByText(/How to action them/i)).toBeInTheDocument();
+  });
+
+  it("collapses the banner when hide button is clicked", () => {
+    renderView();
+    fireEvent.click(screen.getByLabelText("Hide instructions"));
+    expect(screen.queryByText(/How to action them/i)).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Show instructions")).toBeInTheDocument();
+  });
+
+  it("re-expands the banner when the collapsed row is clicked", () => {
+    renderView();
+    fireEvent.click(screen.getByLabelText("Hide instructions"));
+    fireEvent.click(screen.getByLabelText("Show instructions"));
+    expect(screen.getByText(/How to action them/i)).toBeInTheDocument();
+    expect(screen.getByLabelText("Hide instructions")).toBeInTheDocument();
+  });
+
+  it("starts collapsed when sessionStorage flag is pre-set", () => {
+    sessionStorage.setItem("lhf-banner-collapsed", "true");
+    renderView();
+    expect(screen.queryByText(/How to action them/i)).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Show instructions")).toBeInTheDocument();
+  });
+
+  it("persists collapsed state to sessionStorage", () => {
+    renderView();
+    fireEvent.click(screen.getByLabelText("Hide instructions"));
+    expect(sessionStorage.getItem("lhf-banner-collapsed")).toBe("true");
+  });
+
+  it("persists expanded state to sessionStorage when re-expanded", () => {
+    sessionStorage.setItem("lhf-banner-collapsed", "true");
+    renderView();
+    fireEvent.click(screen.getByLabelText("Show instructions"));
+    expect(sessionStorage.getItem("lhf-banner-collapsed")).toBe("false");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests — confirm they fail**
+
+```bash
+npm test -- --run src/features/leaderboard/components/__tests__/LowHangingFruitView.test.tsx
+```
+
+Expected: the 6 new tests FAIL (Hide/Show instructions buttons don't exist yet). The 2 existing tests should still PASS.
+
+- [ ] **Step 3: Add `ChevronUp` to the lucide import**
+
+In `src/features/leaderboard/components/LowHangingFruitView.tsx`, find the existing import:
+
+```tsx
+import { ArrowUpRight, Check, ChevronDown, Plus } from "lucide-react";
+```
+
+Change it to:
+
+```tsx
+import { ArrowUpRight, Check, ChevronDown, ChevronUp, Plus } from "lucide-react";
+```
+
+- [ ] **Step 4: Add `bannerCollapsed` state and `toggleBanner` handler**
+
+In `LowHangingFruitView.tsx`, find the block of `useState`/`useRef` declarations at the top of the `LowHangingFruitView` function (around line 223). Add these two declarations immediately after the existing ones:
+
+```tsx
+const [bannerCollapsed, setBannerCollapsed] = useState(() =>
+  typeof window !== "undefined" &&
+  sessionStorage.getItem("lhf-banner-collapsed") === "true"
+);
+
+const toggleBanner = () => {
+  setBannerCollapsed((prev) => {
+    const next = !prev;
+    sessionStorage.setItem("lhf-banner-collapsed", String(next));
+    return next;
+  });
+};
+```
+
+- [ ] **Step 5: Replace the static banner `<div>` with the collapsible version**
+
+Find the `{/* Summary banner */}` comment and the `<div>` that follows it (lines 356–377 in the original). Replace the entire block with:
+
+```tsx
+{/* Summary banner */}
+{bannerCollapsed ? (
+  <button
+    onClick={toggleBanner}
+    className="flex-shrink-0 flex items-center justify-between px-5 py-2 bg-[#F7F5FA] border-b border-[#E2DEEC] w-full text-left"
+    aria-expanded={false}
+    aria-label="Show instructions"
+  >
+    <span className="text-[11px] font-semibold text-[#6E6390]">Instructions</span>
+    <ChevronDown className="w-3.5 h-3.5 text-[#8A80A8]" />
+  </button>
+) : (
+  <div className="flex-shrink-0 px-5 py-3.5 bg-[#F7F5FA] border-b border-[#E2DEEC]">
+    <div className="flex items-start justify-between gap-2">
+      <div className="flex-1">
+        <p className="text-xs text-[#544A78] leading-relaxed">
+          You&apos;ll find 3 buckets of customers on this page:{" "}
+          <strong className="text-[#403770]">Missing Renewals</strong>,{" "}
+          <strong className="text-[#403770]">Fullmind Winbacks</strong>, and{" "}
+          <strong className="text-[#403770]">Elevate Winbacks</strong>.{" "}
+          All Winbacks are first-come, first-serve — it doesn&apos;t matter if you were the original rep or if the customer is from your company of origin.
+          Grab any winback that looks exciting and fits into the goals you have for your Book of Business!
+        </p>
+        <p className="text-xs text-[#544A78] mt-2">
+          <strong className="text-[#403770]">How to action them:</strong>{" "}
+          Click the <strong className="text-[#403770]">+Opp</strong> button to jump straight into the LMS and create the opportunity, or add to a plan and set a target.
+        </p>
+        <ul className="text-xs text-[#544A78] mt-1.5 space-y-0.5 list-disc pl-5">
+          <li>
+            <strong className="text-[#403770]">Missing Renewals</strong> leave this list once an FY27 opp exists — renewals are required to have an FY27 opportunity, so <strong className="text-[#403770]">+Opp</strong> is the path.
+          </li>
+          <li>
+            <strong className="text-[#403770]">Winbacks</strong> leave this list when an FY27 opp is created <em>or</em> a plan target is set.
+          </li>
+        </ul>
+      </div>
+      <button
+        onClick={toggleBanner}
+        className="flex-shrink-0 text-[#8A80A8] hover:text-[#403770] mt-0.5"
+        aria-expanded={true}
+        aria-label="Hide instructions"
+      >
+        <ChevronUp className="w-3.5 h-3.5" />
+      </button>
+    </div>
+  </div>
+)}
+```
+
+- [ ] **Step 6: Run tests — confirm all pass**
+
+```bash
+npm test -- --run src/features/leaderboard/components/__tests__/LowHangingFruitView.test.tsx
+```
+
+Expected: all 8 tests PASS (2 existing + 6 new).
+
+- [ ] **Step 7: Run full test suite to check for regressions**
+
+```bash
+npm test -- --run
+```
+
+Expected: same number of passes as before — no new failures.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/features/leaderboard/components/LowHangingFruitView.tsx \
+        src/features/leaderboard/components/__tests__/LowHangingFruitView.test.tsx
+git commit -m "feat(lhf): collapsible summary banner with sessionStorage persistence"
+```

--- a/Docs/superpowers/plans/2026-05-06-lhf-target-required-state.md
+++ b/Docs/superpowers/plans/2026-05-06-lhf-target-required-state.md
@@ -1,0 +1,269 @@
+# LHF Target Required State Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the TARGET field's required status self-evident in both the single-district and bulk "Add to Plan" popovers on the Low Hanging Fruit page.
+
+**Architecture:** Three purely visual changes per component — swap the placeholder, apply conditional Tailwind classes on the input, and conditionally render a one-line hint below the field. No new state, no new logic. The existing `parsedTarget` / `targetNum` variables already track whether the value is valid; we just wire them to the UI.
+
+**Tech Stack:** React 19, Tailwind 4, TypeScript — no new dependencies.
+
+---
+
+## Files
+
+| File | Action |
+|---|---|
+| `src/features/leaderboard/components/LhfPlanPicker.tsx` | Modify — placeholder, conditional input classes, helper text |
+| `src/features/leaderboard/components/LhfBulkPlanPicker.tsx` | Modify — placeholder, conditional input classes, helper text |
+
+---
+
+## Task 1: LhfPlanPicker — placeholder, amber field state, helper text
+
+**Files:**
+- Modify: `src/features/leaderboard/components/LhfPlanPicker.tsx:346–372`
+
+### Context
+
+The target input section currently lives at lines 346–372. The relevant variables:
+
+- `targetInput` — raw string state for the input
+- `parsedTarget` — memoized `parseTargetInput(targetInput)`, already defined at line 81. It is `0` when the field is empty or blank.
+
+The three changes all happen inside the `{/* Target input */}` block.
+
+- [ ] **Step 1: Update the input — placeholder + conditional border/bg classes**
+
+Replace the `<input>` element at lines 360–370 with:
+
+```tsx
+<input
+  id="add-plan-target"
+  type="text"
+  inputMode="decimal"
+  value={targetInput}
+  placeholder="e.g. 50,000"
+  onChange={(e) => setTargetInput(e.target.value)}
+  onBlur={(e) => setTargetInput(formatTargetInput(e.target.value))}
+  className={`w-full rounded-md border pl-5 pr-2 py-1.5 text-sm text-[#403770] tabular-nums focus:border-[#403770] focus:outline-none focus:ring-2 focus:ring-[#F37167]/40 ${
+    parsedTarget <= 0
+      ? "border-amber-400 bg-amber-50"
+      : "border-[#C2BBD4] bg-white"
+  }`}
+  required
+/>
+```
+
+Key changes:
+- `placeholder` goes from `"0"` → `"e.g. 50,000"`
+- `className` becomes a template expression: amber border + bg when empty, normal when filled
+
+- [ ] **Step 2: Add helper text below the input wrapper**
+
+After the closing `</div>` of the `relative` wrapper (the one containing the `$` span and the input), add:
+
+```tsx
+{parsedTarget <= 0 && (
+  <p className="text-[11px] text-amber-700 mt-1">
+    Set a target amount to add to plan
+  </p>
+)}
+```
+
+The full updated `{/* Target input */}` block should read:
+
+```tsx
+{/* Target input */}
+<div className="space-y-1">
+  <label
+    htmlFor="add-plan-target"
+    className="block text-[11px] font-semibold text-[#544A78] uppercase tracking-wider"
+  >
+    Target
+  </label>
+  <div className="relative">
+    <span
+      className="absolute left-2 top-1/2 -translate-y-1/2 text-sm text-[#6E6390] pointer-events-none"
+      aria-hidden="true"
+    >
+      $
+    </span>
+    <input
+      id="add-plan-target"
+      type="text"
+      inputMode="decimal"
+      value={targetInput}
+      placeholder="e.g. 50,000"
+      onChange={(e) => setTargetInput(e.target.value)}
+      onBlur={(e) => setTargetInput(formatTargetInput(e.target.value))}
+      className={`w-full rounded-md border pl-5 pr-2 py-1.5 text-sm text-[#403770] tabular-nums focus:border-[#403770] focus:outline-none focus:ring-2 focus:ring-[#F37167]/40 ${
+        parsedTarget <= 0
+          ? "border-amber-400 bg-amber-50"
+          : "border-[#C2BBD4] bg-white"
+      }`}
+      required
+    />
+  </div>
+  {parsedTarget <= 0 && (
+    <p className="text-[11px] text-amber-700 mt-1">
+      Set a target amount to add to plan
+    </p>
+  )}
+</div>
+```
+
+- [ ] **Step 3: Verify TypeScript compiles clean**
+
+```bash
+npx tsc --noEmit 2>&1 | grep LhfPlanPicker
+```
+
+Expected: no output (no errors in this file).
+
+- [ ] **Step 4: Manual smoke test**
+
+```bash
+npm run dev
+```
+
+Open the LHF page (Low Hanging Fruit tab). Click the `+ Plan` button on any district that has **no suggested target** (these open with an empty field).
+
+Verify:
+- TARGET input shows placeholder `e.g. 50,000` (not `0`)
+- TARGET field has an amber border and light amber background
+- Helper text "Set a target amount to add to plan" appears below the field in amber
+- "Add to Plan" button is disabled
+
+Then type any positive number (e.g. `50000`):
+- Amber border and background clear → normal border (`#C2BBD4`), white background
+- Helper text disappears
+- "Add to Plan" button becomes enabled (assuming a plan is selected)
+
+Also click a district **with a suggested target** — the field should open pre-filled, no amber, button enabled immediately.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/leaderboard/components/LhfPlanPicker.tsx
+git commit -m "feat(lhf): amber required state on target field in plan picker"
+```
+
+---
+
+## Task 2: LhfBulkPlanPicker — placeholder, amber field state, helper text
+
+**Files:**
+- Modify: `src/features/leaderboard/components/LhfBulkPlanPicker.tsx:306–340`
+
+### Context
+
+The bulk picker steps through districts one at a time in a modal. The relevant variables (defined at lines 96–99):
+
+- `target` — raw string state for the input
+- `targetNum = Number(target)` — parsed number; is `0` when `target` is `""` or `"0"`
+
+The target field lives in a `<div>` around lines 306–340. The `<input>` at lines 318–327 has no `placeholder` today.
+
+- [ ] **Step 1: Update the input — placeholder + conditional border/bg classes**
+
+Replace the `<input>` element at lines 318–327 with:
+
+```tsx
+<input
+  id="bulk-target-input"
+  type="text"
+  inputMode="decimal"
+  value={target}
+  placeholder="e.g. 50,000"
+  onChange={(e) =>
+    setTarget(e.target.value.replace(/[^\d.]/g, ""))
+  }
+  className={`w-full pl-6 pr-3 py-2 rounded-lg border text-sm text-[#403770] tabular-nums ${
+    targetNum <= 0
+      ? "border-amber-400 bg-amber-50"
+      : "border-[#C2BBD4] bg-white"
+  }`}
+/>
+```
+
+Key changes:
+- `placeholder` added: `"e.g. 50,000"`
+- `className` becomes conditional: amber when `targetNum <= 0`, normal otherwise
+
+- [ ] **Step 2: Add helper text below the input row**
+
+The target section currently ends with an optional "Suggested:" hint and an `{error && ...}` block. Add the amber helper text between the input row and the error block:
+
+```tsx
+<div>
+  <label
+    htmlFor="bulk-target-input"
+    className="block text-[10px] uppercase tracking-wider font-bold text-[#8A80A8] mb-1"
+  >
+    Target
+  </label>
+  <div className="flex items-center gap-2">
+    <div className="flex-1 relative">
+      <span className="absolute left-3 top-1/2 -translate-y-1/2 text-sm text-[#8A80A8]">
+        $
+      </span>
+      <input
+        id="bulk-target-input"
+        type="text"
+        inputMode="decimal"
+        value={target}
+        placeholder="e.g. 50,000"
+        onChange={(e) =>
+          setTarget(e.target.value.replace(/[^\d.]/g, ""))
+        }
+        className={`w-full pl-6 pr-3 py-2 rounded-lg border text-sm text-[#403770] tabular-nums ${
+          targetNum <= 0
+            ? "border-amber-400 bg-amber-50"
+            : "border-[#C2BBD4] bg-white"
+        }`}
+      />
+    </div>
+    {row.suggestedTarget != null && (
+      <span className="text-xs text-[#8A80A8] whitespace-nowrap">
+        Suggested: {formatCurrency(row.suggestedTarget, true)}
+      </span>
+    )}
+  </div>
+  {targetNum <= 0 && (
+    <p className="text-[11px] text-amber-700 mt-1">
+      Set a target amount to add to plan
+    </p>
+  )}
+  {error && (
+    <div className="mt-1 text-xs text-[#B5453D]" role="alert">
+      {error}
+    </div>
+  )}
+</div>
+```
+
+- [ ] **Step 3: Verify TypeScript compiles clean**
+
+```bash
+npx tsc --noEmit 2>&1 | grep LhfBulkPlanPicker
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Manual smoke test**
+
+On the LHF page, select 2+ districts (checkboxes) then click the bulk "Add to Plan" button to open the multi-step modal.
+
+Verify per step:
+- Districts **without** a suggested target: TARGET shows amber border + bg, helper text visible, "Add & continue" disabled
+- Districts **with** a suggested target: TARGET pre-filled, no amber, "Add & continue" enabled
+- Typing a value clears amber immediately, helper text disappears
+- Clearing back to empty restores amber + helper text
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/leaderboard/components/LhfBulkPlanPicker.tsx
+git commit -m "feat(lhf): amber required state on target field in bulk plan picker"
+```

--- a/Docs/superpowers/plans/2026-05-06-mobile-scroll-fix.md
+++ b/Docs/superpowers/plans/2026-05-06-mobile-scroll-fix.md
@@ -1,0 +1,261 @@
+# Mobile Scroll Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix iOS/WebKit touch-scroll being completely frozen on all content tabs (Plans, Activities, Low Hanging Fruit, etc.) by replacing the body `overflow: hidden` pattern with `overscroll-behavior: none`, and modernise the AppShell root to use dynamic viewport height.
+
+**Architecture:** Three targeted changes — `globals.css` (root cause fix + legacy iOS rule), `AppShell.tsx` (dvh height + touch-action hint), `CLAUDE.md` (mobile testing guidance so this class of bug doesn't recur). No per-view changes needed; the global fix covers all tabs.
+
+**Tech Stack:** Tailwind CSS 4, Next.js 16 App Router, React 19. No new dependencies.
+
+---
+
+### Task 1: Create isolated worktree
+
+**Files:**
+- No file edits — workspace setup only
+
+- [ ] **Step 1: Create the worktree**
+
+From the main repo directory run:
+```bash
+git worktree add ../territory-plan-mobile-scroll-fix -b fix/mobile-scroll
+```
+
+- [ ] **Step 2: Confirm worktree is clean**
+
+```bash
+cd ../territory-plan-mobile-scroll-fix && git status
+```
+Expected: `On branch fix/mobile-scroll — nothing to commit, working tree clean`
+
+---
+
+### Task 2: Fix `globals.css` — root cause
+
+**Files:**
+- Modify: `src/app/globals.css:39-46`
+
+The `overflow: hidden` on `html, body` is the root cause. On iOS/WebKit it prevents touch-scroll events from reaching any inner `overflow: auto` container, freezing all tabs. Replace it with `overscroll-behavior: none` (prevents bounce/overscroll without blocking child scroll) and add a global `-webkit-overflow-scrolling: touch` rule for legacy iOS 14 / Chrome-on-iOS coverage.
+
+- [ ] **Step 1: Open `src/app/globals.css` and find the `html, body` block (lines 39–46)**
+
+It currently reads:
+```css
+html,
+body {
+  height: 100%;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+}
+```
+
+- [ ] **Step 2: Replace that block with the following**
+
+```css
+html,
+body {
+  height: 100%;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  overscroll-behavior: none;
+}
+
+[class*="overflow-auto"],
+[class*="overflow-y-auto"],
+[class*="overflow-scroll"],
+[class*="overflow-y-scroll"] {
+  -webkit-overflow-scrolling: touch;
+}
+```
+
+- [ ] **Step 3: Run the test suite to check for regressions**
+
+```bash
+npm test -- --run
+```
+Expected: all existing tests pass. These tests run in jsdom and don't test CSS scrolling — they verify no JS logic was accidentally broken.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/globals.css
+git commit -m "fix(mobile): replace overflow:hidden on body with overscroll-behavior:none"
+```
+
+---
+
+### Task 3: Update `AppShell.tsx` — dvh height + touch-action
+
+**Files:**
+- Modify: `src/features/shared/components/layout/AppShell.tsx:47,63`
+
+Two changes:
+1. Add `h-dvh` to the root div — switches from static `100vh` (which includes iOS address bar, causing layout jump when bar hides) to dynamic viewport height that tracks the actual visible area.
+2. Add `overscroll-none` to the root div — belt-and-suspenders on the fixed container itself.
+3. Add `touch-pan-y` to `<main>` — explicitly tells iOS that vertical panning is valid in the content area.
+
+- [ ] **Step 1: Open `src/features/shared/components/layout/AppShell.tsx`**
+
+Find the return statement. The root div currently reads:
+```tsx
+<div className="fixed inset-0 flex flex-col bg-[#FFFCFA] overflow-hidden">
+```
+
+And `<main>` currently reads:
+```tsx
+<main className="flex-1 relative overflow-hidden">
+```
+
+- [ ] **Step 2: Update the root div — add `h-dvh overscroll-none`**
+
+```tsx
+<div className="fixed inset-0 h-dvh flex flex-col bg-[#FFFCFA] overflow-hidden overscroll-none">
+```
+
+- [ ] **Step 3: Update `<main>` — add `touch-pan-y`**
+
+```tsx
+<main className="flex-1 relative overflow-hidden touch-pan-y">
+```
+
+- [ ] **Step 4: Run the test suite**
+
+```bash
+npm test -- --run
+```
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/features/shared/components/layout/AppShell.tsx
+git commit -m "fix(mobile): use h-dvh and touch-pan-y in AppShell for iOS scroll"
+```
+
+---
+
+### Task 4: Update `CLAUDE.md` — Mobile Testing section
+
+**Files:**
+- Modify: `CLAUDE.md` (after the `### UX Defaults` section)
+
+- [ ] **Step 1: Open `CLAUDE.md` and find the `### UX Defaults` section**
+
+Locate the end of the UX Defaults block (it ends before `### Testing`).
+
+- [ ] **Step 2: Insert the following new section between `### UX Defaults` and `### Testing`**
+
+```markdown
+### Mobile Testing
+This app is used on iPhone (Safari and Chrome). Any view with a scrollable
+inner container must be verified on mobile before shipping.
+
+- **Never set `overflow: hidden` on `html`/`body`** — on iOS/WebKit this blocks
+  touch-scroll delivery to all inner containers. Use `overscroll-behavior: none`
+  instead, which prevents bounce without the side-effect.
+- **Use `touch-action: pan-y`** on `<main>` or any wrapper that contains
+  scrollable children.
+- **Add `-webkit-overflow-scrolling: touch`** to inner scroll containers for
+  legacy iOS 14 / Chrome-on-iOS coverage (handled globally in `globals.css`).
+- **Test scroll on iPhone before marking a view complete** — use Safari
+  Responsive Design Mode locally (Develop → Enter Responsive Design Mode),
+  then verify on a real device before approving a PR.
+- **Local device testing — two options (same WiFi required for both):**
+  - `.local` hostname (permanent): `http://A-Arcega.local:3005` — requires
+    one-time Supabase redirect URL whitelist (`http://A-Arcega.local:3005/**`)
+    and `NEXT_PUBLIC_SITE_URL=http://A-Arcega.local:3005` in `.env.local`
+  - Local IP (per-session): `ipconfig getifaddr en0` → `http://<ip>:3005`
+    (auth redirects will fail; use only for pre-login visual checks)
+- **Smoke-test the map tab** after any AppShell layout change — MapLibre touch
+  gestures share the same event system.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: add mobile testing guidance to CLAUDE.md"
+```
+
+---
+
+### Task 5: Manual smoke test — Safari Responsive Design Mode
+
+No code changes. Verify the fix works before opening the PR.
+
+- [ ] **Step 1: Start the dev server on the worktree**
+
+```bash
+npm run dev
+```
+Expected: server starts on port 3005.
+
+- [ ] **Step 2: Open Safari on Mac, enable Responsive Design Mode**
+
+Safari menu → Develop → Enter Responsive Design Mode (if Develop menu is not visible: Safari → Settings → Advanced → Show Develop menu).
+
+Select an iPhone model preset (e.g. iPhone 15 Pro).
+
+- [ ] **Step 3: Navigate to `http://localhost:3005`**
+
+Log in if needed.
+
+- [ ] **Step 4: Run through the smoke test checklist**
+
+| Surface | Action | Expected |
+|---|---|---|
+| Plans tab | Swipe vertically | List scrolls |
+| Activities tab | Swipe vertically | List scrolls |
+| Low Hanging Fruit | Swipe vertically | Rows scroll |
+| Low Hanging Fruit | Swipe horizontally on table | Table scrolls horizontally |
+| Map tab | Pan and pinch | Map moves and zooms |
+| Any tab | Scroll down to hide address bar | Layout does not jump |
+
+- [ ] **Step 5: If any check fails, stop and debug before continuing**
+
+The most likely remaining issue if scroll still doesn't work: a specific view has its own `overflow: hidden` container without a downstream scroll target. Inspect the failing view's DOM in Safari DevTools (Elements panel) and look for the innermost `overflow: hidden` element — it likely needs `overflow: auto` or a `touch-action: pan-y` addition.
+
+---
+
+### Task 6: Open PR
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin fix/mobile-scroll
+```
+
+- [ ] **Step 2: Open a PR via GitHub CLI**
+
+```bash
+gh pr create \
+  --title "fix(mobile): restore touch-scroll across all tabs on iOS" \
+  --body "$(cat <<'EOF'
+## Problem
+On iPhone (Chrome and Safari), all content tabs — Plans, Activities, Low Hanging Fruit — were completely frozen. No vertical or horizontal scrolling worked in any direction.
+
+## Root cause
+`globals.css` set `overflow: hidden` on both `html` and `body`. On iOS/WebKit this prevents touch-scroll events from propagating to inner `overflow: auto` children, regardless of nesting depth.
+
+## Changes
+- **`globals.css`**: Replace `overflow: hidden` on `html, body` with `overscroll-behavior: none`. Add global `-webkit-overflow-scrolling: touch` rule for legacy iOS 14 / Chrome-on-iOS.
+- **`AppShell.tsx`**: Add `h-dvh` (dynamic viewport height — fixes address-bar layout jump), `overscroll-none`, and `touch-pan-y` on `<main>`.
+- **`CLAUDE.md`**: Add Mobile Testing section so this class of bug doesn't recur.
+
+## Smoke test checklist
+- [ ] Plans tab — vertical scroll works on iPhone
+- [ ] Activities tab — vertical scroll works on iPhone
+- [ ] Low Hanging Fruit — vertical + horizontal table scroll works on iPhone
+- [ ] Map tab — pan and pinch-zoom still work
+- [ ] Address bar hide/show — no layout jump
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Share the PR link with Aston for review and approval before merge**

--- a/Docs/superpowers/specs/2026-05-06-lhf-banner-collapsible-design.md
+++ b/Docs/superpowers/specs/2026-05-06-lhf-banner-collapsible-design.md
@@ -1,0 +1,82 @@
+# LHF Summary Banner — Collapsible Design Spec
+
+**Date:** 2026-05-06
+**Status:** Approved for implementation
+
+## Problem
+
+The summary banner on the Low Hanging Fruit page is always expanded. On mobile/narrow viewports it takes up the majority of visible vertical space before the user reaches the filter bar and table, making the page feel cramped and hard to use.
+
+## Solution
+
+Add a collapse/expand toggle to the summary banner. One file touched, no architecture changes.
+
+### Behaviour
+
+- On first load (or if sessionStorage key is absent): banner is **expanded**
+- A chevron-up button in the top-right corner of the banner collapses it
+- **Collapsed state:** the full banner body is hidden; a slim 28px row replaces it showing "Instructions" label on the left and chevron-down on the right
+- Clicking the collapsed row (or its chevron) re-expands the banner
+- State is persisted to `sessionStorage` under the key `"lhf-banner-collapsed"` so it survives navigation within the session but resets on the next visit
+
+### Implementation
+
+**File:** `src/features/leaderboard/components/LowHangingFruitView.tsx`
+
+Add state near the top of the component:
+```tsx
+const [bannerCollapsed, setBannerCollapsed] = useState(() =>
+  typeof window !== "undefined" &&
+  sessionStorage.getItem("lhf-banner-collapsed") === "true"
+);
+
+const toggleBanner = () => {
+  setBannerCollapsed((prev) => {
+    const next = !prev;
+    sessionStorage.setItem("lhf-banner-collapsed", String(next));
+    return next;
+  });
+};
+```
+
+Replace the existing summary banner `<div>` with:
+
+```tsx
+{/* Summary banner */}
+{bannerCollapsed ? (
+  <button
+    onClick={toggleBanner}
+    className="flex-shrink-0 flex items-center justify-between px-5 py-2 bg-[#F7F5FA] border-b border-[#E2DEEC] w-full text-left"
+    aria-expanded={false}
+    aria-label="Show instructions"
+  >
+    <span className="text-[11px] font-semibold text-[#6E6390]">Instructions</span>
+    <ChevronDown className="w-3.5 h-3.5 text-[#8A80A8]" />
+  </button>
+) : (
+  <div className="flex-shrink-0 px-5 py-3.5 bg-[#F7F5FA] border-b border-[#E2DEEC]">
+    <div className="flex items-start justify-between gap-2">
+      <div className="flex-1">
+        {/* existing banner content — unchanged */}
+      </div>
+      <button
+        onClick={toggleBanner}
+        className="flex-shrink-0 text-[#8A80A8] hover:text-[#403770] mt-0.5"
+        aria-expanded={true}
+        aria-label="Hide instructions"
+      >
+        <ChevronUp className="w-3.5 h-3.5" />
+      </button>
+    </div>
+  </div>
+)}
+```
+
+`ChevronDown` is already imported. Add `ChevronUp` from `lucide-react`.
+
+### Out of Scope
+
+- Persisting collapse state across sessions (localStorage) — sessionStorage is sufficient
+- Collapsing the banner on other pages
+- Any changes to the banner content itself
+- Any changes to the sidebar, Revenue Rank widget, or AppShell

--- a/Docs/superpowers/specs/2026-05-06-lhf-target-required-state-design.md
+++ b/Docs/superpowers/specs/2026-05-06-lhf-target-required-state-design.md
@@ -1,0 +1,73 @@
+# LHF "Add to Plan" — TARGET Required State
+
+**Date:** 2026-05-06  
+**Status:** Approved
+
+## Problem
+
+The "Add to Plan" popover on the Low Hanging Fruit page has a TARGET input that defaults to empty (rendered as `$0` due to `placeholder="0"`). The "Add to Plan" button is already disabled until `parsedTarget > 0`, but nothing in the UI explains why. Users see a button that looks clickable next to a field that looks filled — the mismatch causes confusion.
+
+## Solution
+
+Surface an amber visual state on the TARGET field whenever it is empty/zero, immediately communicating that it must be filled before the button will activate. No change to the disable logic — only the affordance changes.
+
+## Scope
+
+Two components are affected:
+
+- `src/features/leaderboard/components/LhfPlanPicker.tsx` — single-district picker
+- `src/features/leaderboard/components/LhfBulkPlanPicker.tsx` — multi-district bulk picker
+
+## Changes
+
+### 1. Placeholder text
+
+**Before:** `placeholder="0"` — looks like a pre-filled zero value.  
+**After:** `placeholder="e.g. 50,000"` — clearly indicates the field is empty and expects a value. The `$` prefix is already rendered as a separate element.
+
+### 2. Amber border + background (when empty)
+
+When `parsedTarget <= 0` (LhfPlanPicker) or the equivalent parsed value ≤ 0 (LhfBulkPlanPicker), apply amber classes to the input:
+
+```
+border-amber-400 bg-amber-50
+```
+
+When `parsedTarget > 0`, restore to the normal idle state:
+
+```
+border-[#C2BBD4] bg-white
+```
+
+The transition is immediate — no blur required. The amber clears the moment the user types a positive value.
+
+### 3. Helper text (when empty)
+
+Directly below the input wrapper, conditionally render a one-line hint when `parsedTarget <= 0`:
+
+```tsx
+{parsedTarget <= 0 && (
+  <p className="text-[11px] text-amber-700 mt-1">
+    Set a target amount to add to plan
+  </p>
+)}
+```
+
+This sits in the same visual area as the existing red `errorMessage` slot. The two do not conflict — the error message covers the "create new plan" edge case and the amber hint covers the normal open state.
+
+## Behavior Details
+
+| Scenario | Field state | Helper text | Button |
+|---|---|---|---|
+| Open, no suggested target | Amber border, `bg-amber-50` | Shown | Disabled |
+| Open, has suggested target | Normal (field pre-filled) | Hidden | Enabled |
+| User types a valid amount | Normal | Hidden | Enabled (if plan selected) |
+| User clears back to empty | Amber | Shown | Disabled |
+
+**Districts with a `suggestedTarget`** have the field pre-filled on open, so `parsedTarget > 0` from the start — no amber shown, button is already enabled.
+
+## Out of Scope
+
+- No change to the `canSubmit` logic or button disabled condition.
+- No tooltip on the button (chosen over Option C for immediacy — the field draws attention before the user reaches the button).
+- No change to the PLAN or TYPE fields — only TARGET has a required constraint.

--- a/Docs/superpowers/specs/2026-05-06-mobile-scroll-fix-design.md
+++ b/Docs/superpowers/specs/2026-05-06-mobile-scroll-fix-design.md
@@ -1,0 +1,127 @@
+# Mobile Scroll Fix — Design Spec
+
+**Date:** 2026-05-06
+**Status:** Approved for implementation
+
+## Problem
+
+On iPhone (Chrome and Safari), navigating to any content tab — Low Hanging Fruit, Plans, Activities, and others — results in a page where scrolling is completely frozen in all directions.
+
+### Root cause
+
+`globals.css` sets `overflow: hidden` on both `html` and `body`. On iOS/WebKit, this prevents touch-scroll events from propagating to inner `overflow: auto` children, regardless of how deep they are in the tree. Every tab is affected because AppShell wraps all content.
+
+A secondary issue: the AppShell root div uses `fixed inset-0`, which calculates height from `100vh`. On iOS, `100vh` includes the address bar height, so when the bar hides/shows on scroll the layout jumps.
+
+---
+
+## Solution
+
+Three targeted changes. One PR, approved by Aston before merge.
+
+### 1. `src/app/globals.css`
+
+Replace `overflow: hidden` on `html, body` with `overscroll-behavior: none`. This prevents iOS overscroll bounce without blocking touch-scroll delivery to inner containers.
+
+Add a global rule giving every `overflow-auto`/`overflow-scroll` element `-webkit-overflow-scrolling: touch` for legacy iOS 14 and Chrome-on-iOS edge cases.
+
+**Before:**
+```css
+html,
+body {
+  height: 100%;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+}
+```
+
+**After:**
+```css
+html,
+body {
+  height: 100%;
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  overscroll-behavior: none;
+}
+
+/* iOS touch-scroll for all inner scroll containers */
+[class*="overflow-auto"],
+[class*="overflow-y-auto"],
+[class*="overflow-scroll"],
+[class*="overflow-y-scroll"] {
+  -webkit-overflow-scrolling: touch;
+}
+```
+
+### 2. `src/features/shared/components/layout/AppShell.tsx`
+
+Two changes to the JSX:
+
+- Root div: add `h-dvh` (dynamic viewport height — tracks visible viewport as address bar appears/disappears) and `overscroll-none` (Tailwind belt-and-suspenders on the fixed container)
+- `<main>`: add `touch-pan-y` so iOS explicitly recognises vertical panning in the content area
+
+**Before:**
+```tsx
+<div className="fixed inset-0 flex flex-col bg-[#FFFCFA] overflow-hidden">
+  ...
+  <main className="flex-1 relative overflow-hidden">
+```
+
+**After:**
+```tsx
+<div className="fixed inset-0 h-dvh flex flex-col bg-[#FFFCFA] overflow-hidden overscroll-none">
+  ...
+  <main className="flex-1 relative overflow-hidden touch-pan-y">
+```
+
+### 3. `CLAUDE.md` — Mobile Testing section
+
+Add after the existing **UX Defaults** section:
+
+```markdown
+### Mobile Testing
+This app is used on iPhone (Safari and Chrome). Any view with a scrollable
+inner container must be verified on mobile before shipping.
+
+- **Never set `overflow: hidden` on `html`/`body`** — on iOS/WebKit this blocks
+  touch-scroll delivery to all inner containers. Use `overscroll-behavior: none`
+  instead, which prevents bounce without the side-effect.
+- **Use `touch-action: pan-y`** on `<main>` or any wrapper that contains
+  scrollable children.
+- **Add `-webkit-overflow-scrolling: touch`** to inner scroll containers for
+  legacy iOS 14 / Chrome-on-iOS coverage.
+- **Test scroll on iPhone before marking a view complete** — use Safari
+  Responsive Design Mode (Develop → Enter Responsive Design Mode) locally, then
+  verify on a real device before approving a PR.
+- **Local device testing options:**
+  - Same WiFi: `ipconfig getifaddr en0` → open `http://<mac-ip>:3005` on iPhone
+  - ngrok: `ngrok http 3005` → open the tunnel URL on iPhone (clean up `.env.local` after)
+- **Smoke-test the map tab** after any AppShell layout change — MapLibre touch
+  gestures share the same event system.
+```
+
+---
+
+## Smoke Tests (pre-PR-approval)
+
+Run on actual iPhone (Safari or Chrome) using local IP or ngrok:
+
+| Surface | What to verify |
+|---|---|
+| Map tab | Pan, zoom, pinch-zoom all work |
+| Plans tab | List scrolls vertically |
+| Activities tab | List scrolls vertically |
+| Low Hanging Fruit | Vertical scroll + horizontal table scroll both work |
+| Any tab | Scroll down to hide address bar — layout does not jump |
+
+---
+
+## Out of Scope
+
+- Per-view scroll container restructuring (not needed; the global fix covers all tabs)
+- `100dvh` fallback for browsers that don't support `dvh` (all modern iOS/Android support it; desktop fallback via `fixed inset-0` is unchanged)
+- Map tab scrolling internals (MapLibre manages its own touch handling)

--- a/src/features/leaderboard/components/LhfBulkPlanPicker.tsx
+++ b/src/features/leaderboard/components/LhfBulkPlanPicker.tsx
@@ -320,10 +320,15 @@ export default function LhfBulkPlanPicker({
                   type="text"
                   inputMode="decimal"
                   value={target}
+                  placeholder="e.g. 50,000"
                   onChange={(e) =>
                     setTarget(e.target.value.replace(/[^\d.]/g, ""))
                   }
-                  className="w-full pl-6 pr-3 py-2 rounded-lg border border-[#C2BBD4] text-sm text-[#403770] tabular-nums"
+                  className={`w-full pl-6 pr-3 py-2 rounded-lg border text-sm text-[#403770] tabular-nums ${
+                    targetNum <= 0
+                      ? "border-amber-400 bg-amber-50"
+                      : "border-[#C2BBD4] bg-white"
+                  }`}
                 />
               </div>
               {row.suggestedTarget != null && (
@@ -332,6 +337,9 @@ export default function LhfBulkPlanPicker({
                 </span>
               )}
             </div>
+            <p className="text-[11px] text-amber-700 mt-1" aria-live="polite" aria-atomic="true">
+              {targetNum <= 0 ? "Set a target amount to add to plan" : ""}
+            </p>
             {error && (
               <div className="mt-1 text-xs text-[#B5453D]" role="alert">
                 {error}

--- a/src/features/leaderboard/components/LhfPlanPicker.tsx
+++ b/src/features/leaderboard/components/LhfPlanPicker.tsx
@@ -373,11 +373,9 @@ export default function LhfPlanPicker({
               required
             />
           </div>
-          {parsedTarget <= 0 && (
-            <p className="text-[11px] text-amber-700 mt-1">
-              Set a target amount to add to plan
-            </p>
-          )}
+          <p className="text-[11px] text-amber-700 mt-1" aria-live="polite" aria-atomic="true">
+            {parsedTarget <= 0 ? "Set a target amount to add to plan" : ""}
+          </p>
         </div>
 
         {/* Error */}

--- a/src/features/leaderboard/components/LhfPlanPicker.tsx
+++ b/src/features/leaderboard/components/LhfPlanPicker.tsx
@@ -362,13 +362,22 @@ export default function LhfPlanPicker({
               type="text"
               inputMode="decimal"
               value={targetInput}
-              placeholder="0"
+              placeholder="e.g. 50,000"
               onChange={(e) => setTargetInput(e.target.value)}
               onBlur={(e) => setTargetInput(formatTargetInput(e.target.value))}
-              className="w-full rounded-md border border-[#C2BBD4] bg-white pl-5 pr-2 py-1.5 text-sm text-[#403770] tabular-nums focus:border-[#403770] focus:outline-none focus:ring-2 focus:ring-[#F37167]/40"
+              className={`w-full rounded-md border pl-5 pr-2 py-1.5 text-sm text-[#403770] tabular-nums focus:border-[#403770] focus:outline-none focus:ring-2 focus:ring-[#F37167]/40 ${
+                parsedTarget <= 0
+                  ? "border-amber-400 bg-amber-50"
+                  : "border-[#C2BBD4] bg-white"
+              }`}
               required
             />
           </div>
+          {parsedTarget <= 0 && (
+            <p className="text-[11px] text-amber-700 mt-1">
+              Set a target amount to add to plan
+            </p>
+          )}
         </div>
 
         {/* Error */}


### PR DESCRIPTION
## Summary

- The TARGET field in the LHF \"Add to Plan\" popover previously showed `$0` as a placeholder, making it look pre-filled — users couldn't tell why the \"Add to Plan\" button was disabled
- Single-district picker (`LhfPlanPicker`) and bulk picker (`LhfBulkPlanPicker`) now both show an amber border + background on the target input when empty, with a helper text line below: \"Set a target amount to add to plan\"
- Amber state clears immediately when a valid amount is typed; districts with a suggested target open pre-filled with no amber
- Helper text uses `aria-live="polite"` with an always-mounted element for reliable screen reader announcements

## Test Plan

- [ ] Open LHF page → click `+ Plan` on a district with no suggested target → TARGET field shows amber border/bg, helper text visible, \"Add to Plan\" disabled
- [ ] Type a positive amount → amber clears, helper text disappears, button enables
- [ ] Click `+ Plan` on a district with a suggested target → field pre-filled, no amber, button enabled immediately
- [ ] Select 2+ districts → open bulk picker → verify same amber behavior per step

🤖 Generated with [Claude Code](https://claude.com/claude-code)